### PR TITLE
add readiness gate to HTTP and gRPC servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ already-reachable port; it is not a substitute for transport security.
 
 | RPC | Request | Response | Description |
 |-----|---------|----------|-------------|
-| `GetDiffs` | `GetDiffsRequest` | `GetDiffsResponse` | Returns all currently-detected job diffs, plus the last check time and git commit |
-| `GetStatus` | `GetStatusRequest` | `GetStatusResponse` | Returns git watcher status: last commit hash and last successful fetch time |
+| `GetDiffs` | `GetDiffsRequest` | `GetDiffsResponse` | Returns all currently-detected job diffs, plus the last check time and git commit. Returns `codes.Unavailable` until startup is complete. |
+| `GetStatus` | `GetStatusRequest` | `GetStatusResponse` | Returns git watcher status: last commit hash and last successful fetch time. Returns `codes.Unavailable` until the initial clone completes. |
 | `TriggerRefresh` | `TriggerRefreshRequest` | `TriggerRefreshResponse` | Triggers an immediate git pull and diff check (same effect as a webhook push event) |
 | `GetVersion` | `GetVersionRequest` | `GetVersionResponse` | Returns the server's version string, git commit hash, and build date (as set by `-ldflags` at build time; defaults to `dev` / `unknown`) |
 
@@ -412,7 +412,7 @@ grpcurl -plaintext \
 
 ### `/healthz`
 
-Always returns **HTTP 200**. The JSON body describes the current drift state:
+Returns **HTTP 200** once the server has built its initial state (completed the first git clone and the first diff check). Until then it returns **HTTP 503** with `"status": "starting"`.
 
 ```json
 {
@@ -437,7 +437,9 @@ Always returns **HTTP 200**. The JSON body describes the current drift state:
 }
 ```
 
-`"status"` is `"ok"` when there are no diffs, `"diffs_detected"` otherwise.
+`"status"` is `"ok"` when there are no diffs, `"diffs_detected"` when drift is detected, and `"starting"` (with HTTP 503) before the first diff check completes.
+
+The `/diffs` endpoint and all gRPC RPCs that return state also return HTTP 503 / `codes.Unavailable` during startup.
 
 ### `/metrics`
 

--- a/cmd/nbctl/commands_test.go
+++ b/cmd/nbctl/commands_test.go
@@ -27,14 +27,17 @@ func (m *mockDiffSource) Diffs() ([]nomad.JobDiff, time.Time, string) {
 	return m.diffs, m.lastCheck, m.lastCommit
 }
 
+func (m *mockDiffSource) Ready() bool { return !m.lastCheck.IsZero() }
+
 // mockGitSource implements grpcserver.GitStatusSource for tests.
 type mockGitSource struct {
 	lastCommit string
 	lastUpdate time.Time
 }
 
