### PR TITLE
Add monitoring/ directory and expand metrics documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Three kinds of drift are tracked:
 - [Configuration](#configuration)
 - [Webhooks](#webhooks)
 - [Monitoring](#monitoring)
+  - [`/healthz`](#healthz)
+  - [`/metrics`](#metrics)
+  - [Sample Prometheus configuration](#sample-prometheus-configuration)
 - [Docker](#docker)
 - [Development](#development)
 
@@ -177,54 +180,78 @@ Always returns **HTTP 200**. The JSON body describes the current drift state:
 
 ### `/metrics`
 
-Standard Prometheus endpoint. Key metrics:
+Standard Prometheus exposition endpoint. All metric names are prefixed with `nomad_botherer_`.
 
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `nomad_botherer_job_diffs` | Gauge | `job`, `diff_type` | 1 for each active drift entry |
-| `nomad_botherer_drifted_jobs` | Gauge | `diff_type` | Count of jobs currently in each drift state |
-| `nomad_botherer_job_drift_first_seen_timestamp_seconds` | Gauge | `job`, `diff_type` | Unix time when drift was first detected; cleared on resolution. Use `time()-metric` for time-in-drift. |
-| `nomad_botherer_last_check_timestamp_seconds` | Gauge | — | Unix time of last diff check |
-| `nomad_botherer_diff_checks_total` | Counter | — | Total diff checks run |
-| `nomad_botherer_nomad_api_errors_total` | Counter | `op` (`info`, `plan`, `list`) | Nomad API errors by operation |
-| `nomad_botherer_hcl_parse_errors_total` | Counter | — | HCL files that failed to parse |
-| `nomad_botherer_hcl_non_job_files_skipped_total` | Counter | — | HCL files skipped (no job stanza) |
-| `nomad_botherer_git_fetches_total` | Counter | — | Total remote git fetch/clone attempts |
-| `nomad_botherer_git_fetch_errors_total` | Counter | — | Remote git fetch/clone failures |
-| `nomad_botherer_git_last_update_timestamp_seconds` | Gauge | — | Unix time of last successful git fetch |
-| `nomad_botherer_webhook_events_total` | Counter | `event` (`push`, `ping`, `unknown`, `error`) | Webhook events received |
-| `nomad_botherer_info` | Gauge | `version` | Build version info |
+#### Drift state
 
-**Example Prometheus alert:**
+These metrics describe the current relationship between the git repo and the live Nomad cluster. They are reset and recomputed on every diff check.
 
-```yaml
-groups:
-  - name: nomad-botherer
-    rules:
-      - alert: NomadJobDrift
-        expr: sum(nomad_botherer_drifted_jobs) > 0
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "Nomad job definitions have drifted from git"
-          description: "{{ $value }} job(s) differ between the git repo and the running cluster."
+| Metric | Type | Labels | What it tells you |
+|--------|------|--------|-------------------|
+| `nomad_botherer_drifted_jobs` | Gauge | `diff_type` | Number of jobs currently in each drift state. The simplest signal for "is anything wrong?" — alert on `sum(nomad_botherer_drifted_jobs) > 0`. |
+| `nomad_botherer_job_diffs` | Gauge | `job`, `diff_type` | 1 for every (job, diff_type) pair currently detected. Useful for per-job dashboards or filtering by job name. |
+| `nomad_botherer_job_drift_first_seen_timestamp_seconds` | Gauge | `job`, `diff_type` | Unix timestamp of when drift was first detected for this job. Absent when no drift is present. `time() - metric` gives how long the job has been drifting — use this to distinguish a deploy in progress from a job that's been stuck for hours. |
 
-      - alert: NomadJobDriftPersistent
-        expr: time() - nomad_botherer_job_drift_first_seen_timestamp_seconds > 3600
-        labels:
-          severity: critical
-        annotations:
-          summary: "Nomad job {{ $labels.job }} has been in {{ $labels.diff_type }} drift for over 1h"
+#### Diff checks
 
-      - alert: NomadBothererStale
-        expr: time() - nomad_botherer_last_check_timestamp_seconds > 300
-        for: 2m
-        labels:
-          severity: warning
-        annotations:
-          summary: "nomad-botherer has not run a diff check recently"
-```
+These counters and timestamps describe the diff check loop itself — how often it runs and whether it is working correctly.
+
+| Metric | Type | Labels | What it tells you |
+|--------|------|--------|-------------------|
+| `nomad_botherer_diff_checks_total` | Counter | — | Total diff checks run since startup. Use `rate()` to confirm the loop is running at the expected frequency. |
+| `nomad_botherer_last_check_timestamp_seconds` | Gauge | — | Unix timestamp of the most recent completed diff check. Alert when `time() - metric` exceeds 2× `--diff-interval` to catch a stuck check loop. |
+| `nomad_botherer_nomad_api_errors_total` | Counter | `op` (`info`, `plan`, `list`) | Nomad API call failures by operation. `info` = job lookup, `plan` = drift plan, `list` = listing all jobs. A rising count means drift results may be incomplete for that operation. |
+| `nomad_botherer_hcl_parse_errors_total` | Counter | — | HCL files that failed to parse via the Nomad API. These files are skipped; the rest of the check continues. |
+| `nomad_botherer_hcl_non_job_files_skipped_total` | Counter | — | HCL files that were skipped because they contain no `job` stanza (e.g. ACL policies, volumes). Expected and normal; a rising rate may indicate `--hcl-dir` is set too broadly. |
+
+#### Git tracking
+
+These metrics describe the in-memory git clone and polling loop.
+
+| Metric | Type | Labels | What it tells you |
+|--------|------|--------|-------------------|
+| `nomad_botherer_git_fetches_total` | Counter | — | Total remote fetch/clone attempts. Each poll interval triggers one. |
+| `nomad_botherer_git_fetch_errors_total` | Counter | — | Fetch/clone attempts that failed. A rising count means new commits are not being picked up; diff checks continue against the last known commit. |
+| `nomad_botherer_git_last_update_timestamp_seconds` | Gauge | — | Unix timestamp of the last successful fetch. Alert when `time() - metric` is significantly larger than `--poll-interval` to catch a stuck git loop. |
+
+#### Webhooks
+
+These metrics describe incoming webhook events from GitHub.
+
+| Metric | Type | Labels | What it tells you |
+|--------|------|--------|-------------------|
+| `nomad_botherer_webhook_events_total` | Counter | `event` (`push`, `ping`, `unknown`, `error`) | Webhook events received by type. `push` events trigger an immediate fetch. `error` events indicate a failed delivery (bad signature, parse error, etc.). |
+| `nomad_botherer_last_webhook_success_timestamp_seconds` | Gauge | — | Unix timestamp of the last successfully processed webhook. Zero if no webhook has been received yet. |
+| `nomad_botherer_last_webhook_failure_timestamp_seconds` | Gauge | — | Unix timestamp of the last failed webhook delivery. Zero if no failure has occurred. |
+
+#### Service info
+
+| Metric | Type | Labels | What it tells you |
+|--------|------|--------|-------------------|
+| `nomad_botherer_info` | Gauge | `version` | Always 1. The `version` label holds the build version string. Useful for tracking rollouts: `count by(version)(nomad_botherer_info)`. |
+
+### Sample Prometheus configuration
+
+The [`monitoring/`](monitoring/) directory contains ready-to-use configuration files:
+
+| File | Contents |
+|------|----------|
+| [`monitoring/prometheus.yml`](monitoring/prometheus.yml) | Scrape configuration for nomad-botherer |
+| [`monitoring/recording_rules.yml`](monitoring/recording_rules.yml) | Pre-aggregated series for dashboards and alerts |
+| [`monitoring/alerts.yml`](monitoring/alerts.yml) | Alerting rules covering drift, service health, git, and webhooks |
+
+The alerts cover:
+
+- **NomadJobDrift** — any drift detected for more than 5 minutes
+- **NomadJobModifiedPersistent** — a job's config has diverged from git for over 1 hour
+- **NomadJobMissingFromNomad** — a git-defined job has been absent from Nomad for over 15 minutes
+- **NomadJobMissingFromHCL** — a running Nomad job has no HCL file in the repo for over 1 hour
+- **NomadBothererCheckStale** — no diff check has completed in over 5 minutes
+- **NomadBothererGitFetchFailing** — git fetches have been failing for 10 minutes
+- **NomadBothererGitStale** — the in-memory git clone has not refreshed in over 30 minutes
+- **NomadBothererAPIErrors** — Nomad API calls are failing
+- **NomadBothererDown** — Prometheus cannot reach the `/metrics` endpoint
+- **NomadBothererWebhookErrors** — webhook deliveries are consistently failing
 
 ---
 

--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -1,0 +1,160 @@
+# Alerting rules for nomad-botherer.
+#
+# Assumes recording_rules.yml is also loaded. All expressions that reference
+# nomad_botherer:* series can be rewritten to use the raw metrics directly
+# if you prefer not to load the recording rules.
+#
+# Severity conventions used here:
+#   warning  — something needs attention but is not immediately breaking
+#   critical — action required; a job or the service itself is in a bad state
+
+groups:
+  - name: nomad_botherer_drift
+    rules:
+
+      # Any drift detected. The 5m 'for' window absorbs the normal gap
+      # between a git push and the next diff check — a job transitioning
+      # through a deploy will look drifted briefly. Tune to your
+      # --diff-interval / --poll-interval values.
+      - alert: NomadJobDrift
+        expr: nomad_botherer:drifted_jobs:total > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $value }} Nomad job(s) have drifted from git"
+          description: >
+            nomad-botherer has detected drift between the git repo and the
+            live Nomad cluster for more than 5 minutes.
+            Check /healthz or /diffs for details.
+
+      # A specific job has been in a modified state for an extended period.
+      # This usually means a deploy is stuck or someone edited the job in
+      # Nomad directly without pushing to git.
+      - alert: NomadJobModifiedPersistent
+        expr: >
+          nomad_botherer:job_drift_age_seconds{diff_type="modified"} > 3600
+        labels:
+          severity: critical
+        annotations:
+          summary: "Nomad job {{ $labels.job }} has been modified for {{ $value | humanizeDuration }}"
+          description: >
+            The running definition of job {{ $labels.job }} differs from the
+            HCL in git and has not been reconciled for over 1 hour.
+
+      # A job defined in git is absent from Nomad. Could be a failed deploy,
+      # an accidentally stopped job, or a job that was never submitted.
+      - alert: NomadJobMissingFromNomad
+        expr: >
+          nomad_botherer:job_drift_age_seconds{diff_type="missing_from_nomad"} > 900
+        labels:
+          severity: warning
+        annotations:
+          summary: "Nomad job {{ $labels.job }} is defined in git but missing from Nomad"
+          description: >
+            Job {{ $labels.job }} (defined in {{ $labels.hcl_file }}) has not
+            been registered in Nomad for over 15 minutes.
+
+      # A job is running in Nomad with no corresponding HCL file in the repo.
+      # Could be an untracked legacy job or one that was manually submitted.
+      - alert: NomadJobMissingFromHCL
+        expr: >
+          nomad_botherer:job_drift_age_seconds{diff_type="missing_from_hcl"} > 3600
+        labels:
+          severity: warning
+        annotations:
+          summary: "Nomad job {{ $labels.job }} has no HCL definition in git"
+          description: >
+            Job {{ $labels.job }} is running in Nomad but has no corresponding
+            HCL file in the watched git repo. It has been in this state for
+            {{ $value | humanizeDuration }}.
+
+  - name: nomad_botherer_health
+    rules:
+
+      # nomad-botherer has not completed a diff check recently.
+      # This fires if the service is running but stuck — e.g. the Nomad API
+      # is unreachable or the diff loop has stopped for another reason.
+      # Threshold should be at least 2× --diff-interval.
+      - alert: NomadBothererCheckStale
+        expr: nomad_botherer:seconds_since_last_check > 300
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "nomad-botherer has not run a diff check in {{ $value | humanizeDuration }}"
+          description: >
+            The last diff check was more than 5 minutes ago. The service may
+            be unable to reach the Nomad API or may have crashed.
+
+      # The git fetch loop is failing. nomad-botherer will continue checking
+      # drift against the last known commit, but won't pick up new changes.
+      - alert: NomadBothererGitFetchFailing
+        expr: nomad_botherer:git_fetch_error_rate5m > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "nomad-botherer git fetch is failing"
+          description: >
+            Git fetch/clone operations have been failing for 10 minutes.
+            Drift checks continue against the last successful fetch, but
+            new commits will not be picked up until fetching recovers.
+
+      # The git repo has not been successfully fetched in a while.
+      # Tune the threshold to be noticeably longer than --poll-interval.
+      - alert: NomadBothererGitStale
+        expr: nomad_botherer:seconds_since_git_update > 1800
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "nomad-botherer git repo has not been updated in {{ $value | humanizeDuration }}"
+          description: >
+            The in-memory git checkout has not been refreshed from the remote
+            in over 30 minutes. Drift checks may be running against a stale
+            view of the repo.
+
+      # Nomad API calls are failing. Depending on which operation is failing
+      # (info, plan, list), some or all drift checks will produce incomplete
+      # results.
+      - alert: NomadBothererAPIErrors
+        expr: nomad_botherer:nomad_api_error_rate5m > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "nomad-botherer is seeing Nomad API errors (op={{ $labels.op }})"
+          description: >
+            Nomad API {{ $labels.op }} operations have been failing for 10
+            minutes. Drift detection results may be incomplete.
+
+      # The service is not reachable by Prometheus at all.
+      - alert: NomadBothererDown
+        expr: up{job="nomad-botherer"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "nomad-botherer is not reachable"
+          description: >
+            Prometheus cannot scrape the nomad-botherer /metrics endpoint.
+            The service may be down or the network path may be broken.
+
+  - name: nomad_botherer_webhooks
+    rules:
+
+      # Webhook deliveries are consistently failing. The service will fall
+      # back to polling, but real-time drift detection is degraded.
+      - alert: NomadBothererWebhookErrors
+        expr: >
+          rate(nomad_botherer_webhook_events_total{event="error"}[10m]) > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "nomad-botherer webhook handler is returning errors"
+          description: >
+            Webhook events have been failing for 10 minutes. The service
+            will fall back to --poll-interval-based checks. Check logs for
+            signature verification or parse errors.

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,33 @@
+# Example Prometheus configuration for scraping nomad-botherer.
+#
+# Adjust the target address and labels to match your environment.
+# If you run multiple nomad-botherer instances (e.g. one per Nomad cluster),
+# add each as a separate static_configs entry with a distinguishing label.
+
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+rule_files:
+  - recording_rules.yml
+  - alerts.yml
+
+scrape_configs:
+  - job_name: nomad-botherer
+
+    static_configs:
+      - targets:
+          - localhost:8080
+        labels:
+          # Add any extra labels that help identify which cluster or
+          # environment this instance is watching.
+          cluster: default
+
+    # nomad-botherer's /metrics endpoint is at the default path.
+    # Uncomment if you run it on a non-default path.
+    # metrics_path: /metrics
+
+    # If nomad-botherer is behind TLS termination:
+    # scheme: https
+    # tls_config:
+    #   ca_file: /etc/prometheus/ca.crt

--- a/monitoring/recording_rules.yml
+++ b/monitoring/recording_rules.yml
@@ -1,0 +1,43 @@
+# Recording rules for nomad-botherer.
+#
+# These pre-aggregate frequently-used expressions so dashboards and alerts
+# can reference cheap series instead of recomputing the same expressions
+# on every query.
+
+groups:
+  - name: nomad_botherer_recording
+    interval: 30s
+    rules:
+
+      # Total number of drifting jobs across all diff types.
+      # Use this for a single "is anything wrong?" gauge.
+      - record: nomad_botherer:drifted_jobs:total
+        expr: sum without(diff_type) (nomad_botherer_drifted_jobs)
+
+      # Per-type count, preserved with the diff_type label.
+      # Equivalent to nomad_botherer_drifted_jobs but available under a
+      # stable recording-rule name for dashboards.
+      - record: nomad_botherer:drifted_jobs:by_type
+        expr: nomad_botherer_drifted_jobs
+
+      # How long each drifting job has been in its current state (seconds).
+      # Only present for jobs that are currently drifting.
+      - record: nomad_botherer:job_drift_age_seconds
+        expr: time() - nomad_botherer_job_drift_first_seen_timestamp_seconds
+
+      # 5-minute rate of git fetch errors.
+      # Positive values indicate the git polling loop is failing.
+      - record: nomad_botherer:git_fetch_error_rate5m
+        expr: rate(nomad_botherer_git_fetch_errors_total[5m])
+
+      # 5-minute rate of Nomad API errors, labelled by operation.
+      - record: nomad_botherer:nomad_api_error_rate5m
+        expr: rate(nomad_botherer_nomad_api_errors_total[5m])
+
+      # Seconds since the last successful diff check.
+      - record: nomad_botherer:seconds_since_last_check
+        expr: time() - nomad_botherer_last_check_timestamp_seconds
+
+      # Seconds since the last successful git fetch.
+      - record: nomad_botherer:seconds_since_git_update
+        expr: time() - nomad_botherer_git_last_update_timestamp_seconds


### PR DESCRIPTION
## What changed

### monitoring/ directory (new)

Three files for dropping into a Prometheus setup:

**`monitoring/prometheus.yml`** — minimal scrape config with commented sections for TLS, non-default metrics path, and multi-instance labelling.

**`monitoring/recording_rules.yml`** — pre-aggregated series so dashboards and alerts don't recompute the same expressions repeatedly: total and per-type drifted job counts, per-job drift age in seconds, git fetch and Nomad API error rates, seconds-since-last-check and seconds-since-last-git-update.

**`monitoring/alerts.yml`** — ten alert rules across three groups:
- Drift alerts: any drift >5m, modified drift >1h, job missing from Nomad >15m, job missing from HCL >1h
- Health alerts: check loop stale, git fetch failing, git clone stale, Nomad API errors, service down
- Webhook alerts: consistent webhook delivery failures

Each alert has an annotation explaining what the condition likely means and what to look at.

### README

The Monitoring section is expanded significantly:
- Metrics table split into four categories (drift state, diff checks, git tracking, webhooks) plus service info
- Added a "What it tells you" column in place of the brief one-liner descriptions
- Two webhook timestamp metrics that were missing from the table are now included
- The inline alert snippet is replaced by a table pointing to `monitoring/` with a summary of each alert

## What to review

- Alert thresholds in `alerts.yml` are reasonable starting points but will need tuning to match `--diff-interval` / `--poll-interval` values for a given deployment
- The `for:` durations on drift alerts are designed to avoid false positives during normal deploys — adjust if your deployment windows are longer