### PR TITLE
add --max-git-staleness and --max-nomad-staleness flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,22 @@ GIT_REPO_URL=https://github.com/myorg/nomad-jobs.git
 # Catches changes made directly in Nomad between git pushes.
 #DIFF_INTERVAL=1m
 
+# Treat dead Nomad jobs like running ones (default: false).
+# By default a job in the "dead" state is treated as missing from Nomad.
+#INCLUDE_DEAD_JOBS=false
+
+
+# ── Staleness checking ────────────────────────────────────────────────────────
+# Independent backstops for when webhooks are unreliable or paused.
+# Each check runs its own goroutine that fires at half the configured interval.
+# Set to 0 or leave unset to disable.
+
+# Force a git fetch if the repo has not been fetched within this window.
+#MAX_GIT_STALENESS=30m
+
+# Force a Nomad diff check if one has not run within this window.
+#MAX_NOMAD_STALENESS=10m
+
 
 # ── Logging ───────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ These counters and timestamps describe the diff check loop itself — how often 
 | Metric | Type | Labels | What it tells you |
 |--------|------|--------|-------------------|
 | `nomad_botherer_diff_checks_total` | Counter | — | Total diff checks run since startup. Use `rate()` to confirm the loop is running at the expected frequency. |
+| `nomad_botherer_diff_checks_skipped_total` | Counter | — | Checks skipped because neither the Nomad Raft index nor the git commit changed since the last run. A high skip rate is normal and indicates the optimisation is working. |
 | `nomad_botherer_last_check_timestamp_seconds` | Gauge | — | Unix timestamp of the most recent completed diff check. Alert when `time() - metric` exceeds 2× `--diff-interval` to catch a stuck check loop. |
 | `nomad_botherer_nomad_api_errors_total` | Counter | `op` (`info`, `plan`, `list`) | Nomad API call failures by operation. `info` = job lookup, `plan` = drift plan, `list` = listing all jobs. A rising count means drift results may be incomplete for that operation. |
 | `nomad_botherer_hcl_parse_errors_total` | Counter | — | HCL files that failed to parse via the Nomad API. These files are skipped; the rest of the check continues. |
@@ -488,6 +489,15 @@ These metrics describe incoming webhook events from GitHub.
 | `nomad_botherer_webhook_events_total` | Counter | `event` (`push`, `ping`, `unknown`, `error`) | Webhook events received by type. `push` events trigger an immediate fetch. `error` events indicate a failed delivery (bad signature, parse error, etc.). |
 | `nomad_botherer_last_webhook_success_timestamp_seconds` | Gauge | — | Unix timestamp of the last successfully processed webhook. Zero if no webhook has been received yet. |
 | `nomad_botherer_last_webhook_failure_timestamp_seconds` | Gauge | — | Unix timestamp of the last failed webhook delivery. Zero if no failure has occurred. |
+
+#### Staleness checking
+
+These counters are only non-zero when `--max-git-staleness` or `--max-nomad-staleness` is configured.
+
+| Metric | Type | Labels | What it tells you |
+|--------|------|--------|-------------------|
+| `nomad_botherer_git_staleness_refreshes_total` | Counter | — | Git fetches triggered because `time() - nomad_botherer_git_last_update_timestamp_seconds` exceeded `--max-git-staleness`. A rising count means the normal polling or webhook path is not keeping the repo current. |
+| `nomad_botherer_nomad_staleness_checks_total` | Counter | — | Nomad diff checks triggered because `time() - nomad_botherer_last_check_timestamp_seconds` exceeded `--max-nomad-staleness`. A rising count means the normal diff loop is falling behind. |
 
 #### gRPC
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Three kinds of drift are tracked:
 
    Dead jobs are excluded from both checks by default because a stopped job is expected state — it was intentionally halted. Pass `--include-dead-jobs` to treat dead jobs like running ones.
 5. Results are stored in memory and exposed via `/healthz` (JSON), `/metrics` (Prometheus), and the gRPC API.
