### PR TITLE
Fix Dockerfile Go version for v0.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #     --build-arg VERSION=$(git describe --tags --always --dirty) \
 #     -t ghcr.io/gerrowadat/nomad-botherer:VERSION .
 
-FROM --platform=${BUILDPLATFORM} golang:1.24-alpine AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.25-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -35,6 +35,6 @@ COPY --from=builder /out/nomad-botherer /usr/local/bin/nomad-botherer
 
 USER nomad-botherer
 
-EXPOSE 8080
+EXPOSE 8080 9090
 
 ENTRYPOINT ["/usr/local/bin/nomad-botherer"]


### PR DESCRIPTION
The grpc dependency added in v0.1.0 bumped `go.mod` to Go 1.25, but the Dockerfile builder image was still on `golang:1.24-alpine`, causing the Docker build to fail.

Changes:
- Builder image: `golang:1.24-alpine` → `golang:1.25-alpine`
- `EXPOSE 8080` → `EXPOSE 8080 9090` (adds the gRPC port alongside HTTP)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuoTfxWoUy2Ye3evcKSsdv)_