### PR TITLE
update alpine to 3.21 and fix docs for release prep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # syntax=docker/dockerfile:1
 # Multi-platform build: linux/amd64 and linux/arm64 (Raspberry Pi 4+).
-# Build with:
-#   docker buildx build --platform linux/amd64,linux/arm64 \
-#     --build-arg VERSION=$(git describe --tags --always --dirty) \
-#     -t ghcr.io/gerrowadat/nomad-botherer:VERSION .
+# Build via the Makefile: make docker (local) or make docker-push (push to registry).
 
 FROM --platform=${BUILDPLATFORM} golang:1.25-alpine AS builder
 
@@ -25,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     ./cmd/nomad-botherer
 
 # ── runtime image ──────────────────────────────────────────────────────────────
-FROM alpine:3.19
+FROM alpine:3.21
 
 RUN apk add --no-cache ca-certificates tzdata && \
     addgroup -S nomad-botherer && \

--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ make build-server # compile just the server
 make build-ctl    # compile just nbctl
 make install      # go install both binaries to $GOPATH/bin
 make test         # go test -race ./...
-make test-cover   # run tests and open an HTML coverage report
+make test-cover   # run tests and generate coverage.html
 make lint         # go vet ./...
 make clean        # remove build artefacts
 ```


### PR DESCRIPTION
- Bump runtime image from alpine:3.19 to alpine:3.21 (3.19 is EOL November 2025)
- Replace the manual docker buildx example in the Dockerfile header comment with a
  pointer to the Makefile, which is what users should actually run
- Fix make test-cover description in README: the target generates coverage.html, it
  does not open a browser

https://claude.ai/code/session_01FRdjAWkF2XW4XVKymT3TLQ