### PR TITLE
use Nomad Raft index to skip unchanged diff checks

### DIFF
--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -65,20 +65,22 @@ type Differ struct {
 	namespace       string
 	includeDeadJobs bool
 
-	mu             sync.RWMutex
-	diffs          []JobDiff
-	lastCheckTime  time.Time
-	lastCommit     string
-	driftFirstSeen map[string]time.Time // key: driftKey(jobID, diffType); protected by mu
+	mu              sync.RWMutex
+	diffs           []JobDiff
+	lastCheckTime   time.Time
+	lastCommit      string
+	lastNomadIndex  uint64            // Raft index from the last successful List(); protected by mu
+	driftFirstSeen  map[string]time.Time // key: driftKey(jobID, diffType); protected by mu
 
-	hclParseErrors  prometheus.Counter
-	hclFilesSkipped prometheus.Counter
-	diffChecks      prometheus.Counter
-	nomadAPIErrors  *prometheus.CounterVec
-	lastCheck       prometheus.Gauge
-	jobDiffs        *prometheus.GaugeVec
-	driftedJobs     *prometheus.GaugeVec
-	jobDriftSince   *prometheus.GaugeVec
+	hclParseErrors    prometheus.Counter
+	hclFilesSkipped   prometheus.Counter
+	diffChecks        prometheus.Counter
+	diffChecksSkipped prometheus.Counter
+	nomadAPIErrors    *prometheus.CounterVec
+	lastCheck         prometheus.Gauge
+	jobDiffs          *prometheus.GaugeVec
+	driftedJobs       *prometheus.GaugeVec
+	jobDriftSince     *prometheus.GaugeVec
 }
 
 // newDifferBase constructs a Differ with metrics registered into reg.