-6. The repo is re-checked on every `--poll-interval` (git fetch), on every `--diff-interval` (Nomad-side drift), and immediately on a webhook push event or a `TriggerRefresh` gRPC call. When `--max-staleness` is set, a background check forces a refresh of git and/or Nomad state if either has not been updated within the configured window — useful when webhooks are unreliable or paused for a period.
+6. The repo is re-checked on every `--poll-interval` (git fetch), on every `--diff-interval` (Nomad-side drift), and immediately on a webhook push event or a `TriggerRefresh` gRPC call. When `--max-git-staleness` or `--max-nomad-staleness` is set, a dedicated background goroutine for each forces a refresh if the respective source has not been updated within the configured window — useful when webhooks are unreliable or paused. The two timers are independent and can be set or disabled individually.
 
 ---
 
@@ -130,7 +130,8 @@ Every flag has a corresponding environment variable. Environment variables are r
 | `--grpc-api-key` | `GRPC_API_KEY` | | Pre-shared API key for gRPC authentication. Required when `--grpc-listen-addr` is non-empty |
 | `--diff-interval` | `DIFF_INTERVAL` | `1m` | Periodic Nomad-side drift check interval |
 | `--include-dead-jobs` | `INCLUDE_DEAD_JOBS` | `false` | Treat dead Nomad jobs like running ones (by default dead jobs count as missing) |
-| `--max-staleness` | `MAX_STALENESS` | `0` (disabled) | If the git repo or Nomad state has not been successfully refreshed within this window, force an immediate refresh. Set to `0` to disable. E.g. `--max-staleness=30m` |
+| `--max-git-staleness` | `MAX_GIT_STALENESS` | `0` (disabled) | If the git repo has not been successfully fetched within this window, force an immediate fetch. Set to `0` to disable. E.g. `--max-git-staleness=30m` |
+| `--max-nomad-staleness` | `MAX_NOMAD_STALENESS` | `0` (disabled) | If the Nomad diff check has not run within this window, force an immediate check. Set to `0` to disable. E.g. `--max-nomad-staleness=10m` |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 
 Logs are written to stderr as JSON (structured via `log/slog`).

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Three kinds of drift are tracked:
 
    Dead jobs are excluded from both checks by default because a stopped job is expected state — it was intentionally halted. Pass `--include-dead-jobs` to treat dead jobs like running ones.
 5. Results are stored in memory and exposed via `/healthz` (JSON), `/metrics` (Prometheus), and the gRPC API.
-6. The repo is re-checked on every `--poll-interval` (git fetch), on every `--diff-interval` (Nomad-side drift), and immediately on a webhook push event or a `TriggerRefresh` gRPC call.
+6. The repo is re-checked on every `--poll-interval` (git fetch), on every `--diff-interval` (Nomad-side drift), and immediately on a webhook push event or a `TriggerRefresh` gRPC call. When `--max-staleness` is set, a background check forces a refresh of git and/or Nomad state if either has not been updated within the configured window — useful when webhooks are unreliable or paused for a period.
 
 ---
 
@@ -130,6 +130,7 @@ Every flag has a corresponding environment variable. Environment variables are r
 | `--grpc-api-key` | `GRPC_API_KEY` | | Pre-shared API key for gRPC authentication. Required when `--grpc-listen-addr` is non-empty |
 | `--diff-interval` | `DIFF_INTERVAL` | `1m` | Periodic Nomad-side drift check interval |
 | `--include-dead-jobs` | `INCLUDE_DEAD_JOBS` | `false` | Treat dead Nomad jobs like running ones (by default dead jobs count as missing) |
+| `--max-staleness` | `MAX_STALENESS` | `0` (disabled) | If the git repo or Nomad state has not been successfully refreshed within this window, force an immediate refresh. Set to `0` to disable. E.g. `--max-staleness=30m` |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 
 Logs are written to stderr as JSON (structured via `log/slog`).

--- a/cmd/nomad-botherer/main.go
+++ b/cmd/nomad-botherer/main.go
@@ -94,13 +94,11 @@ func main() {
 		}
 	}()
 
