### PR TITLE
Improve test coverage across all packages

### DIFF
--- a/internal/gitwatch/watcher_test.go
+++ b/internal/gitwatch/watcher_test.go
@@ -391,3 +391,45 @@ func TestWatcher_ReadHCLFiles_EmptyDir(t *testing.T) {
 		t.Errorf("expected 0 files for empty dir, got %d", len(files))
 	}
 }
+
+// ── Ready ─────────────────────────────────────────────────────────────────────
+
+func TestWatcher_Ready_BeforeClone(t *testing.T) {
+	w := &Watcher{cfg: &config.Config{}}
+	if w.Ready() {
+		t.Error("Ready() should return false before repo is cloned")
+	}
+}
+
+func TestWatcher_Ready_AfterClone(t *testing.T) {
+	repo := makeTestRepo(t, map[string]string{"job.hcl": `job "x" {}`})
+	w := &Watcher{cfg: &config.Config{}, repo: repo}
+	if !w.Ready() {
+		t.Error("Ready() should return true once repo is set")
+	}
+}
+
+// ── TriggerStale metric ───────────────────────────────────────────────────────
+
+func TestWatcher_TriggerStale_IncrementsMetric(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	w := NewWithRegistry(&config.Config{PollInterval: time.Minute}, nil, reg)
+
+	w.TriggerStale()
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var count float64
+	for _, mf := range mfs {
+		if mf.GetName() == "nomad_botherer_git_staleness_refreshes_total" {
+			for _, m := range mf.GetMetric() {
+				count += m.GetCounter().GetValue()
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected stale_refreshes_total=1 after TriggerStale, got %v", count)
+	}
+}

--- a/internal/grpcserver/server.go
+++ b/internal/grpcserver/server.go
@@ -116,7 +116,7 @@ func (s *Server) Serve(ctx context.Context, lis net.Listener) error {
 	}()
 
 	slog.Info("gRPC server listening", "addr", lis.Addr())
-	if err := srv.Serve(lis); err != nil {
+	if err := srv.Serve(lis); err != nil && err != grpc.ErrServerStopped {
 		return fmt.Errorf("grpc serve: %w", err)
 	}
 	return nil

--- a/internal/grpcserver/server_test.go
+++ b/internal/grpcserver/server_test.go
@@ -392,6 +392,57 @@ func TestMetrics_AuthErrorCounted(t *testing.T) {
 	}
 }
 
+// TestListen_BindsSuccessfully verifies that Listen() returns a usable
+// net.Listener bound to a free port when given address ":0".
+func TestListen_BindsSuccessfully(t *testing.T) {
+	diffSrc := &mockDiffSource{}
+	gitSrc := &mockGitSource{}
+	reg := prometheus.NewRegistry()
+	srv := grpcserver.NewWithRegistry(testAPIKey, diffSrc, gitSrc, testBuildInfo, reg)
+
+	lis, err := srv.Listen("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen returned error: %v", err)
+	}
+	defer lis.Close()
+
+	if lis.Addr() == nil {
+		t.Error("expected non-nil listener address")
+	}
+}
+
+// TestServe_ExitsOnContextCancel verifies that Serve() stops accepting new
+// connections and returns nil once its context is cancelled.
+func TestServe_ExitsOnContextCancel(t *testing.T) {
+	diffSrc := &mockDiffSource{}
+	gitSrc := &mockGitSource{}
+	reg := prometheus.NewRegistry()
+	srv := grpcserver.NewWithRegistry(testAPIKey, diffSrc, gitSrc, testBuildInfo, reg)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Serve(ctx, lis)
+	}()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Serve returned unexpected error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("Serve did not return after context cancellation")
+	}
+}
+
 func TestMetrics_SuccessfulRequestCounted(t *testing.T) {
 	now := time.Now()
 	diffSrc := &mockDiffSource{lastCheck: now, lastCommit: "abc"}

--- a/internal/nomad/differ_test.go
+++ b/internal/nomad/differ_test.go
@@ -670,6 +670,107 @@ func TestDiffer_ForceCheck_RunsCheck(t *testing.T) {
 	_ = diffs
 }
 
+// TestDiffer_Ready_BeforeCheck verifies that Ready() returns false before any
+// Check has completed.
+func TestDiffer_Ready_BeforeCheck(t *testing.T) {
+	d := newTestDiffer(defaultMock())
+	if d.Ready() {
+		t.Error("Ready() should return false before any Check has completed")
+	}
+}
+
+// TestDiffer_Ready_AfterCheck verifies that Ready() returns true once the first
+// Check has run.
+func TestDiffer_Ready_AfterCheck(t *testing.T) {
+	d := newTestDiffer(defaultMock())
+	if err := d.Check(map[string]string{"job.hcl": `job "test-job" {}`}, "abc"); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !d.Ready() {
+		t.Error("Ready() should return true after Check has completed")
+	}
+}
+
+// TestDiffer_Diffs_SnapshotIsolation verifies that mutating the slice returned
+// by Diffs() does not affect the Differ's internal state.
+func TestDiffer_Diffs_SnapshotIsolation(t *testing.T) {
+	mock := defaultMock()
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return nil, nil, fmt.Errorf("404: not found")
+	}
+	d := newTestDiffer(mock)
+
+	if err := d.Check(map[string]string{"job.hcl": `job "test-job" {}`}, "abc"); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+
+	diffs1, _, _ := d.Diffs()
+	if len(diffs1) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs1))
+	}
+
+	// Mutate the returned slice — the Differ's internal state must be unaffected.
+	diffs1[0] = nomad.JobDiff{JobID: "mutated"}
+
+	diffs2, _, _ := d.Diffs()
+	if len(diffs2) != 1 {
+		t.Fatalf("expected 1 diff after mutation, got %d", len(diffs2))
+	}
+	if diffs2[0].JobID != "test-job" {
+		t.Errorf("Diffs() snapshot was affected by mutation; got job ID %q, want %q", diffs2[0].JobID, "test-job")
+	}
+}
+
+// TestDiffer_EmptyJobID_Skipped verifies that a job returned by ParseHCL with
+// an empty (non-nil) job ID is silently skipped.
+func TestDiffer_EmptyJobID_Skipped(t *testing.T) {
+	mock := defaultMock()
+	emptyID := ""
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		return &nomadapi.Job{ID: &emptyID}, nil
+	}
+	d := newTestDiffer(mock)
+
+	if err := d.Check(map[string]string{`job.hcl`: `job "x" {}`}, "abc"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 0 {
+		t.Errorf("empty string job ID should be skipped, got %d diffs", len(diffs))
+	}
+}
+
+// TestDiffer_ForceCheck_IncrementsStaleCounter verifies that ForceCheck
+// increments the staleness check counter metric.
+func TestDiffer_ForceCheck_IncrementsStaleCounter(t *testing.T) {
+	mock := defaultMock()
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return nil, &nomadapi.QueryMeta{LastIndex: 42}, nil
+	}
+	reg := prometheus.NewRegistry()
+	d := newTestDifferWithRegistry(mock, reg)
+
+	if err := d.ForceCheck(map[string]string{"job.hcl": `job "test-job" {}`}, "abc"); err != nil {
+		t.Fatalf("ForceCheck: %v", err)
+	}
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var staleChecks float64
+	for _, mf := range mfs {
+		if mf.GetName() == "nomad_botherer_nomad_staleness_checks_total" {
+			for _, m := range mf.GetMetric() {
+				staleChecks += m.GetCounter().GetValue()
+			}
+		}
+	}
+	if staleChecks != 1 {
+		t.Errorf("expected nomad_staleness_checks_total=1 after ForceCheck, got %v", staleChecks)
+	}
+}
+
 func TestDiffer_ForceCheck_BypassesSkipOptimization(t *testing.T) {
 	// Confirm that two identical ForceCheck calls both run (the second would
 	// normally be skipped by the Raft-index optimisation, but ForceCheck must

--- a/internal/server/render_internal_test.go
+++ b/internal/server/render_internal_test.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	nomadapi "github.com/hashicorp/nomad/api"
+
+	"github.com/gerrowadat/nomad-botherer/internal/nomad"
+)
+
+// TestRenderDiffsText_ZeroLastCheck verifies that a zero lastCheck time omits
+// the "Last check:" line from the output.
+func TestRenderDiffsText_ZeroLastCheck(t *testing.T) {
+	out := renderDiffsText(nil, time.Time{}, "")
+	if strings.Contains(out, "Last check:") {
+		t.Error("zero lastCheck should not produce a 'Last check:' line")
+	}
+	if !strings.Contains(out, "No differences") {
+		t.Error("expected 'No differences' message")
+	}
+}
+
+// TestRenderObjects verifies that ObjectDiff entries are rendered with braces
+// and their nested fields.
+func TestRenderObjects(t *testing.T) {
+	diffs := []nomad.JobDiff{
+		{
+			JobID:    "myapp",
+			HCLFile:  "myapp.hcl",
+			DiffType: nomad.DiffTypeModified,
+			PlanDiff: &nomadapi.JobDiff{
+				Type: "Edited",
+				ID:   "myapp",
+				Objects: []*nomadapi.ObjectDiff{
+					{
+						Type: "Edited",
+						Name: "Meta",
+						Fields: []*nomadapi.FieldDiff{
+							{Type: "Added", Name: "env", New: "production"},
+						},
+					},
+				},
+			},
+		},
+	}
+	out := renderDiffsText(diffs, time.Now(), "abc123")
+	if !strings.Contains(out, "Meta") {
+		t.Error("object name should appear in output")
+	}
+	if !strings.Contains(out, `+ env`) {
+		t.Error("object field should appear with '+' prefix")
+	}
+	if !strings.Contains(out, "{") || !strings.Contains(out, "}") {
+		t.Error("object diff should be wrapped in braces")
+	}
+}
+
+// TestRenderObjects_Nested verifies that ObjectDiff entries nested inside
+// other ObjectDiff entries are rendered recursively.
+func TestRenderObjects_Nested(t *testing.T) {
+	diffs := []nomad.JobDiff{
+		{
+			JobID:    "myapp",
+			HCLFile:  "myapp.hcl",
+			DiffType: nomad.DiffTypeModified,
+			PlanDiff: &nomadapi.JobDiff{
+				Type: "Edited",
+				ID:   "myapp",
+				Objects: []*nomadapi.ObjectDiff{
+					{
+						Type: "Edited",
+						Name: "Outer",
+						Objects: []*nomadapi.ObjectDiff{
+							{
+								Type: "Added",
+								Name: "Inner",
+								Fields: []*nomadapi.FieldDiff{
+									{Type: "Added", Name: "key", New: "val"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	out := renderDiffsText(diffs, time.Now(), "abc123")
+	if !strings.Contains(out, "Outer") {
+		t.Error("outer object name should appear in output")
+	}
+	if !strings.Contains(out, "Inner") {
+		t.Error("inner object name should appear in output")
+	}
+	if !strings.Contains(out, `+ key`) {
+		t.Error("inner object field should appear in output")
+	}
+}
+
+// TestDiffSymbol_AllTypes exercises every branch of diffSymbol.
+func TestDiffSymbol_AllTypes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Added", "+"},
+		{"Deleted", "-"},
+		{"Edited", "+/-"},
+		{"None", "?"},
+		{"", "?"},
+		{"unknown", "?"},
+	}
+	for _, tc := range cases {
+		if got := diffSymbol(tc.in); got != tc.want {
+			t.Errorf("diffSymbol(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestRenderFields_EditedType verifies that "Edited" fields render with the
+// '~' prefix and both old and new values.
+func TestRenderFields_EditedType(t *testing.T) {
+	diffs := []nomad.JobDiff{
+		{
+			JobID:    "myapp",
+			HCLFile:  "myapp.hcl",
+			DiffType: nomad.DiffTypeModified,
+			PlanDiff: &nomadapi.JobDiff{
+				Type: "Edited",
+				ID:   "myapp",
+				Fields: []*nomadapi.FieldDiff{
+					{Type: "Edited", Name: "count", Old: "1", New: "3"},
+				},
+			},
+		},
+	}
+	out := renderDiffsText(diffs, time.Now(), "abc123")
+	if !strings.Contains(out, `~ count: "1" => "3"`) {
+		t.Errorf("edited field should render with '~' and old/new values, got:\n%s", out)
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -665,3 +665,42 @@ func TestIndex_NotReady_Returns503(t *testing.T) {
 		t.Error("index page should show starting state when not ready")
 	}
 }
+
+// ── /metrics ──────────────────────────────────────────────────────────────────
+
+func TestMetrics_Endpoint_Returns200(t *testing.T) {
+	srv, _ := newTestServer(t, nil)
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from /metrics, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("expected text/plain content-type from /metrics, got %q", ct)
+	}
+}
+
+func TestMetrics_Endpoint_ContainsBuildInfo(t *testing.T) {
+	srv, _ := newTestServer(t, nil)
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "nomad_botherer_info") {
+		t.Error("expected nomad_botherer_info metric in /metrics output")
+	}
+}
+
+// ── Handler consistency ───────────────────────────────────────────────────────
+
+func TestHandler_ConsistentReturn(t *testing.T) {
+	srv, _ := newTestServer(t, nil)
+	h1 := srv.Handler()
+	h2 := srv.Handler()
+	if h1 != h2 {
+		t.Error("Handler() should return the same http.Handler on repeated calls")
+	}
+}


### PR DESCRIPTION
Add tests for previously uncovered behaviour:
- gitwatch: Watcher.Ready() before/after clone; TriggerStale metric increment
- nomad/differ: Differ.Ready() before/after check; Diffs() snapshot isolation
  (verifies returned slice is a copy); empty-string job ID skipped; ForceCheck
  increments the staleness counter metric
- server/render: new internal test file covering renderDiffsText with a zero
  lastCheck (no "Last check:" line), renderObjects with nested objects,
  diffSymbol for all type strings, and the "Edited" branch of renderFields
- server: /metrics endpoint returns 200 with text/plain content; Handler()
  returns the same http.Handler on repeated calls; nomad_botherer_info metric
  present in /metrics output
- grpcserver: Listen() binds successfully on a random port; Serve() exits
  cleanly when its context is cancelled

Also fix grpcserver.Serve() to treat grpc.ErrServerStopped as a clean
shutdown (analogous to how the HTTP server ignores http.ErrServerClosed),
which the new lifecycle test revealed was missing.

https://claude.ai/code/session_01YKG5GnEeo8oVf6a7tjsNhP