@@ -100,6 +102,10 @@ func newDifferBase(jobs NomadJobsClient, namespace string, includeDeadJobs bool,
 		diffChecks: f.NewCounter(prometheus.CounterOpts{
 			Name: "nomad_botherer_diff_checks_total",
 			Help: "Total number of diff checks run against the Nomad cluster.",
+		}),
+		diffChecksSkipped: f.NewCounter(prometheus.CounterOpts{
+			Name: "nomad_botherer_diff_checks_skipped_total",
+			Help: "Total number of diff checks skipped because neither the Nomad index nor the git commit changed.",
 		}),
 		nomadAPIErrors: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "nomad_botherer_nomad_api_errors_total",
@@ -154,11 +160,33 @@ func NewWithClientAndRegistry(cfg *config.Config, jobs NomadJobsClient, reg prom
 // Check compares the given HCL files (path → content) against the live Nomad
 // cluster and stores the results. commit is recorded for informational purposes.
 func (d *Differ) Check(hclFiles map[string]string, commit string) error {
-	slog.Info("Running diff check", "commit", commit, "hcl_files", len(hclFiles))
-	d.diffChecks.Inc()
-
 	q := &nomadapi.QueryOptions{Namespace: d.namespace}
 	wq := &nomadapi.WriteOptions{Namespace: d.namespace}
+
+	// List all Nomad jobs first. The returned Raft index lets us skip the
+	// expensive per-job work when neither Nomad state nor the git commit has
+	// changed since the last check.
+	allJobs, listMeta, err := d.jobs.List(q)
+	if err != nil {
+		d.nomadAPIErrors.WithLabelValues("list").Inc()
+		slog.Warn("Failed to list Nomad jobs", "err", err)
+		allJobs = nil
+		listMeta = nil
+	}
+
+	d.mu.RLock()
+	prevCommit := d.lastCommit
+	prevIndex := d.lastNomadIndex
+	d.mu.RUnlock()
+
+	if listMeta != nil && listMeta.LastIndex == prevIndex && commit == prevCommit {
+		slog.Debug("Skipping diff: Nomad index and commit unchanged", "index", listMeta.LastIndex, "commit", commit)
+		d.diffChecksSkipped.Inc()
+		return nil
+	}
+
+	slog.Info("Running diff check", "commit", commit, "hcl_files", len(hclFiles))
+	d.diffChecks.Inc()
 
 	// Parse all HCL files via the Nomad API.
 	hclJobs := make(map[string]*nomadapi.Job) // jobID → parsed job
@@ -244,22 +272,16 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 	// Find jobs in Nomad that have no corresponding HCL file.
 	// Dead jobs are skipped unless --include-dead-jobs is set, since a dead
 	// job without HCL is expected (it was stopped intentionally).
-	allJobs, _, err := d.jobs.List(q)
-	if err != nil {
-		d.nomadAPIErrors.WithLabelValues("list").Inc()
-		slog.Warn("Failed to list Nomad jobs", "err", err)
-	} else {
-		for _, j := range allJobs {
-			if !d.includeDeadJobs && j.Status == "dead" {
-				continue
-			}
-			if _, ok := hclJobs[j.ID]; !ok {
-				diffs = append(diffs, JobDiff{
-					JobID:    j.ID,
-					DiffType: DiffTypeMissingFromHCL,
-					Detail:   fmt.Sprintf("job is running in Nomad (status: %s) but has no HCL definition in the repo", j.Status),
-				})
-			}
+	for _, j := range allJobs {
+		if !d.includeDeadJobs && j.Status == "dead" {
+			continue
+		}
+		if _, ok := hclJobs[j.ID]; !ok {
+			diffs = append(diffs, JobDiff{
+				JobID:    j.ID,
+				DiffType: DiffTypeMissingFromHCL,
+				Detail:   fmt.Sprintf("job is running in Nomad (status: %s) but has no HCL definition in the repo", j.Status),
+			})
 		}
 	}
 
@@ -275,6 +297,9 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 	d.diffs = diffs
 	d.lastCheckTime = now
 	d.lastCommit = commit
+	if listMeta != nil {
+		d.lastNomadIndex = listMeta.LastIndex
+	}
 
 	// Remove entries that are no longer drifting.
 	for k := range d.driftFirstSeen {

--- a/internal/nomad/differ_test.go
+++ b/internal/nomad/differ_test.go
@@ -516,6 +516,115 @@ func gatherJobDriftSince(t *testing.T, reg prometheus.Gatherer, job, diffType st
 	return 0
 }
 
+// TestDiffer_SkipOnUnchangedIndexAndCommit verifies that Check skips all
+// per-job API calls when both the Nomad Raft index and the git commit are
+// identical to the previous check.
+func TestDiffer_SkipOnUnchangedIndexAndCommit(t *testing.T) {
+	mock := defaultMock()
+	infoCalls := 0
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		infoCalls++
+		return &nomadapi.Job{ID: strPtr(jobID)}, nil, nil
+	}
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return nil, &nomadapi.QueryMeta{LastIndex: 42}, nil
+	}
+	d := newTestDiffer(mock)
+
+	if err := d.Check(map[string]string{"a.hcl": `job "test-job" {}`}, "abc123"); err != nil {
+		t.Fatal(err)
+	}
+	if infoCalls != 1 {
+		t.Fatalf("expected 1 Info call after first check, got %d", infoCalls)
+	}
+
+	// Second call: same commit, same Nomad index — must skip per-job work.
+	if err := d.Check(map[string]string{"a.hcl": `job "test-job" {}`}, "abc123"); err != nil {
+		t.Fatal(err)
+	}
+	if infoCalls != 1 {
+		t.Errorf("expected Info not called on skip, got %d total calls", infoCalls)
+	}
+}
+
+// TestDiffer_NoSkipOnChangedCommit verifies that a new git commit forces a
+// full check even when the Nomad index has not advanced.
+func TestDiffer_NoSkipOnChangedCommit(t *testing.T) {
+	mock := defaultMock()
+	infoCalls := 0
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		infoCalls++
+		return &nomadapi.Job{ID: strPtr(jobID)}, nil, nil
+	}
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return nil, &nomadapi.QueryMeta{LastIndex: 42}, nil
+	}
+	d := newTestDiffer(mock)
+
+	if err := d.Check(map[string]string{"a.hcl": `job "test-job" {}`}, "abc123"); err != nil {
+		t.Fatal(err)
+	}
+	// Different commit, same Nomad index — must not skip.
+	if err := d.Check(map[string]string{"a.hcl": `job "test-job" {}`}, "def456"); err != nil {
+		t.Fatal(err)
+	}
+	if infoCalls != 2 {
+		t.Errorf("expected 2 Info calls when commit changes, got %d", infoCalls)
+	}
+}
+
+// TestDiffer_NoSkipOnChangedNomadIndex verifies that an advanced Nomad Raft
+// index forces a full check even when the git commit is unchanged.
+func TestDiffer_NoSkipOnChangedNomadIndex(t *testing.T) {
+	mock := defaultMock()
+	infoCalls := 0
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		infoCalls++
+		return &nomadapi.Job{ID: strPtr(jobID)}, nil, nil
+	}
+	nomadIndex := uint64(42)
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return nil, &nomadapi.QueryMeta{LastIndex: nomadIndex}, nil
+	}
+	d := newTestDiffer(mock)
+
+	if err := d.Check(map[string]string{"a.hcl": `job "test-job" {}`}, "abc123"); err != nil {
+		t.Fatal(err)
+	}
+	// Advance the Nomad index, same commit — must not skip.
+	nomadIndex = 99
+	if err := d.Check(map[string]string{"a.hcl": `job "test-job" {}`}, "abc123"); err != nil {
+		t.Fatal(err)
+	}
+	if infoCalls != 2 {
+		t.Errorf("expected 2 Info calls when Nomad index advances, got %d", infoCalls)
+	}
+}
+
+// TestDiffer_NoSkipOnNilListMeta verifies that a nil QueryMeta (e.g. list
+// error) never triggers a skip.
+func TestDiffer_NoSkipOnNilListMeta(t *testing.T) {
+	mock := defaultMock()
+	infoCalls := 0
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		infoCalls++
+		return &nomadapi.Job{ID: strPtr(jobID)}, nil, nil
+	}
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return nil, nil, nil // nil meta, no error
+	}
+	d := newTestDiffer(mock)
+
+	for i := 0; i < 3; i++ {
+		if err := d.Check(map[string]string{"a.hcl": `job "test-job" {}`}, "abc123"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if infoCalls != 3 {
+		t.Errorf("expected 3 Info calls with nil meta (no skip), got %d", infoCalls)
+	}
+}
+
 // TestDiffer_DeadJobInNomad_NoHCL_IncludeDeadJobs verifies that with
 // IncludeDeadJobs=true a dead Nomad job without HCL IS reported as missing_from_hcl.
 func TestDiffer_DeadJobInNomad_NoHCL_IncludeDeadJobs(t *testing.T) {


### PR DESCRIPTION
The Nomad List() response includes a QueryMeta.LastIndex (the cluster-wide
Raft index). By storing this after each full check and comparing it on the
next call, we can skip all per-job Info()/Plan() work when neither Nomad
state nor the git commit has changed since the last run.

The List() call is moved to the top of Check() so the index is available
before any per-job work, and the already-fetched job list is reused for
the orphan (missing-from-HCL) scan at the bottom.

A new nomad_botherer_diff_checks_skipped_total counter tracks how often
the optimisation fires. The existing nomad_botherer_diff_checks_total
counter now reflects only checks that actually ran.

https://claude.ai/code/session_01P7EzhsarXHX5zW48qBioxy