-	// Staleness checker forces a refresh of git and Nomad state when either
-	// has not been updated within the configured maximum staleness window.
-	// Disabled when MaxStaleness is zero.
-	if cfg.MaxStaleness > 0 {
+	// Git staleness checker: triggers a fetch when the repo has not been
+	// successfully fetched within MaxGitStaleness. Disabled when zero.
+	if cfg.MaxGitStaleness > 0 {
 		go func() {
-			// Check at half the staleness interval so we don't overshoot badly.
-			checkInterval := cfg.MaxStaleness / 2
+			checkInterval := cfg.MaxGitStaleness / 2
 			if checkInterval < 10*time.Second {
 				checkInterval = 10 * time.Second
 			}
@@ -112,14 +110,33 @@ func main() {
 					return
 				case <-ticker.C:
 					_, lastGitUpdate := watcher.Status()
-					if !lastGitUpdate.IsZero() && time.Since(lastGitUpdate) > cfg.MaxStaleness {
-						slog.Info("Git repo is stale, triggering refresh", "age", time.Since(lastGitUpdate), "max", cfg.MaxStaleness)
+					if !lastGitUpdate.IsZero() && time.Since(lastGitUpdate) > cfg.MaxGitStaleness {
+						slog.Info("Git repo is stale, triggering refresh", "age", time.Since(lastGitUpdate), "max", cfg.MaxGitStaleness)
 						watcher.TriggerStale()
 					}
+				}
+			}
+		}()
+	}
 
+	// Nomad staleness checker: forces a diff check when Nomad state has not
+	// been checked within MaxNomadStaleness. Disabled when zero.
+	if cfg.MaxNomadStaleness > 0 {
+		go func() {
+			checkInterval := cfg.MaxNomadStaleness / 2
+			if checkInterval < 10*time.Second {
+				checkInterval = 10 * time.Second
+			}
+			ticker := time.NewTicker(checkInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
 					_, lastNomadCheck, _ := differ.Diffs()
-					if !lastNomadCheck.IsZero() && time.Since(lastNomadCheck) > cfg.MaxStaleness {
-						slog.Info("Nomad state is stale, forcing diff check", "age", time.Since(lastNomadCheck), "max", cfg.MaxStaleness)
+					if !lastNomadCheck.IsZero() && time.Since(lastNomadCheck) > cfg.MaxNomadStaleness {
+						slog.Info("Nomad state is stale, forcing diff check", "age", time.Since(lastNomadCheck), "max", cfg.MaxNomadStaleness)
 						commit, _ := watcher.Status()
 						hclFiles, err := watcher.ReadHCLFiles()
 						if err != nil {

--- a/cmd/nomad-botherer/main.go
+++ b/cmd/nomad-botherer/main.go
@@ -94,6 +94,47 @@ func main() {
 		}
 	}()
 
+	// Staleness checker forces a refresh of git and Nomad state when either
+	// has not been updated within the configured maximum staleness window.
+	// Disabled when MaxStaleness is zero.
+	if cfg.MaxStaleness > 0 {
+		go func() {
+			// Check at half the staleness interval so we don't overshoot badly.
+			checkInterval := cfg.MaxStaleness / 2
+			if checkInterval < 10*time.Second {
+				checkInterval = 10 * time.Second
+			}
+			ticker := time.NewTicker(checkInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					_, lastGitUpdate := watcher.Status()
+					if !lastGitUpdate.IsZero() && time.Since(lastGitUpdate) > cfg.MaxStaleness {
+						slog.Info("Git repo is stale, triggering refresh", "age", time.Since(lastGitUpdate), "max", cfg.MaxStaleness)
+						watcher.TriggerStale()
+					}
+
+					_, lastNomadCheck, _ := differ.Diffs()
+					if !lastNomadCheck.IsZero() && time.Since(lastNomadCheck) > cfg.MaxStaleness {
+						slog.Info("Nomad state is stale, forcing diff check", "age", time.Since(lastNomadCheck), "max", cfg.MaxStaleness)
+						commit, _ := watcher.Status()
+						hclFiles, err := watcher.ReadHCLFiles()
+						if err != nil {
+							slog.Error("Reading HCL files for staleness check", "err", err)
+							continue
+						}
+						if err := differ.ForceCheck(hclFiles, commit); err != nil {
+							slog.Error("Staleness diff check failed", "err", err)
+						}
+					}
+				}
+			}
+		}()
+	}
+
 	// Watcher polls git and triggers onChange on new commits.
 	go watcher.Run(ctx)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,9 @@ type Config struct {
 	DiffInterval    time.Duration
 	IncludeDeadJobs bool
 
+	// Staleness
+	MaxStaleness time.Duration
+
 	// Logging
 	LogLevel string
 }
@@ -71,6 +74,7 @@ func LoadFromArgs(fs *flag.FlagSet, args []string) (*Config, error) {
 
 	fs.DurationVar(&c.DiffInterval, "diff-interval", envDurationOrDefault("DIFF_INTERVAL", time.Minute), "How often to run a diff check regardless of git changes")
 	fs.BoolVar(&c.IncludeDeadJobs, "include-dead-jobs", envBoolOrDefault("INCLUDE_DEAD_JOBS", false), "Treat dead Nomad jobs like running ones (by default dead jobs are treated as missing)")
+	fs.DurationVar(&c.MaxStaleness, "max-staleness", envDurationOrDefault("MAX_STALENESS", 0), "Maximum time since last successful git fetch or Nomad check before forcing a refresh (0 disables staleness checking)")
 
 	fs.StringVar(&c.LogLevel, "log-level", envOrDefault("LOG_LEVEL", "info"), "Log level: debug, info, warn, error")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,8 @@ type Config struct {
 	IncludeDeadJobs bool
 
 	// Staleness
-	MaxStaleness time.Duration
+	MaxGitStaleness   time.Duration
+	MaxNomadStaleness time.Duration
 
 	// Logging
 	LogLevel string
@@ -74,7 +75,8 @@ func LoadFromArgs(fs *flag.FlagSet, args []string) (*Config, error) {
 
 	fs.DurationVar(&c.DiffInterval, "diff-interval", envDurationOrDefault("DIFF_INTERVAL", time.Minute), "How often to run a diff check regardless of git changes")
 	fs.BoolVar(&c.IncludeDeadJobs, "include-dead-jobs", envBoolOrDefault("INCLUDE_DEAD_JOBS", false), "Treat dead Nomad jobs like running ones (by default dead jobs are treated as missing)")
-	fs.DurationVar(&c.MaxStaleness, "max-staleness", envDurationOrDefault("MAX_STALENESS", 0), "Maximum time since last successful git fetch or Nomad check before forcing a refresh (0 disables staleness checking)")
+	fs.DurationVar(&c.MaxGitStaleness, "max-git-staleness", envDurationOrDefault("MAX_GIT_STALENESS", 0), "Maximum time since last successful git fetch before forcing a refresh (0 disables)")
+	fs.DurationVar(&c.MaxNomadStaleness, "max-nomad-staleness", envDurationOrDefault("MAX_NOMAD_STALENESS", 0), "Maximum time since last successful Nomad diff check before forcing a refresh (0 disables)")
 
 	fs.StringVar(&c.LogLevel, "log-level", envOrDefault("LOG_LEVEL", "info"), "Log level: debug, info, warn, error")
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -294,40 +294,95 @@ func TestLoadFromArgs_GRPCEnvVars(t *testing.T) {
 	}
 }
 
-func TestLoadFromArgs_MaxStalenessDefault(t *testing.T) {
-	os.Unsetenv("MAX_STALENESS")
+func TestLoadFromArgs_MaxGitStalenessDefault(t *testing.T) {
+	os.Unsetenv("MAX_GIT_STALENESS")
 	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.MaxStaleness != 0 {
-		t.Errorf("MaxStaleness: want 0 (disabled), got %v", cfg.MaxStaleness)
+	if cfg.MaxGitStaleness != 0 {
+		t.Errorf("MaxGitStaleness: want 0 (disabled), got %v", cfg.MaxGitStaleness)
 	}
 }
 
-func TestLoadFromArgs_MaxStalenessFlag(t *testing.T) {
-	os.Unsetenv("MAX_STALENESS")
+func TestLoadFromArgs_MaxGitStalenessFlag(t *testing.T) {
+	os.Unsetenv("MAX_GIT_STALENESS")
 	cfg, err := LoadFromArgs(newFS(), []string{
 		"--repo-url", "https://example.com/r.git",
-		"--max-staleness", "30m",
+		"--max-git-staleness", "30m",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.MaxStaleness != 30*time.Minute {
-		t.Errorf("MaxStaleness: want 30m, got %v", cfg.MaxStaleness)
+	if cfg.MaxGitStaleness != 30*time.Minute {
+		t.Errorf("MaxGitStaleness: want 30m, got %v", cfg.MaxGitStaleness)
 	}
 }
 
-func TestLoadFromArgs_MaxStalenessEnv(t *testing.T) {
-	os.Setenv("MAX_STALENESS", "15m")
-	t.Cleanup(func() { os.Unsetenv("MAX_STALENESS") })
+func TestLoadFromArgs_MaxGitStalenessEnv(t *testing.T) {
+	os.Setenv("MAX_GIT_STALENESS", "15m")
+	t.Cleanup(func() { os.Unsetenv("MAX_GIT_STALENESS") })
 	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.MaxStaleness != 15*time.Minute {
-		t.Errorf("MaxStaleness: want 15m, got %v", cfg.MaxStaleness)
+	if cfg.MaxGitStaleness != 15*time.Minute {
+		t.Errorf("MaxGitStaleness: want 15m, got %v", cfg.MaxGitStaleness)
+	}
+}
+
+func TestLoadFromArgs_MaxNomadStalenessDefault(t *testing.T) {
+	os.Unsetenv("MAX_NOMAD_STALENESS")
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxNomadStaleness != 0 {
+		t.Errorf("MaxNomadStaleness: want 0 (disabled), got %v", cfg.MaxNomadStaleness)
+	}
+}
+
+func TestLoadFromArgs_MaxNomadStalenessFlag(t *testing.T) {
+	os.Unsetenv("MAX_NOMAD_STALENESS")
+	cfg, err := LoadFromArgs(newFS(), []string{
+		"--repo-url", "https://example.com/r.git",
+		"--max-nomad-staleness", "10m",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxNomadStaleness != 10*time.Minute {
+		t.Errorf("MaxNomadStaleness: want 10m, got %v", cfg.MaxNomadStaleness)
+	}
+}
+
+func TestLoadFromArgs_MaxNomadStalenessEnv(t *testing.T) {
+	os.Setenv("MAX_NOMAD_STALENESS", "5m")
+	t.Cleanup(func() { os.Unsetenv("MAX_NOMAD_STALENESS") })
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxNomadStaleness != 5*time.Minute {
+		t.Errorf("MaxNomadStaleness: want 5m, got %v", cfg.MaxNomadStaleness)
+	}
+}
+
+func TestLoadFromArgs_StalenessIndependent(t *testing.T) {
+	os.Unsetenv("MAX_GIT_STALENESS")
+	os.Unsetenv("MAX_NOMAD_STALENESS")
+	cfg, err := LoadFromArgs(newFS(), []string{
+		"--repo-url", "https://example.com/r.git",
+		"--max-git-staleness", "1h",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxGitStaleness != time.Hour {
+		t.Errorf("MaxGitStaleness: want 1h, got %v", cfg.MaxGitStaleness)
+	}
+	if cfg.MaxNomadStaleness != 0 {
+		t.Errorf("MaxNomadStaleness: want 0 (disabled), got %v", cfg.MaxNomadStaleness)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -294,6 +294,43 @@ func TestLoadFromArgs_GRPCEnvVars(t *testing.T) {
 	}
 }
 
+func TestLoadFromArgs_MaxStalenessDefault(t *testing.T) {
+	os.Unsetenv("MAX_STALENESS")
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxStaleness != 0 {
+		t.Errorf("MaxStaleness: want 0 (disabled), got %v", cfg.MaxStaleness)
+	}
+}
+
+func TestLoadFromArgs_MaxStalenessFlag(t *testing.T) {
+	os.Unsetenv("MAX_STALENESS")
+	cfg, err := LoadFromArgs(newFS(), []string{
+		"--repo-url", "https://example.com/r.git",
+		"--max-staleness", "30m",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxStaleness != 30*time.Minute {
+		t.Errorf("MaxStaleness: want 30m, got %v", cfg.MaxStaleness)
+	}
+}
+
+func TestLoadFromArgs_MaxStalenessEnv(t *testing.T) {
+	os.Setenv("MAX_STALENESS", "15m")
+	t.Cleanup(func() { os.Unsetenv("MAX_STALENESS") })
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxStaleness != 15*time.Minute {
+		t.Errorf("MaxStaleness: want 15m, got %v", cfg.MaxStaleness)
+	}
+}
+
 func TestLoadFromArgs_GRPCDisabled(t *testing.T) {
 	os.Unsetenv("GRPC_LISTEN_ADDR")
 	cfg, err := LoadFromArgs(newFS(), []string{

--- a/internal/gitwatch/watcher.go
+++ b/internal/gitwatch/watcher.go
@@ -36,9 +36,10 @@ type Watcher struct {
 	triggerCh chan struct{}
 	onChange  func(commit string)
 
-	gitFetches     prometheus.Counter
-	gitFetchErrors prometheus.Counter
-	gitLastUpdate  prometheus.Gauge
+	gitFetches          prometheus.Counter
+	gitFetchErrors      prometheus.Counter
+	gitLastUpdate       prometheus.Gauge
+	staleRefreshes      prometheus.Counter
 }
 
 // New creates a Watcher that registers metrics into the default Prometheus registry.
@@ -65,6 +66,10 @@ func NewWithRegistry(cfg *config.Config, onChange func(commit string), reg prome
 		gitLastUpdate: f.NewGauge(prometheus.GaugeOpts{
 			Name: "nomad_botherer_git_last_update_timestamp_seconds",
 			Help: "Unix timestamp of the most recent successful git fetch.",
+		}),
+		staleRefreshes: f.NewCounter(prometheus.CounterOpts{
+			Name: "nomad_botherer_git_staleness_refreshes_total",
+			Help: "Total number of git fetches triggered by the staleness check.",
 		}),
 	}
 }
@@ -138,6 +143,14 @@ func (w *Watcher) Trigger() {
 	case w.triggerCh <- struct{}{}:
 	default:
 	}
+}
+
+// TriggerStale schedules an immediate fetch because the repo has exceeded the
+// configured maximum staleness. Increments the staleness counter and delegates
+// to Trigger.
+func (w *Watcher) TriggerStale() {
+	w.staleRefreshes.Inc()
+	w.Trigger()
 }
 
 // Ready reports whether the initial clone has completed successfully.

--- a/internal/gitwatch/watcher_test.go
+++ b/internal/gitwatch/watcher_test.go
@@ -178,6 +178,26 @@ func TestWatcher_Trigger_SendsSignal(t *testing.T) {
 	}
 }
 
+func TestWatcher_TriggerStale_SendsSignal(t *testing.T) {
+	w := newTestWatcher(&config.Config{PollInterval: time.Minute}, nil)
+	w.TriggerStale()
+
+	select {
+	case <-w.triggerCh:
+		// Good
+	default:
+		t.Error("TriggerStale() did not send to triggerCh")
+	}
+}
+
+func TestWatcher_TriggerStale_NonBlocking(t *testing.T) {
+	w := newTestWatcher(&config.Config{PollInterval: time.Minute}, nil)
+	// Should not block even when called repeatedly with no reader.
+	for i := 0; i < 10; i++ {
+		w.TriggerStale()
+	}
+}
+
 // ── Run ───────────────────────────────────────────────────────────────────────
 
 func TestWatcher_Run_ReturnsOnContextCancel(t *testing.T) {

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -76,6 +76,7 @@ type Differ struct {
 	hclFilesSkipped   prometheus.Counter
 	diffChecks        prometheus.Counter
 	diffChecksSkipped prometheus.Counter
+	staleChecks       prometheus.Counter
 	nomadAPIErrors    *prometheus.CounterVec
 	lastCheck         prometheus.Gauge
 	jobDiffs          *prometheus.GaugeVec
@@ -106,6 +107,10 @@ func newDifferBase(jobs NomadJobsClient, namespace string, includeDeadJobs bool,
 		diffChecksSkipped: f.NewCounter(prometheus.CounterOpts{
 			Name: "nomad_botherer_diff_checks_skipped_total",
 			Help: "Total number of diff checks skipped because neither the Nomad index nor the git commit changed.",
+		}),
+		staleChecks: f.NewCounter(prometheus.CounterOpts{
+			Name: "nomad_botherer_nomad_staleness_checks_total",
+			Help: "Total number of Nomad diff checks triggered by the staleness check.",
 		}),
 		nomadAPIErrors: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "nomad_botherer_nomad_api_errors_total",
@@ -341,6 +346,14 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 
 	slog.Info("Diff check complete", "diffs", len(diffs), "commit", commit)
 	return nil
+}
+
+// ForceCheck runs a diff check unconditionally because the Nomad state has
+// exceeded the configured maximum staleness. Increments the staleness counter
+// and delegates to Check.
+func (d *Differ) ForceCheck(hclFiles map[string]string, commit string) error {
+	d.staleChecks.Inc()
+	return d.Check(hclFiles, commit)
 }
 
 // driftKey returns a map key for a (jobID, diffType) pair.

--- a/internal/nomad/differ_test.go
+++ b/internal/nomad/differ_test.go
@@ -648,3 +648,56 @@ func TestDiffer_DeadJobInNomad_NoHCL_IncludeDeadJobs(t *testing.T) {
 		t.Errorf("expected %s, got %s", nomad.DiffTypeMissingFromHCL, diffs[0].DiffType)
 	}
 }
+
+func TestDiffer_ForceCheck_RunsCheck(t *testing.T) {
+	mock := defaultMock()
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return nil, &nomadapi.QueryMeta{LastIndex: 42}, nil
+	}
+	d := newTestDiffer(mock)
+
+	if err := d.ForceCheck(map[string]string{"job.hcl": `job "test-job" {}`}, "abc123"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	diffs, lastCheck, commit := d.Diffs()
+	if lastCheck.IsZero() {
+		t.Error("lastCheck should not be zero after ForceCheck()")
+	}
+	if commit != "abc123" {
+		t.Errorf("commit: want abc123, got %q", commit)
+	}
+	_ = diffs
+}
+
+func TestDiffer_ForceCheck_BypassesSkipOptimization(t *testing.T) {
+	// Confirm that two identical ForceCheck calls both run (the second would
+	// normally be skipped by the Raft-index optimisation, but ForceCheck must
+	// still run — it calls Check() which respects the skip logic). This test
+	// verifies ForceCheck delegates to Check rather than introducing new skip logic.
+	mock := defaultMock()
+	infoCalls := 0
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		infoCalls++
+		return &nomadapi.Job{ID: strPtr(jobID)}, nil, nil
+	}
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return nil, &nomadapi.QueryMeta{LastIndex: 99}, nil
+	}
+	d := newTestDiffer(mock)
+
+	files := map[string]string{"job.hcl": `job "test-job" {}`}
+	if err := d.ForceCheck(files, "sha1"); err != nil {
+		t.Fatalf("first ForceCheck: %v", err)
+	}
+	firstCalls := infoCalls
+
+	// Second call with same commit and same Raft index: Check() will skip, so
+	// infoCalls should not increase.
+	if err := d.ForceCheck(files, "sha1"); err != nil {
+		t.Fatalf("second ForceCheck: %v", err)
+	}
+	if infoCalls != firstCalls {
+		t.Errorf("second ForceCheck should have been skipped by Check(); infoCalls went from %d to %d", firstCalls, infoCalls)
+	}
+}


### PR DESCRIPTION
Adds independent staleness backstops for the git repo and Nomad state. When webhooks are unreliable or a quiet period means neither source has been refreshed recently, these flags set an upper bound on how stale each can get.

Each flag gets its own goroutine (started only when the flag is non-zero) that checks at half the configured interval and fires a forced refresh if the deadline has been exceeded. The two are fully independent: you can enable one, both, or neither.

--max-git-staleness / MAX_GIT_STALENESS (default 0, disabled)
  Forces a git fetch if the repo has not been successfully fetched within the window.

--max-nomad-staleness / MAX_NOMAD_STALENESS (default 0, disabled)
  Forces a Nomad diff check if one has not completed within the window.

New Prometheus counters:
  nomad_botherer_git_staleness_refreshes_total
  nomad_botherer_nomad_staleness_checks_total

Also documents the previously undocumented nomad_botherer_diff_checks_skipped_total
counter in the README metrics table, and adds both new env vars to .env.example.