-func (m *mockGitSource) Trigger()                          {}
-func (m *mockGitSource) Status() (string, time.Time)       { return m.lastCommit, m.lastUpdate }
+func (m *mockGitSource) Trigger()                    {}
+func (m *mockGitSource) Status() (string, time.Time) { return m.lastCommit, m.lastUpdate }
+func (m *mockGitSource) Ready() bool                 { return !m.lastUpdate.IsZero() }
 
 // startServer starts a throwaway gRPC server and returns its address and a stop function.
 func startServer(t *testing.T, diffs grpcserver.DiffSource, git grpcserver.GitStatusSource, info grpcserver.BuildInfo) (addr string, stop func()) {
@@ -75,7 +78,8 @@ var defaultInfo = grpcserver.BuildInfo{
 // ── diffs ────────────────────────────────────────────────────────────────────
 
 func TestDiffsCmd_NoDiffs(t *testing.T) {
-	addr, stop := startServer(t, &mockDiffSource{}, &mockGitSource{}, defaultInfo)
+	now := time.Now()
+	addr, stop := startServer(t, &mockDiffSource{lastCheck: now}, &mockGitSource{lastUpdate: now}, defaultInfo)
 	defer stop()
 
 	out, err := runCmd(t, addr, testKey, "diffs")
@@ -104,7 +108,8 @@ func TestDiffsCmd_WithDiffs(t *testing.T) {
 		lastCheck:  time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC),
 		lastCommit: "abc123",
 	}
-	addr, stop := startServer(t, src, &mockGitSource{}, defaultInfo)
+	git := &mockGitSource{lastUpdate: time.Date(2026, 5, 8, 11, 0, 0, 0, time.UTC)}
+	addr, stop := startServer(t, src, git, defaultInfo)
 	defer stop()
 
 	out, err := runCmd(t, addr, testKey, "diffs")
@@ -126,8 +131,9 @@ func TestDiffsCmd_WithDiffs(t *testing.T) {
 }
 
 func TestDiffsCmd_JSON(t *testing.T) {
-	src := &mockDiffSource{lastCommit: "abc123"}
-	addr, stop := startServer(t, src, &mockGitSource{}, defaultInfo)
+	now := time.Now()
+	src := &mockDiffSource{lastCheck: now, lastCommit: "abc123"}
+	addr, stop := startServer(t, src, &mockGitSource{lastUpdate: now}, defaultInfo)
 	defer stop()
 
 	out, err := runCmd(t, addr, testKey, "diffs", "--output", "json")
@@ -161,17 +167,13 @@ func TestStatusCmd(t *testing.T) {
 	}
 }
 
-func TestStatusCmd_NoData(t *testing.T) {
+func TestStatusCmd_NotReady(t *testing.T) {
 	addr, stop := startServer(t, &mockDiffSource{}, &mockGitSource{}, defaultInfo)
 	defer stop()
 
-	out, err := runCmd(t, addr, testKey, "status")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// Zero-value times produce "(none)" placeholders.
-	if strings.Count(out, "(none)") != 2 {
-		t.Errorf("want 2 '(none)' placeholders, got: %q", out)
+	_, err := runCmd(t, addr, testKey, "status")
+	if err == nil {
+		t.Fatal("expected error when server not ready, got nil")
 	}
 }
 
@@ -254,7 +256,8 @@ func TestWrongAPIKey(t *testing.T) {
 // ── env var fallback ──────────────────────────────────────────────────────────
 
 func TestAPIKeyFromEnv(t *testing.T) {
-	addr, stop := startServer(t, &mockDiffSource{}, &mockGitSource{}, defaultInfo)
+	now := time.Now()
+	addr, stop := startServer(t, &mockDiffSource{lastCheck: now}, &mockGitSource{lastUpdate: now}, defaultInfo)
 	defer stop()
 
 	t.Setenv("NBCTL_API_KEY", testKey)
@@ -270,7 +273,8 @@ func TestAPIKeyFromEnv(t *testing.T) {
 }
 
 func TestServerFromEnv(t *testing.T) {
-	addr, stop := startServer(t, &mockDiffSource{}, &mockGitSource{}, defaultInfo)
+	now := time.Now()
+	addr, stop := startServer(t, &mockDiffSource{lastCheck: now}, &mockGitSource{lastUpdate: now}, defaultInfo)
 	defer stop()
 
 	t.Setenv("NBCTL_SERVER", addr)

--- a/internal/gitwatch/watcher.go
+++ b/internal/gitwatch/watcher.go
@@ -140,6 +140,14 @@ func (w *Watcher) Trigger() {
 	}
 }
 
+// Ready reports whether the initial clone has completed successfully.
+// Before Clone returns, Status and ReadHCLFiles return zero/nil values.
+func (w *Watcher) Ready() bool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.repo != nil
+}
+
 // Status returns the last seen commit hash and the time it was seen.
 func (w *Watcher) Status() (lastCommit string, lastUpdate time.Time) {
 	w.mu.RLock()

--- a/internal/grpcserver/server.go
+++ b/internal/grpcserver/server.go
@@ -25,12 +25,16 @@ import (
 // DiffSource is satisfied by *nomad.Differ.
 type DiffSource interface {
 	Diffs() ([]nomad.JobDiff, time.Time, string)
+	// Ready reports whether at least one diff check has completed.
+	Ready() bool
 }
 
 // GitStatusSource is satisfied by *gitwatch.Watcher.
 type GitStatusSource interface {
 	Trigger()
 	Status() (lastCommit string, lastUpdate time.Time)
+	// Ready reports whether the initial git clone has completed.
+	Ready() bool
 }
 
 // BuildInfo holds the version strings injected at link time.
@@ -148,6 +152,9 @@ func (s *Server) authInterceptor(ctx context.Context, req any, info *grpc.UnaryS
 
 // GetDiffs returns the latest set of job diffs.
 func (s *Server) GetDiffs(_ context.Context, _ *grpcapi.GetDiffsRequest) (*grpcapi.GetDiffsResponse, error) {
+	if !s.git.Ready() || !s.diffs.Ready() {
+		return nil, status.Error(codes.Unavailable, "server is not ready: initial state not yet built")
+	}
 	diffs, lastCheck, lastCommit := s.diffs.Diffs()
 
 	pbDiffs := make([]*grpcapi.JobDiff, 0, len(diffs))
@@ -172,6 +179,9 @@ func (s *Server) GetDiffs(_ context.Context, _ *grpcapi.GetDiffsRequest) (*grpca
 
 // GetStatus returns git watcher status.
 func (s *Server) GetStatus(_ context.Context, _ *grpcapi.GetStatusRequest) (*grpcapi.GetStatusResponse, error) {
+	if !s.git.Ready() {
+		return nil, status.Error(codes.Unavailable, "server is not ready: git state not yet initialized")
+	}
 	lastCommit, lastUpdate := s.git.Status()
 	resp := &grpcapi.GetStatusResponse{
 		LastCommit: lastCommit,

--- a/internal/grpcserver/server_test.go
+++ b/internal/grpcserver/server_test.go
@@ -31,11 +31,13 @@ func (m *mockDiffSource) Diffs() ([]nomad.JobDiff, time.Time, string) {
 	return m.diffs, m.lastCheck, m.lastCommit
 }
 
+func (m *mockDiffSource) Ready() bool { return !m.lastCheck.IsZero() }
+
 // mockGitSource implements grpcserver.GitStatusSource.
 type mockGitSource struct {
-	lastCommit  string
-	lastUpdate  time.Time
-	triggered   bool
+	lastCommit string
+	lastUpdate time.Time
+	triggered  bool
 }
 
 func (m *mockGitSource) Trigger() {
@@ -45,6 +47,8 @@ func (m *mockGitSource) Trigger() {
 func (m *mockGitSource) Status() (string, time.Time) {
 	return m.lastCommit, m.lastUpdate
 }
+
+func (m *mockGitSource) Ready() bool { return !m.lastUpdate.IsZero() }
 
 var testBuildInfo = grpcserver.BuildInfo{
 	Version:   "v1.2.3",
@@ -122,7 +126,7 @@ func TestGetDiffs_Empty(t *testing.T) {
 		lastCheck:  time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
 		lastCommit: "abc123",
 	}
-	gitSrc := &mockGitSource{}
+	gitSrc := &mockGitSource{lastUpdate: time.Date(2026, 1, 1, 11, 0, 0, 0, time.UTC)}
 	client, stop := startTestServer(t, diffSrc, gitSrc)
 	defer stop()
 
@@ -159,7 +163,7 @@ func TestGetDiffs_WithDiffs(t *testing.T) {
 		lastCheck:  now,
 		lastCommit: "def456",
 	}
-	gitSrc := &mockGitSource{}
+	gitSrc := &mockGitSource{lastUpdate: now}
 	client, stop := startTestServer(t, diffSrc, gitSrc)
 	defer stop()
 
@@ -194,18 +198,33 @@ func TestGetDiffs_WithDiffs(t *testing.T) {
 	}
 }
 
-func TestGetDiffs_ZeroLastCheck(t *testing.T) {
-	diffSrc := &mockDiffSource{}
-	gitSrc := &mockGitSource{}
+func TestGetDiffs_NotReady(t *testing.T) {
+	diffSrc := &mockDiffSource{} // zero lastCheck → not ready
+	gitSrc := &mockGitSource{}   // zero lastUpdate → not ready
 	client, stop := startTestServer(t, diffSrc, gitSrc)
 	defer stop()
 
-	resp, err := client.GetDiffs(authCtx(testAPIKey), &grpcapi.GetDiffsRequest{})
-	if err != nil {
-		t.Fatalf("GetDiffs: %v", err)
+	_, err := client.GetDiffs(authCtx(testAPIKey), &grpcapi.GetDiffsRequest{})
+	if err == nil {
+		t.Fatal("expected error when server not ready, got nil")
 	}
-	if resp.LastCheckTime != "" {
-		t.Fatalf("want empty last_check_time for zero time, got %q", resp.LastCheckTime)
+	if s, _ := status.FromError(err); s.Code() != codes.Unavailable {
+		t.Fatalf("want Unavailable, got %s", s.Code())
+	}
+}
+
+func TestGetDiffs_GitNotReady(t *testing.T) {
+	diffSrc := &mockDiffSource{lastCheck: time.Now(), lastCommit: "abc"} // diffs ready
+	gitSrc := &mockGitSource{}                                            // git not ready
+	client, stop := startTestServer(t, diffSrc, gitSrc)
+	defer stop()
+
+	_, err := client.GetDiffs(authCtx(testAPIKey), &grpcapi.GetDiffsRequest{})
+	if err == nil {
+		t.Fatal("expected error when git not ready, got nil")
+	}
+	if s, _ := status.FromError(err); s.Code() != codes.Unavailable {
+		t.Fatalf("want Unavailable, got %s", s.Code())
 	}
 }
 
@@ -233,18 +252,18 @@ func TestGetStatus(t *testing.T) {
 	}
 }
 
-func TestGetStatus_ZeroLastUpdate(t *testing.T) {
+func TestGetStatus_GitNotReady(t *testing.T) {
 	diffSrc := &mockDiffSource{}
-	gitSrc := &mockGitSource{}
+	gitSrc := &mockGitSource{} // zero lastUpdate → git not ready
 	client, stop := startTestServer(t, diffSrc, gitSrc)
 	defer stop()
 
-	resp, err := client.GetStatus(authCtx(testAPIKey), &grpcapi.GetStatusRequest{})
-	if err != nil {
-		t.Fatalf("GetStatus: %v", err)
+	_, err := client.GetStatus(authCtx(testAPIKey), &grpcapi.GetStatusRequest{})
+	if err == nil {
+		t.Fatal("expected error when git not ready, got nil")
 	}
-	if resp.LastUpdateTime != "" {
-		t.Fatalf("want empty last_update_time for zero time, got %q", resp.LastUpdateTime)
+	if s, _ := status.FromError(err); s.Code() != codes.Unavailable {
+		t.Fatalf("want Unavailable, got %s", s.Code())
 	}
 }
 
@@ -374,8 +393,9 @@ func TestMetrics_AuthErrorCounted(t *testing.T) {
 }
 
 func TestMetrics_SuccessfulRequestCounted(t *testing.T) {
-	diffSrc := &mockDiffSource{}
-	gitSrc := &mockGitSource{}
+	now := time.Now()
+	diffSrc := &mockDiffSource{lastCheck: now, lastCommit: "abc"}
+	gitSrc := &mockGitSource{lastUpdate: now}
 	reg := prometheus.NewRegistry()
 	srv := grpcserver.NewWithRegistry(testAPIKey, diffSrc, gitSrc, testBuildInfo, reg)
 

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -323,6 +323,15 @@ func driftKey(jobID, diffType string) string {
 	return jobID + "\x00" + diffType
 }
 
+// Ready reports whether at least one diff check has completed successfully.
+// Before the first check finishes, callers cannot distinguish "no drift" from
+// "haven't checked yet", so they should treat the Differ as unavailable.
+func (d *Differ) Ready() bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return !d.lastCheckTime.IsZero()
+}
+
 // Diffs returns a snapshot of the latest diffs, the time they were computed,
 // and the git commit they were computed against.
 func (d *Differ) Diffs() ([]JobDiff, time.Time, string) {

--- a/internal/server/render_test.go
+++ b/internal/server/render_test.go
@@ -16,11 +16,12 @@ import (
 )
 
 // diffsResponse builds a /diffs response with full control over the diff source.
+// Both sources are "ready" (non-zero times) so the handler serves the render output.
 func diffsResponse(t *testing.T, diffs []nomad.JobDiff, lastCheck time.Time) string {
 	t.Helper()
 	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main"}
 	diffSrc := &mockDiffSource{diffs: diffs, lastCheck: lastCheck, lastCommit: "abc"}
-	gitSrc := &mockGitSource{}
+	gitSrc := &mockGitSource{lastUpdate: time.Now()}
 	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, "test", prometheus.NewRegistry())
 	req := httptest.NewRequest(http.MethodGet, "/diffs", nil)
 	rec := httptest.NewRecorder()
@@ -30,11 +31,11 @@ func diffsResponse(t *testing.T, diffs []nomad.JobDiff, lastCheck time.Time) str
 
 // ── renderDiffsText ───────────────────────────────────────────────────────────
 
-func TestDiffs_ZeroLastCheck(t *testing.T) {
-	body := diffsResponse(t, nil, time.Time{})
-	// Zero lastCheck: the "Last check:" line should not appear.
-	if strings.Contains(body, "Last check:") {
-		t.Error("zero lastCheck should not produce a 'Last check:' line")
+func TestDiffs_NoLastCheckLine(t *testing.T) {
+	// When lastCheck is provided as a non-zero time, the "Last check:" line should appear.
+	body := diffsResponse(t, nil, time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	if !strings.Contains(body, "Last check:") {
+		t.Error("non-zero lastCheck should produce a 'Last check:' line")
 	}
 	if !strings.Contains(body, "No differences") {
 		t.Error("expected 'No differences' message")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,12 +25,16 @@ import (
 // DiffSource is satisfied by *nomad.Differ.
 type DiffSource interface {
 	Diffs() ([]nomad.JobDiff, time.Time, string)
+	// Ready reports whether at least one diff check has completed.
+	Ready() bool
 }
 
 // GitStatusSource is satisfied by *gitwatch.Watcher.
 type GitStatusSource interface {
 	Trigger()
 	Status() (lastCommit string, lastUpdate time.Time)
+	// Ready reports whether the initial git clone has completed.
+	Ready() bool
 }
 
 // Server holds the HTTP mux and all dependencies.
@@ -141,6 +145,7 @@ var indexTmpl = template.Must(template.New("index").Parse(`<!DOCTYPE html>
     h1   { margin-bottom: 0.2em; }
     .ok  { color: #2a7a2a; font-weight: bold; }
     .bad { color: #b94040; font-weight: bold; }
+    .starting { color: #7a6a00; font-weight: bold; }
     code { background: #f4f4f4; padding: 0.1em 0.3em; border-radius: 3px; }
     ul   { line-height: 1.8; }
   </style>
@@ -148,7 +153,9 @@ var indexTmpl = template.Must(template.New("index").Parse(`<!DOCTYPE html>
 <body>
   <h1>nomad-botherer <small>{{.Version}}</small></h1>
   <p>Status:
-    {{- if .DiffCount}}
+    {{- if .Starting}}
+    <span class="starting">starting — initial state not yet built</span>
+    {{- else if .DiffCount}}
     <span class="bad">{{.DiffCount}} difference(s) detected</span>
     {{- else}}
     <span class="ok">OK — no differences</span>
@@ -173,7 +180,14 @@ var indexTmpl = template.Must(template.New("index").Parse(`<!DOCTYPE html>
 `))
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
-	diffs, lastCheck, commit := s.diffs.Diffs()
+	starting := !s.git.Ready() || !s.diffs.Ready()
+
+	var diffs []nomad.JobDiff
+	var lastCheck time.Time
+	var commit string
+	if !starting {
+		diffs, lastCheck, commit = s.diffs.Diffs()
+	}
 
 	s.webhookMu.RLock()
 	lastOK := s.lastWebhookSuccess
@@ -181,14 +195,16 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	s.webhookMu.RUnlock()
 
 	data := struct {
-		Version        string
-		DiffCount      int
-		LastCheck      string
-		Commit         string
-		LastWebhookOK  string
+		Version         string
+		Starting        bool
+		DiffCount       int
+		LastCheck       string
+		Commit          string
+		LastWebhookOK   string
 		LastWebhookFail string
 	}{
 		Version:   s.version,
+		Starting:  starting,
 		DiffCount: len(diffs),
 		Commit:    commit,
 	}
@@ -203,10 +219,17 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if starting {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
 	_ = indexTmpl.Execute(w, data)
 }
 
 func (s *Server) handleDiffs(w http.ResponseWriter, r *http.Request) {
+	if !s.git.Ready() || !s.diffs.Ready() {
+		http.Error(w, "not ready: initial state not yet built", http.StatusServiceUnavailable)
+		return
+	}
 	diffs, lastCheck, commit := s.diffs.Diffs()
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	fmt.Fprint(w, renderDiffsText(diffs, lastCheck, commit))
@@ -215,6 +238,7 @@ func (s *Server) handleDiffs(w http.ResponseWriter, r *http.Request) {
 // HealthResponse is the JSON body returned by /healthz.
 type HealthResponse struct {
 	Status     string      `json:"status"`
+	Message    string      `json:"message,omitempty"`
 	DiffCount  int         `json:"diff_count"`
 	Diffs      []DiffEntry `json:"diffs"`
 	LastCheck  string      `json:"last_check,omitempty"`
@@ -231,6 +255,16 @@ type DiffEntry struct {
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	if !s.git.Ready() || !s.diffs.Ready() {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(HealthResponse{
+			Status:  "starting",
+			Message: "initial state not yet built",
+		})
+		return
+	}
+
 	diffs, lastCheck, gitCommit := s.diffs.Diffs()
 	_, gitUpdated := s.git.Status()
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -32,6 +32,8 @@ func (m *mockDiffSource) Diffs() ([]nomad.JobDiff, time.Time, string) {
 	return m.diffs, m.lastCheck, m.lastCommit
 }
 
+func (m *mockDiffSource) Ready() bool { return !m.lastCheck.IsZero() }
+
 // mockGitSource implements server.GitStatusSource.
 type mockGitSource struct {
 	lastCommit string
@@ -41,6 +43,7 @@ type mockGitSource struct {
 
 func (m *mockGitSource) Trigger()                    { m.triggered = true }
 func (m *mockGitSource) Status() (string, time.Time) { return m.lastCommit, m.lastUpdate }
+func (m *mockGitSource) Ready() bool                 { return !m.lastUpdate.IsZero() }
 
 // newTestServer builds a Server with fresh per-test Prometheus registry.
 func newTestServer(t *testing.T, diffs []nomad.JobDiff) (*server.Server, *mockGitSource) {
@@ -577,5 +580,88 @@ func TestWebhook_WithSecret_InvalidSignature_Rejected(t *testing.T) {
 	}
 	if gitSrc.triggered {
 		t.Error("Trigger() should NOT be called when signature is invalid")
+	}
+}
+
+// ── readiness gate ────────────────────────────────────────────────────────────
+
+// newNotReadyServer builds a server where neither git nor diffs are ready.
+func newNotReadyServer(t *testing.T) *server.Server {
+	t.Helper()
+	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main"}
+	diffSrc := &mockDiffSource{} // zero lastCheck → not ready
+	gitSrc := &mockGitSource{}   // zero lastUpdate → not ready
+	return server.NewWithRegistry(cfg, diffSrc, gitSrc, "test", prometheus.NewRegistry())
+}
+
+func TestHealthz_NotReady_Returns503(t *testing.T) {
+	srv := newNotReadyServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", rec.Code)
+	}
+	var resp server.HealthResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != "starting" {
+		t.Errorf("want status starting, got %q", resp.Status)
+	}
+	if resp.Message == "" {
+		t.Error("want non-empty message when not ready")
+	}
+}
+
+func TestHealthz_GitNotReady_Returns503(t *testing.T) {
+	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main"}
+	diffSrc := &mockDiffSource{lastCheck: time.Now(), lastCommit: "abc"} // diffs ready
+	gitSrc := &mockGitSource{}                                            // git not ready
+	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, "test", prometheus.NewRegistry())
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503 when git not ready, got %d", rec.Code)
+	}
+}
+
+func TestHealthz_DiffsNotReady_Returns503(t *testing.T) {
+	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main"}
+	diffSrc := &mockDiffSource{}                                                // diffs not ready
+	gitSrc := &mockGitSource{lastCommit: "abc", lastUpdate: time.Now()} // git ready
+	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, "test", prometheus.NewRegistry())
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503 when diffs not ready, got %d", rec.Code)
+	}
+}
+
+func TestDiffs_NotReady_Returns503(t *testing.T) {
+	srv := newNotReadyServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/diffs", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", rec.Code)
+	}
+}
+
+func TestIndex_NotReady_Returns503(t *testing.T) {
+	srv := newNotReadyServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "starting") {
+		t.Error("index page should show starting state when not ready")
 	}
 }


### PR DESCRIPTION
Before this change, both servers returned empty/zero-value responses before the initial git clone completed and before the first diff check ran. A caller had no way to distinguish "no drift detected" from "haven't checked yet".

## What changed

**New `Ready() bool` methods:**
- `gitwatch.Watcher.Ready()` — true after `Clone()` completes
- `nomad.Differ.Ready()` — true after the first `Check()` call

Both `DiffSource` and `GitStatusSource` interfaces (in `internal/server` and `internal/grpcserver`) are extended with `Ready() bool`.

**HTTP server:**
- `/healthz` returns HTTP 503 with `{"status":"starting","message":"initial state not yet built"}` until both sources are ready; once ready, behaviour is unchanged
- `/diffs` returns HTTP 503 with a plain-text not-ready message during startup
- `/` (index) returns HTTP 503 and renders a "starting" status instead of the misleading "OK — no differences"

**gRPC server:**
- `GetDiffs` returns `codes.Unavailable` until both git clone and first diff check complete
- `GetStatus` returns `codes.Unavailable` until the git clone completes
- `TriggerRefresh` and `GetVersion` are unaffected — they have no state dependency

**Tests:** existing happy-path tests updated to use non-zero timestamps so mocks report ready; new tests added for the 503/Unavailable path on each affected endpoint.

**Docs:** `/healthz` section updated to document the 503 startup window; gRPC table updated to note which RPCs gate on readiness.

https://claude.ai/code/session_01EuoTfxWoUy2Ye3evcKSsdv

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuoTfxWoUy2Ye3evcKSsdv)_