### PR TITLE
docs: add GitOps job update and change checkpointing proposals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,3 +32,114 @@ internal/server/        HTTP: /, /healthz, /diffs, /metrics, /webhook
 - Tests use injected interfaces (`NomadJobsClient`, `DiffSource`, etc.) — keep production code testable without a live Nomad cluster
 - Per-test Prometheus registries (`prometheus.NewRegistry()`) to avoid duplicate-registration panics
 - `/{$}` for exact root match (Go 1.22+ ServeMux)
+
+## Design intent
+
+### What nomad-botherer is and where it is going
+
+nomad-botherer is currently a **drift detector**: it watches a Git repo and a
+Nomad cluster and reports when they disagree. It does not apply changes.
+
+The intended next phase is **GitOps application**: when drift is detected,
+nomad-botherer applies the Git state to Nomad. The design proposals in
+`docs/proposals/` cover this in detail. `docs/prior-art.md` surveys the
+existing tooling (nomad-gitops-operator, nomad-ops, Levant, Waypoint) and
+explains what problems they have that nomad-botherer is trying to avoid.
+
+Before implementing the apply side, read both proposal docs. The decisions in
+them were made deliberately and the reasoning matters.
+
+### Core design principles for the apply side
+
+**Conservative by default.** Never register a job without running a plan first.
+Never register without a CAS token. The apply path is:
+`Jobs.Info()` (capture `JobModifyIndex`) → `Jobs.Plan()` (confirm diff) →
+`Jobs.Register(EnforceIndex=true, JobModifyIndex=<captured>)`. If Nomad rejects
+the write because the index changed, mark the update failed, trigger a fresh
+diff, and let the next cycle produce a new update with current state.
+
+**Opt-in scope via job meta.** Jobs must declare `meta { "gitops.managed" =
+"true" }` in their HCL to be managed by nomad-botherer. A job without this key
+is never diffed for application purposes, never registered, and never
+deregistered — even if it is running in Nomad without a corresponding HCL file.
+This is the "Operator Pattern in Nomad" (see scalad, Pondidum/nomad-operator).
+Do not change this default without a strong reason; it is what prevents
+nomad-botherer from touching manually-managed jobs on a shared cluster.
+
+**Separate the two uses of job meta.** The `gitops.managed` flag is set by
+humans in HCL and read by the tool — that is fine. Writing tool state (applied
+commit, timestamps, status) back into the live job's meta is a different thing
+and causes the meta-drift problem: the next `nomad job run` from plain HCL
+silently removes those keys. Store apply state in Nomad Variables instead
+(see `docs/proposals/change-checkpointing.md`). Do not write tool-generated
+keys into the live job's meta stanza.
+
+**No external database.** nomad-botherer should be schedulable on any node
+without volume claims. The checkpointing proposal recommends Nomad Variables
+(Raft-backed, CAS-protected, requires Nomad 1.4+) as the default, with a
+`CheckpointStore` interface so the backend is swappable. Do not introduce
+SQLite, PostgreSQL, Redis, or any other external store.
+
+**Decoupled detection and application.** The diff check loop and the apply loop
+are separate. A slow or failing apply must not delay the next diff check. The
+async queue model (Alternative B in the job updates proposal) is the right
+shape. Updates for the same job that arrive while a prior update is still pending
+should be marked `SUPERSEDED`; the most recent intended state wins.
+
+**Conservative deletion.** `missing_from_hcl` is an observation today. When
+deregister is implemented, it should require: (a) `gitops.managed = "true"` on
+the live job (confirming the operator previously registered it), and (b) probably
+an explicit config flag to enable deregister at all. Purge (`purge=true` in the
+Nomad API) should not be the default.
+
+### What the existing detection code already does — preserve it
+
+The detection side has optimisations that are easy to accidentally break:
+
+- **Raft index skip**: `Differ.lastNomadIndex` caches the `QueryMeta.LastIndex`
+  from `Jobs.List()`. If that index and `lastCommit` are both unchanged from the
+  prior cycle, per-job plan calls are skipped entirely. Keep this optimisation
+  when extending `Check()`.
+- **In-memory clone**: `gitwatch.Watcher` uses `memory.NewStorage()` —
+  no disk writes, no persistent files. Any new git interaction should stay
+  in-memory or go through a clearly separate path (e.g. a checkpoint writer on
+  a state branch).
+- **Webhook coalescing**: `Watcher.triggerCh` is a buffered channel of size 1.
+  Multiple rapid triggers collapse to one fetch. Don't change this to unbuffered.
+
+### Prior art pitfalls to avoid
+
+These are the specific mistakes made by nomad-gitops-operator and nomad-ops that
+should not be repeated:
+
+- **Do not re-clone on every cycle.** nomad-gitops-operator clones the full repo
+  every 30 seconds. Use HEAD comparison and Raft index to skip work when nothing
+  has changed.
+- **Do not Register unconditionally.** nomad-gitops-operator calls Register on
+  every job every cycle, whether the plan shows a diff or not. Only register
+  when `Jobs.Plan()` shows a real change.
+- **Do not skip CAS.** Neither existing operator uses `EnforceIndex`. This is
+  a correctness gap, not a performance tradeoff. Always use the `JobModifyIndex`
+  captured at detection time.
+- **Do not fight the autoscaler.** nomad-ops filters out `Count`/`Scaling` diffs
+  before deciding to register, so it does not overwrite autoscaler-managed counts
+  every cycle. If a scaling policy is present, treat changes to `Count` as owned
+  by the autoscaler, not by Git.
+- **Do not hardcode intervals.** Every timing parameter should be a config flag
+  with a corresponding env var. Document both in the README table.
+
+### Vocabulary used in proposals
+
+Use these terms consistently so the code and docs match:
+
+| Term | Meaning |
+|---|---|
+| `JobDiff` | An observation: detected drift between Git and Nomad. Already implemented. |
+| `JobUpdate` | An intended transition: a planned change to apply to Nomad. Not yet implemented. |
+| `JobUpdateOperation` | `REGISTER` or `DEREGISTER` |
+| `JobUpdateStatus` | `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `SUPERSEDED` |
+| opt-in key | `gitops.managed = "true"` in job HCL meta — scope selector, never written by the tool |
+| meta-drift | The problem of tool-written meta keys being clobbered by the next human `nomad job run` |
+| `CheckpointStore` | Interface for persisting update queue state across restarts |
+| Raft index | `QueryMeta.LastIndex` from `Jobs.List()` — used for skip optimisation, not locking |
+| `JobModifyIndex` | Per-job monotonic counter from `Jobs.Info()` — used as CAS token on `Jobs.Register()` |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Three kinds of drift are tracked:
 
 ## Contents
 
+- [Design and prior art](#design-and-prior-art)
 - [How it works](#how-it-works)
 - [Installation](#installation)
 - [Quick start](#quick-start)
@@ -33,6 +34,22 @@ Three kinds of drift are tracked:
   - [Sample Prometheus configuration](#sample-prometheus-configuration)
 - [Docker](#docker)
 - [Development](#development)
+
+---
+
+## Design and prior art
+
+nomad-botherer is currently a **drift detector only** — it observes and reports
+differences between Git and a live Nomad cluster but does not apply changes.
+Job application (GitOps-style reconciliation) is planned but not yet implemented.
+
+[`docs/prior-art.md`](docs/prior-art.md) surveys the existing Nomad GitOps
+tooling (nomad-gitops-operator, nomad-ops, Levant, Waypoint), explains what each
+does and where each falls short, and describes the design decisions that will
+guide the apply side of nomad-botherer when it is built.
+
+The design proposals for job application and change checkpointing are in
+[`docs/proposals/`](docs/proposals/).
 
 ---
 

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -1,0 +1,187 @@
+# Prior art: GitOps for Nomad
+
+This document surveys the existing tooling for GitOps-style job management in
+Nomad, identifies what each tool does well and where each falls short, and
+explains what problems nomad-botherer is trying to solve differently.
+
+Job *application* (actually submitting changes to Nomad from Git) is not yet
+implemented in nomad-botherer. The design proposals that inform that work are in
+[`docs/proposals/`](proposals/).
+
+---
+
+## The tools
+
+### nomad-gitops-operator (jonasvinther)
+
+A single Go binary that clones a Git repo, compares its HCL files to a live
+Nomad cluster, and applies the difference. Deletion is controlled by a `--delete`
+flag; when on, any job tagged with the operator's metadata key that is absent
+from the current repo glob is purged. Written with go-git.
+
+**What it gets right**: the basic shape of the problem — clone, parse, plan,
+register — is correct. Tags managed jobs in Nomad metadata so deletion scope is
+bounded to jobs the operator registered.
+
+**Where it falls short**:
+
+- Re-clones the entire repo from scratch on every 30-second cycle. There is no
+  incremental fetch, no HEAD comparison to skip unchanged commits, no Raft index
+  check to skip unchanged Nomad state. Every cycle parses and plans every job
+  regardless of whether anything changed.
+- Calls `Jobs.Register()` unconditionally on every cycle, even when the plan
+  shows no diff. This generates unnecessary Nomad evaluations continuously.
+- No CAS or conflict handling. There is no use of `EnforceIndex` /
+  `JobModifyIndex`, so a concurrent human edit between plan and register is
+  silently overwritten or silently wins depending on timing.
+- The 30-second poll interval is hardcoded with no flag or environment variable.
+- No webhook support; detection latency is always at least 30 seconds.
+- No Prometheus metrics, no HTTP health endpoint.
+- The managed-job metadata key has a typo (`nomoporater`, with an `e`) that is
+  now a permanent compatibility constraint across versions.
+- Minimal active development since early 2024.
+
+### nomad-ops (nomad-ops/nomad-ops)
+
+A more complete service with a Go backend, a React/PocketBase frontend, and
+SQLite state storage. Repositories are configured as "Sources" through a UI.
+Each Source points at a URL, branch, path glob, Nomad namespace, and region.
+Multiple Sources run independently.
+
+**What it gets right**:
+
+- Disk-cached clones with incremental `git pull`, configurable interval (default
+  60 seconds).
+- A `hasUpdate()` function that reads the Nomad plan diff before deciding whether
+  to call Register. If the plan shows no real field changes, Register is skipped.
+- Autoscaler awareness: diffs that are only in `Count` or `Scaling` fields are
+  treated as not requiring re-registration, so nomad-ops does not fight an
+  autoscaler running alongside it.
+- Deletion excludes batch, periodic, and dispatch-child jobs, which is a
+  meaningful safety default.
+- Prometheus metrics and structured state in PocketBase for event history.
+
+**Where it falls short**:
+
+- Still no CAS on Register. The plan-then-register window has no optimistic
+  locking.
+- No webhook trigger. Detection latency is bounded by the poll interval.
+- Requires SQLite via PocketBase for all state. This means the pod needs
+  persistent storage (or NFS) if it needs to be rescheduled to a different node.
+- No multi-cluster support.
+- No workload identity (JWT tokens); requires a static `NOMAD_TOKEN`.
+- Deletion is always on for managed jobs with no per-job override or protection
+  flag. A job whose file was renamed or moved triggers deregistration before the
+  new file is registered.
+
+### Levant (hashicorp/levant) — archived June 2025
+
+A CLI templating and single-shot deployment tool. Takes a job HCL template,
+substitutes variables, runs `nomad job plan`, registers the job, and polls
+allocations until stable. Supports canary auto-promotion and auto-revert.
+
+Not a GitOps operator: no polling loop, no continuous reconciliation, no drift
+detection. You call it from a CI pipeline on git push. Its replacement, nomad-pack,
+is a similar CLI with a packaging layer on top. Neither has reconciliation
+behaviour.
+
+### Waypoint (HashiCorp) — OSS archived January 2024
+
+Waypoint had a runner component that polled a Git repo and ran `waypoint up`
+pipelines on new commits. For Nomad, the `nomad-jobspec` plugin submitted a job
+spec. This was push-triggered CD, not continuous state reconciliation: a new
+commit triggered a pipeline run, but there was no comparison of desired vs
+actual cluster state and no reverting of manual drift. The HCP SaaS successor
+focuses on internal developer platforms and has no Nomad deployment story.
+
+---
+
+## What nomad-botherer does differently today
+
+nomad-botherer currently only detects drift; it does not apply changes. The
+detection side addresses several of the problems above:
+
+**Incremental change detection.** The git watcher stores HEAD between cycles.
+If HEAD has not advanced since the last check, no per-job work is triggered from
+the git side. On the Nomad side, `Jobs.List()` returns a Raft index
+(`QueryMeta.LastIndex`); if that index has not advanced since the last check,
+the per-job plan calls are skipped entirely. A quiet cluster with no git
+activity costs one `Jobs.List()` call per diff interval, not N plan calls.
+
+**Webhook trigger.** A GitHub push webhook can trigger an immediate fetch and
+diff check, reducing detection latency from poll-interval to seconds.
+
+**Prometheus metrics throughout.** Every meaningful operation — git fetches,
+diff checks, skipped checks, API errors, per-job drift, drift duration,
+webhook events — is a counter or gauge. This makes the detection loop
+observable without log scraping.
+
+**No persistent storage.** State is entirely in-memory. There is no database,
+no local disk requirement. The tradeoff is that a restart re-derives all state
+from the next diff cycle, which is acceptable for a read-only observer.
+
+**Staleness guards.** `--max-git-staleness` and `--max-nomad-staleness` can
+force refreshes if the normal polling path falls behind, independently of the
+main poll interval.
+
+---
+
+## What nomad-botherer wants to do differently for job application
+
+The proposals in [`docs/proposals/`](proposals/) describe the intended approach
+to applying changes. The main design decisions, and how they differ from the
+tools above:
+
+**Plan before every apply, CAS on register.** Rather than calling Register
+unconditionally or after a simple plan check, the intent is to use Nomad's
+`JobModifyIndex` as a check-and-set token. The index is recorded at detection
+time; Register is called with `EnforceIndex=true` and that index value. If the
+cluster state changed between detection and apply, Nomad rejects the write. This
+prevents the plan-then-register race that neither existing operator handles.
+
+**Opt-in scope via job meta.** Rather than managing every job found in the repo
+or every job tagged with an operator-specific key the tool wrote, the intent is
+to require an explicit `gitops.managed = "true"` key in the job's HCL meta
+stanza. This is the "Operator Pattern in Nomad" — the same model that scalad
+(trivago) uses for autoscaling opt-in and that Pondidum/nomad-operator
+documented for backup automation in 2021. A job without the opt-in key is never
+touched, even if it is running in Nomad without a corresponding HCL file. This
+prevents accidental deregistration of manually-managed jobs.
+
+**No external database for state.** nomad-ops requires SQLite on persistent
+storage. The design proposals describe three alternatives that avoid this: Nomad
+Variables (Raft-backed KV built into Nomad 1.4+), a dedicated Git state branch,
+or deriving restart state from per-job metadata. The goal is that nomad-botherer
+can be rescheduled to any node without volume claims.
+
+**Async apply queue, not synchronous blocking.** An in-process queue decouples
+detection from application. A slow or failing apply does not delay the next diff
+check. Updates for the same job that arrive faster than applies finish are
+marked superseded; the most recent intended state always wins.
+
+**Conservative deletion.** The `missing_from_hcl` drift type in nomad-botherer
+is an observation, not an automatic action. Any future deregister behaviour
+should require the opt-in key to be present on the live job (confirming the job
+was previously managed by this operator), and should probably require an explicit
+flag, not be on-by-default.
+
+---
+
+## What no existing tool solves
+
+Several problems remain open across all Nomad GitOps tooling, including
+nomad-botherer's planned work:
+
+- **No multi-cluster support** in any OSS tool. Cluster fan-out requires a
+  separate instance per cluster.
+- **No workload identity.** All tools require a static Nomad token. Nomad's
+  JWT-based workload identity (available when nomad-botherer itself runs as a
+  Nomad job) is not used by any of the tools surveyed.
+- **No dependency ordering.** If job B depends on job A being registered first,
+  there is no mechanism to express or enforce this. Nomad does not expose a
+  dependency graph; any ordering would require explicit metadata in HCL.
+- **No standard has emerged.** HashiCorp has no official GitOps operator for
+  Nomad and does not recommend one. The dominant production pattern remains
+  push-based: a CI pipeline calls `nomad job run` on git push. nomad-ops is the
+  most feature-complete pull-based operator but has ~111 stars and is maintained
+  by a small team. There is no ArgoCD equivalent for Nomad.

--- a/docs/proposals/change-checkpointing.md
+++ b/docs/proposals/change-checkpointing.md
@@ -200,130 +200,213 @@ make it awkward as a default.
 
 ---
 
-## Alternative 3: Nomad job meta as distributed per-job state
+## Alternative 3: Nomad job meta as opt-in selector
 
-**How it works**
+**The pattern**
 
-Rather than storing a single centralised checkpoint, nomad-botherer records the
-GitOps state of each job *on the job itself* using Nomad's `Meta` map. Every
-registered job has a key-value `Meta` field that is stored in Nomad's state and
-returned with `Jobs.Info()`. nomad-botherer writes to this field when applying
-an update:
+Rather than nomad-botherer managing every job it finds in Git, jobs must opt in
+to GitOps management by declaring a meta key in their HCL:
 
-```json
-{
-  "Meta": {
-    "gitops.commit":      "abc1234def5678",
-    "gitops.hcl_path":    "jobs/api-server.hcl",
-    "gitops.applied_at":  "2026-05-13T10:00:00Z",
-    "gitops.status":      "succeeded"
+```hcl
+job "api-server" {
+  meta {
+    "gitops.managed" = "true"
+  }
+  # rest of job spec
+}
+```
+
+nomad-botherer reads this key from both the parsed HCL and the live job
+(`Jobs.Info()`) to decide whether to include a job in its reconciliation scope.
+A job without `gitops.managed = "true"` is skipped entirely — no diff, no
+apply, no deregister. The meta key is a scope selector, not a state store.
+
+This is a direct application of what the Nomad community calls the **Operator
+Pattern**: an external controller watches for jobs bearing a specific meta key
+and acts only on those, leaving everything else alone. It is the Nomad
+equivalent of the annotation-based opt-in used by Kubernetes controllers such as
+cert-manager (`cert-manager.io/cluster-issuer: "letsencrypt"`) or the Prometheus
+auto-discovery annotations (`prometheus.io/scrape: "true"`).
+
+**Prior art in the Nomad ecosystem**
+
+The pattern is established and in production use:
+
+- **scalad** (trivago/scalad): a horizontal autoscaler for Nomad. Jobs opt in
+  with `meta { scaler = "true" }`, then supply additional meta keys for
+  min/max counts, cooldown periods, and scaling queries. The entire scaling
+  policy lives in the job spec alongside the opt-in flag. This is the clearest
+  real-world example of the pattern.
+  (https://github.com/trivago/scalad)
+
+- **nomad-operator** (Pondidum/nomad-operator): a community-documented
+  implementation applied to automated database backups. Jobs declare
+  `meta { auto-backup = "true"; backup-schedule = "@daily" }`. The operator
+  watches the Nomad event stream for job registration events, reads the meta
+  keys, and creates or removes a backup job accordingly. This is the only
+  written description of the pattern under the name "The Operator Pattern in
+  Nomad" (Andy Dote, 2021). There is a corresponding HashiCorp Discuss thread.
+  (https://andydote.co.uk/2021/11/22/nomad-operator-pattern/,
+  https://github.com/Pondidum/nomad-operator)
+
+- **Nomad Autoscaler** (HashiCorp official): uses the same conceptual pattern
+  but resolved it with a first-class `scaling` stanza rather than the freeform
+  `meta` map. The `scaling` block has an `enabled` boolean for opt-in and a
+  `policy` map for per-job configuration — effectively the pattern promoted to
+  a named stanza in the job spec. Conceptually identical; mechanically cleaner.
+  (https://developer.hashicorp.com/nomad/tools/autoscaling/policy)
+
+Kubernetes formalised annotation-based opt-in under two conventions: labels are
+for identity and selection (controllers use `labelSelector` to query), while
+annotations carry per-object configuration. It also mandates DNS-subdomain
+prefixes (e.g., `cert-manager.io/`) to prevent key collisions between tools.
+Nomad has no equivalent formal convention. The observed practice across the
+tools above is a short tool-name prefix with a dot separator (`gitops.managed`,
+`scaler`, `auto-backup`). Key naming is worth being deliberate about: keys
+containing characters outside `[A-Za-z0-9_.]` are silently converted to
+underscores when exposed as `NOMAD_META_*` environment variables inside tasks,
+though the original form is preserved in the API response.
+
+**Separating opt-in from state storage**
+
+The version of this alternative described in earlier drafts conflated two
+distinct uses of the `Meta` map:
+
+1. **Opt-in flag** (set by humans in HCL, read by the tool): `gitops.managed =
+   "true"`. The human controls this; it lives in the HCL file and is therefore
+   version-controlled. Safe and stable.
+
+2. **Applied state** (written by the tool back into the live job): `gitops.commit
+   = "abc123"`, `gitops.applied_at = "..."`. This is where the approach breaks
+   down.
+
+When a tool writes state back into a job's meta, the live job spec diverges from
+the HCL in Git. The next time a human runs `nomad job run jobs/api-server.hcl`
+without those keys, Nomad silently removes the tool-written fields. This is the
+**meta-drift problem**: human submissions clobber tool state, and tool writes
+clobber human submissions. `jonasvinther/nomad-gitops-operator` ran into this
+directly when using meta fields to track reconciliation state and documented it
+as an open limitation. The underlying Nomad issue (#19329, "Add meta for Nomad
+Variables") remains open as of 2026.
+
+The clean resolution: use `meta` only for the opt-in flag that the human writes
+and controls; store applied state in Nomad Variables (Alternative 1).
+
+**Hybrid: meta opt-in + Variables state**
+
+```hcl
+// jobs/api-server.hcl (human-controlled, version-controlled)
+job "api-server" {
+  meta {
+    "gitops.managed" = "true"
   }
 }
 ```
 
-On startup, nomad-botherer calls `Jobs.List()` and then `Jobs.Info()` for each
-job, reads the `gitops.*` meta keys, and reconstructs which jobs have already
-been reconciled to which commit. Jobs whose `gitops.commit` matches the current
-Git HEAD and whose `gitops.status` is `succeeded` do not need to be re-applied;
-the diff check will confirm this independently via `EnforceIndex`.
+nomad-botherer behaviour with this flag:
 
-There is no checkpoint file. State is entirely distributed across the jobs
-themselves.
+- Include a job in the diff scope if and only if its HCL file or its live
+  `Jobs.Info()` response contains `meta["gitops.managed"] == "true"`.
+- Store checkpoint state in Nomad Variables (Alternative 1). Never write back
+  to the job's `meta` stanza.
+- A live job that does not have `gitops.managed` is never flagged as
+  `missing_from_hcl`, even if it has no corresponding HCL file. This prevents
+  nomad-botherer from attempting to deregister manually-registered jobs.
 
-**Handling deregistered jobs**
+**Effect on the differ**
 
-For jobs that were deregistered (`missing_from_hcl`), there is no job record to
-write meta to. The apply removes the job entirely, so there is nothing to read
-on restart. This is acceptable: on restart, `Jobs.List()` will not return the
-deregistered job, and the diff check will confirm it is absent from both Git and
-Nomad, so no action is taken.
+`Check()` changes from "compare all HCL files against all Nomad jobs" to a
+narrower scope:
 
-**Implementation sketch**
+- For HCL files: include only files whose parsed job spec has
+  `meta["gitops.managed"] == "true"`.
+- For live Nomad jobs: include only jobs with `meta["gitops.managed"] == "true"`
+  in their live spec.
+- The `missing_from_hcl` drift type becomes "a managed job (live meta has the
+  flag) has no HCL file". This is a meaningful and intentional signal, not "any
+  job not in Git".
 
-When calling `Jobs.Register()` for a GitOps update, merge the `gitops.*` meta
-keys into the job's `Meta` map before sending:
-
-```go
-func applyMeta(job *nomadapi.Job, update JobUpdate) {
-    if job.Meta == nil {
-        job.Meta = make(map[string]string)
-    }
-    job.Meta["gitops.commit"] = update.GitCommit
-    job.Meta["gitops.hcl_path"] = update.HCLFile
-    job.Meta["gitops.applied_at"] = time.Now().UTC().Format(time.RFC3339)
-    job.Meta["gitops.status"] = "succeeded"
-}
-```
-
-On startup, the reconstruction scan is a single `Jobs.List()` plus N
-`Jobs.Info()` calls, which nomad-botherer already makes for its first diff
-check. The restart cost is zero additional API calls.
+The `missingFromNomad` type changes to "an HCL file has the opt-in key but the
+job does not exist in Nomad yet". The first registration also writes
+`gitops.managed = "true"` to the live job, which is already in the HCL, so
+there is no meta drift from this write.
 
 **Pros**
 
-- Truly zero new infrastructure. State is stored in Nomad's existing job
-  records; no Variables API, no Git writes, no files on disk.
-- The checkpoint scan on startup reuses the same `Jobs.Info()` calls that the
-  first diff check makes anyway, so restart cost is exactly one diff cycle.
-- Meta fields are visible in the Nomad UI and `nomad job status` output,
-  so the GitOps commit and apply time are self-documenting on the job.
-- Works with all Nomad versions (Meta has been present since early Nomad).
-- No concurrency concerns: meta is written atomically as part of job
-  registration, using the same `EnforceIndex` CAS that prevents double-apply.
+- Operators explicitly enrol jobs. Manual jobs and legacy jobs are never
+  touched, regardless of whether they have a corresponding HCL file.
+- The opt-in key lives in the HCL file and is therefore in Git history; the
+  decision to enrol a job is auditable and reviewable.
+- The pattern is recognisable to anyone who has used scalad or the Nomad
+  Operator Pattern. It does not require explanation.
+- When combined with Nomad Variables for state (the hybrid), there is no
+  meta-drift problem and no spurious diff loops.
+- Works with all Nomad versions; no Variables API required for the opt-in
+  mechanism itself.
 
 **Cons**
 
-- Modifies the job's `Meta` map on every GitOps apply. If the HCL file defines
-  its own `meta` stanza, the GitOps keys must be merged without overwriting
-  user-defined keys. This requires care in the merge logic.
-- The next diff check will detect the `gitops.*` meta changes as a "modified"
-  diff if the HCL file does not include those keys, creating a spurious diff
-  loop. Mitigation: the differ must strip `gitops.*` meta keys from the Nomad
-  job before comparing with HCL, or the HCL author must include placeholder
-  values.
-- State for `IN_PROGRESS` updates is not stored at all; only `succeeded` is
-  written (after the fact). An `IN_PROGRESS` update that is interrupted by a
-  restart is re-derived from the diff on the next cycle, but the operator has
-  no record that an apply was attempted.
-- Deregistered jobs leave no trace. If an operator later wonders why a job is
-  not running, there is no meta record explaining that it was intentionally
-  removed by GitOps.
-- Meta values are strings; structured data (e.g., a list of failed attempts)
-  requires JSON encoding within the string value, which is fragile.
+- Every job that should be managed must have `gitops.managed = "true"` in its
+  HCL. Easy to forget; there is no directory-level default.
+- The key appears as `NOMAD_META_gitops_managed` in every allocation's
+  environment, which is minor but visible noise.
+- Nomad has no server-side filtering by meta value. nomad-botherer must list
+  all jobs and filter client-side, which is the same cost as today.
+- If a job is registered manually from an HCL file that lacks the opt-in key,
+  but the canonical HCL in Git does have it, nomad-botherer sees a `modified`
+  diff and will re-register the job with the key present. This is correct GitOps
+  behaviour but will surprise operators the first time they encounter it.
 
-**Verdict**: the most elegant option in terms of zero infrastructure, but the
-spurious-diff problem (alternatives: ignore-list logic in `Check()`, or require
-HCL authors to include meta stanza) adds non-trivial complexity to the differ.
-Best suited to environments where Nomad Variables are not available.
+**Verdict**: the opt-in pattern is the right default for production deployments
+managing a cluster shared with manually-run jobs. It should be paired with
+Alternative 1 (Nomad Variables) for state storage. The `meta` flag is a scope
+selector; it is not a checkpoint mechanism.
 
 ---
 
 ## Comparison
 
-| Property | Nomad Variables | Git state branch | Job meta |
+The three alternatives address the same problem (where to persist checkpoint
+state) but sit on different infrastructure axes. Alternative 3 is also an answer
+to a slightly different question (which jobs should be managed at all), so it
+layers on top of either of the other two rather than replacing them.
+
+| Property | Alt 1: Nomad Variables | Alt 2: Git state branch | Alt 3: meta opt-in |
 |---|---|---|---|
+| What it stores | Pending/completed updates | Pending/completed updates | Scope selector only |
 | Infrastructure | Nomad 1.4+ | Git write access | Any Nomad |
-| Durability | Raft-backed | Git history | Nomad job store |
-| Audit trail | Moderate (Variable history) | Best (full Git log) | Minimal (current meta only) |
-| Startup cost | List Variables + rehydrate | Clone state branch + read files | Reuses diff-cycle Info() calls |
-| Concurrent instances | CAS on Variable ModifyIndex | Push rejection + retry | CAS on JobModifyIndex |
-| Diff loop risk | None | None | Requires differ to strip gitops.* keys |
-| Deregister tracking | Variable deleted on success | Checkpoint file deleted | No record |
+| Durability | Raft-backed | Full Git history | N/A (opt-in flag, not state) |
+| Audit trail | Moderate | Best | N/A |
+| Startup cost | List Variables + rehydrate | Clone state branch + read files | Already paid by diff cycle |
+| Concurrent instances | CAS on Variable ModifyIndex | Push rejection + retry | N/A |
+| Diff loop risk | None | None | None (flag is in HCL, not written by tool) |
+| Deregister tracking | Variable deleted on success | Checkpoint file removed | No record |
 | Nomad version required | 1.4+ | Any | Any |
+| Prevents touching manual jobs | No | No | Yes |
 
 ---
 
 ## Recommended path
 
-Implement Alternative 1 (Nomad Variables) as the default, gated behind a config
-flag (`--checkpoint-store`, default: `nomad-variables`). Add Alternative 3 (job
-meta) as a fallback for Nomad versions before 1.4, selectable via
-`--checkpoint-store=job-meta`. Alternative 2 (Git branch) is available as an
-opt-in for teams that want the full audit trail.
+Implement the hybrid of Alternative 3 + Alternative 1:
+
+1. Gate all GitOps behaviour behind the `gitops.managed = "true"` meta opt-in
+   (Alternative 3). This scopes the operator and prevents accidental deregistration
+   of manually-managed jobs. It requires no infrastructure and works on any Nomad
+   version.
+
+2. Use Nomad Variables for checkpoint state (Alternative 1), gated behind a
+   config flag (`--checkpoint-store`, default: `nomad-variables`). This provides
+   durable, CAS-protected restart state without an external database.
+
+3. Offer Alternative 2 (Git state branch) as `--checkpoint-store=git-branch` for
+   teams that need a full audit trail and already have repo write access.
 
 The `CheckpointStore` interface above is the right abstraction boundary. Each
 alternative is an implementation of that interface; the update queue does not
-need to know which backend is active.
+need to know which backend is active. The opt-in flag is orthogonal to this
+interface and should be a config-level default (`--gitops-opt-in-key`, default:
+`gitops.managed`) so teams can rename it if they have a key naming convention.
 
 ---
 

--- a/docs/proposals/change-checkpointing.md
+++ b/docs/proposals/change-checkpointing.md
@@ -1,0 +1,342 @@
+# Proposal: checkpointing ongoing job updates
+
+**Status**: draft  
+**Date**: 2026-05-13
+
+## Background
+
+The async update queue described in the GitOps job updates proposal is
+in-memory. When nomad-botherer restarts — upgrade, crash, or eviction — any
+updates that were `PENDING` or `IN_PROGRESS` are lost. The next diff cycle
+recreates them, so correctness is not compromised, but there is a window where
+an apply was already sent to Nomad but the outcome was never recorded, and a
+second apply of the same change can occur.
+
+For idempotent operations (re-registering an already-registered job with the
+same content) this double-apply is harmless. For `DEREGISTER` operations it
+could be a problem if the job was re-registered between the first apply and
+the restart; the second apply could delete a job that should be running.
+
+The more significant problem is durability of intent. If a long-running
+multi-job rollout (e.g., deploying 30 jobs from a single commit) is interrupted
+halfway, the operator has no record of which jobs were applied and which were
+not. A fresh diff cycle will detect the remaining drift and queue new updates,
+but whether those new updates correspond to the same intent as the interrupted
+rollout is ambiguous.
+
+This proposal describes three ways to checkpoint update state without a
+standalone database.
+
+---
+
+## Requirements
+
+- Survive a nomad-botherer process restart without losing knowledge of which
+  updates were applied and which are still pending.
+- Resume a partial rollout rather than re-deriving intent from scratch on every
+  restart.
+- Not require an external database (PostgreSQL, Redis, etcd, etc.).
+- Ideally, not require additional infrastructure beyond what the service already
+  talks to (Nomad, Git).
+
+---
+
+## Alternative 1: Nomad Variables as the checkpoint store
+
+**How it works**
+
+Nomad 1.4+ includes a built-in key-value store called Nomad Variables, backed
+by Raft and replicated across the cluster. Variables have ACL integration,
+support CAS (check-and-set via `ModifyIndex`), and survive cluster restarts.
+
+nomad-botherer writes one Variable per in-flight rollout at a well-known path:
+
+```
+nomad/jobs/gitops/checkpoints/<git_commit>
+```
+
+The value is a serialised (JSON or protobuf binary) snapshot of the `JobUpdate`
+slice for that commit. The Variable is created when the first update for a
+commit is enqueued and updated atomically as each update transitions through
+`PENDING → IN_PROGRESS → SUCCEEDED/FAILED`. When all updates for a commit reach
+a terminal state, the Variable is deleted (or left for audit; configurable).
+
+On startup, nomad-botherer reads all Variables under
+`nomad/jobs/gitops/checkpoints/` and rehydrates the in-memory queue from any
+non-terminal updates. Updates that were `IN_PROGRESS` are reset to `PENDING`
+and retried (the CAS token from `JobModifyIndex` prevents double-apply harm).
+
+**Interaction with Nomad Raft index**
+
+Nomad Variables use the same Raft log as job state. A Variable write returns a
+`ModifyIndex` that can be used for CAS on the next update, ensuring that two
+concurrent nomad-botherer instances (e.g., during a rolling upgrade) cannot
+write conflicting checkpoint data. The instance that loses the CAS retries after
+re-reading the Variable.
+
+**Implementation sketch**
+
+```go
+type CheckpointStore interface {
+    // Write atomically updates the checkpoint for a commit.
+    // modifyIndex is 0 for a new checkpoint, or the previous ModifyIndex.
+    Write(ctx context.Context, commit string, updates []JobUpdate, modifyIndex uint64) (uint64, error)
+
+    // Read returns the checkpoint for a commit, or nil if none exists.
+    Read(ctx context.Context, commit string) ([]JobUpdate, uint64, error)
+
+    // List returns all active checkpoints.
+    List(ctx context.Context) (map[string][]JobUpdate, error)
+
+    // Delete removes a checkpoint once a rollout is complete.
+    Delete(ctx context.Context, commit string) error
+}
+```
+
+The Nomad client already exists in the process; this adds usage of
+`client.Variables()` from the same `github.com/hashicorp/nomad/api` package.
+
+**Pros**
+
+- No new infrastructure. Nomad is already a hard dependency.
+- Raft-backed durability and replication match the cluster's own guarantees.
+- CAS prevents split-brain between concurrent nomad-botherer instances.
+- ACLs on Variable paths can restrict who can read or modify checkpoint state.
+- Nomad's built-in UI shows Variables; operators can inspect checkpoints without
+  extra tooling.
+
+**Cons**
+
+- Requires Nomad 1.4+ (Variables API). Older clusters cannot use this approach.
+- Adds a new write path to Nomad for operational state, which may conflict with
+  cluster ACL policies that restrict writes to the `nomad/jobs/` namespace.
+- Variable size limit is 64 KiB per key. A very large rollout (hundreds of jobs)
+  may exceed this; mitigation is one Variable per job rather than per commit,
+  at the cost of more API calls on startup.
+- Nomad Variables are not designed as a queue and have no watch/notify semantics;
+  polling is required.
+
+**Verdict**: the cleanest option when Nomad 1.4+ is available. Keeps all
+operational state inside the system being managed.
+
+---
+
+## Alternative 2: Git branch as the checkpoint store
+
+**How it works**
+
+nomad-botherer maintains a dedicated branch in the same repository it watches,
+e.g., `gitops-state`, which it treats as a write-only append log. The branch
+holds one file per active rollout:
+
+```
+checkpoints/<git_commit>.json
+```
+
+Each file contains the `JobUpdate` slice for that commit, serialised as JSON.
+The file is committed and pushed when updates are enqueued, and updated with
+terminal statuses when each update completes. The branch is never merged into
+the main branch; it is purely operational state.
+
+On startup, nomad-botherer shallow-fetches the `gitops-state` branch (a small
+fetch since it only contains checkpoint files, not job HCL), reads all
+non-terminal checkpoint files, and rehydrates the queue.
+
+**Concurrency control**
+
+Git itself provides concurrency control via push rejection. If two instances try
+to push a checkpoint update simultaneously, one will receive a non-fast-forward
+rejection and must pull, merge, and retry. For checkpoint files (one file per
+commit, independent between commits), merge conflicts are essentially impossible;
+the only conflict would be two instances updating the same file, which is
+prevented by the single-writer design (only the instance that detected the
+commit owns its checkpoint).
+
+**Implementation sketch**
+
+The existing `gitwatch.Watcher` uses `go-git` and `memory.NewStorage()`. The
+checkpoint writer needs a separate, persistable storage (not in-memory) so that
+pushes can be made. This likely means a second `go-git` clone with disk-backed
+storage, or a thin wrapper around `git` CLI calls for the state branch.
+
+```go
+type GitCheckpointStore struct {
+    repoURL    string
+    branch     string  // "gitops-state"
+    workDir    string  // disk path for the state clone
+    auth       transport.AuthMethod
+}
+```
+
+**Pros**
+
+- Git is already a dependency; no new credentials or network endpoints needed
+  (assuming write access to the repo is already granted via token or SSH key).
+- The checkpoint history is a full Git log: every state transition is an
+  immutable commit, with timestamp and message. This is a better audit trail
+  than the in-memory or Nomad Variables approaches.
+- Standard Git tooling (`git log`, `git diff`, `git show`) lets operators
+  inspect and manipulate checkpoint state without custom tooling.
+- No external API version constraints (works with any Git host).
+
+**Cons**
+
+- Requires write access to the repository. Read-only tokens (common for
+  pull-based GitOps setups) are not sufficient.
+- Adds Git push latency to the hot path of every status update. A rollout of
+  30 jobs produces 30+ commits to the state branch.
+- Branch history grows unboundedly unless a periodic cleanup job prunes old
+  checkpoint commits (e.g., `git push --force` with a truncated history, or
+  a separate cleanup cron).
+- Mixing operational state and source code in one repository is operationally
+  awkward. Teams that have separate read/write access policies for source vs
+  operational state cannot use this without repo restructuring.
+- The state branch must be protected from human pushes that could corrupt
+  checkpoint data; this requires branch protection rules on the Git host.
+
+**Verdict**: good for teams that already have write access and want a full audit
+trail, but the per-update commit overhead and the read-write access requirement
+make it awkward as a default.
+
+---
+
+## Alternative 3: Nomad job meta as distributed per-job state
+
+**How it works**
+
+Rather than storing a single centralised checkpoint, nomad-botherer records the
+GitOps state of each job *on the job itself* using Nomad's `Meta` map. Every
+registered job has a key-value `Meta` field that is stored in Nomad's state and
+returned with `Jobs.Info()`. nomad-botherer writes to this field when applying
+an update:
+
+```json
+{
+  "Meta": {
+    "gitops.commit":      "abc1234def5678",
+    "gitops.hcl_path":    "jobs/api-server.hcl",
+    "gitops.applied_at":  "2026-05-13T10:00:00Z",
+    "gitops.status":      "succeeded"
+  }
+}
+```
+
+On startup, nomad-botherer calls `Jobs.List()` and then `Jobs.Info()` for each
+job, reads the `gitops.*` meta keys, and reconstructs which jobs have already
+been reconciled to which commit. Jobs whose `gitops.commit` matches the current
+Git HEAD and whose `gitops.status` is `succeeded` do not need to be re-applied;
+the diff check will confirm this independently via `EnforceIndex`.
+
+There is no checkpoint file. State is entirely distributed across the jobs
+themselves.
+
+**Handling deregistered jobs**
+
+For jobs that were deregistered (`missing_from_hcl`), there is no job record to
+write meta to. The apply removes the job entirely, so there is nothing to read
+on restart. This is acceptable: on restart, `Jobs.List()` will not return the
+deregistered job, and the diff check will confirm it is absent from both Git and
+Nomad, so no action is taken.
+
+**Implementation sketch**
+
+When calling `Jobs.Register()` for a GitOps update, merge the `gitops.*` meta
+keys into the job's `Meta` map before sending:
+
+```go
+func applyMeta(job *nomadapi.Job, update JobUpdate) {
+    if job.Meta == nil {
+        job.Meta = make(map[string]string)
+    }
+    job.Meta["gitops.commit"] = update.GitCommit
+    job.Meta["gitops.hcl_path"] = update.HCLFile
+    job.Meta["gitops.applied_at"] = time.Now().UTC().Format(time.RFC3339)
+    job.Meta["gitops.status"] = "succeeded"
+}
+```
+
+On startup, the reconstruction scan is a single `Jobs.List()` plus N
+`Jobs.Info()` calls, which nomad-botherer already makes for its first diff
+check. The restart cost is zero additional API calls.
+
+**Pros**
+
+- Truly zero new infrastructure. State is stored in Nomad's existing job
+  records; no Variables API, no Git writes, no files on disk.
+- The checkpoint scan on startup reuses the same `Jobs.Info()` calls that the
+  first diff check makes anyway, so restart cost is exactly one diff cycle.
+- Meta fields are visible in the Nomad UI and `nomad job status` output,
+  so the GitOps commit and apply time are self-documenting on the job.
+- Works with all Nomad versions (Meta has been present since early Nomad).
+- No concurrency concerns: meta is written atomically as part of job
+  registration, using the same `EnforceIndex` CAS that prevents double-apply.
+
+**Cons**
+
+- Modifies the job's `Meta` map on every GitOps apply. If the HCL file defines
+  its own `meta` stanza, the GitOps keys must be merged without overwriting
+  user-defined keys. This requires care in the merge logic.
+- The next diff check will detect the `gitops.*` meta changes as a "modified"
+  diff if the HCL file does not include those keys, creating a spurious diff
+  loop. Mitigation: the differ must strip `gitops.*` meta keys from the Nomad
+  job before comparing with HCL, or the HCL author must include placeholder
+  values.
+- State for `IN_PROGRESS` updates is not stored at all; only `succeeded` is
+  written (after the fact). An `IN_PROGRESS` update that is interrupted by a
+  restart is re-derived from the diff on the next cycle, but the operator has
+  no record that an apply was attempted.
+- Deregistered jobs leave no trace. If an operator later wonders why a job is
+  not running, there is no meta record explaining that it was intentionally
+  removed by GitOps.
+- Meta values are strings; structured data (e.g., a list of failed attempts)
+  requires JSON encoding within the string value, which is fragile.
+
+**Verdict**: the most elegant option in terms of zero infrastructure, but the
+spurious-diff problem (alternatives: ignore-list logic in `Check()`, or require
+HCL authors to include meta stanza) adds non-trivial complexity to the differ.
+Best suited to environments where Nomad Variables are not available.
+
+---
+
+## Comparison
+
+| Property | Nomad Variables | Git state branch | Job meta |
+|---|---|---|---|
+| Infrastructure | Nomad 1.4+ | Git write access | Any Nomad |
+| Durability | Raft-backed | Git history | Nomad job store |
+| Audit trail | Moderate (Variable history) | Best (full Git log) | Minimal (current meta only) |
+| Startup cost | List Variables + rehydrate | Clone state branch + read files | Reuses diff-cycle Info() calls |
+| Concurrent instances | CAS on Variable ModifyIndex | Push rejection + retry | CAS on JobModifyIndex |
+| Diff loop risk | None | None | Requires differ to strip gitops.* keys |
+| Deregister tracking | Variable deleted on success | Checkpoint file deleted | No record |
+| Nomad version required | 1.4+ | Any | Any |
+
+---
+
+## Recommended path
+
+Implement Alternative 1 (Nomad Variables) as the default, gated behind a config
+flag (`--checkpoint-store`, default: `nomad-variables`). Add Alternative 3 (job
+meta) as a fallback for Nomad versions before 1.4, selectable via
+`--checkpoint-store=job-meta`. Alternative 2 (Git branch) is available as an
+opt-in for teams that want the full audit trail.
+
+The `CheckpointStore` interface above is the right abstraction boundary. Each
+alternative is an implementation of that interface; the update queue does not
+need to know which backend is active.
+
+---
+
+## Open questions
+
+- **Variable path prefix**: should the path be configurable
+  (`--nomad-variable-prefix`) to allow multiple nomad-botherer instances
+  managing different namespaces to coexist without collision?
+- **Cleanup policy**: should terminal checkpoints be deleted immediately or
+  retained for a configurable duration (e.g., `--checkpoint-retention 24h`)
+  for post-hoc debugging?
+- **IN_PROGRESS fence**: if a Variable shows `IN_PROGRESS` on startup (the
+  previous instance crashed mid-apply), should nomad-botherer immediately
+  retry, wait one diff interval, or require manual intervention? Retrying is
+  safe due to CAS, but may surprise operators who want to inspect state before
+  resuming.

--- a/docs/proposals/gitops-job-updates.md
+++ b/docs/proposals/gitops-job-updates.md
@@ -1,0 +1,337 @@
+# Proposal: GitOps job updates
+
+**Status**: draft  
+**Date**: 2026-05-13
+
+## Background
+
+nomad-botherer currently detects drift between a Git repository and a live Nomad
+cluster, but takes no action on it. This proposal describes how to extend it to
+*apply* changes — turning it from a drift detector into a GitOps operator that
+reconciles Nomad job state toward what is declared in Git.
+
+The core questions are:
+
+1. How should a job update be represented internally (and in the gRPC API)?
+2. How should we use Nomad cluster state — particularly the Raft index and job
+   version fields — to make updates safe and idempotent?
+3. Which of three possible architectures should we adopt?
+
+---
+
+## What constitutes a job update
+
+A GitOps update is triggered when `Check()` detects any of the following:
+
+| Drift type | Desired action |
+|---|---|
+| `modified` | Re-register the job from the HCL file |
+| `missing_from_nomad` | Register the job for the first time |
+| `missing_from_hcl` | Deregister (or stop) the job |
+
+The update carries enough context to execute the action and to record what
+happened. It is distinct from a `JobDiff`: a diff is an observation, an update
+is an intended transition.
+
+---
+
+## Protobuf representation
+
+The existing `JobDiff` message in `proto/nomad_botherer.proto` captures the
+observation side. A new `JobUpdate` message captures the action side. Below is
+the proposed addition to the proto file.
+
+```protobuf
+// JobUpdate represents a single intended change to a Nomad job, derived from
+// a detected diff between Git and the cluster. One diff produces one update.
+message JobUpdate {
+  // Unique identifier for this update, assigned by nomad-botherer.
+  // Format: <job_id>/<git_commit_short> — stable across restarts.
+  string update_id = 1;
+
+  string job_id = 2;
+
+  // Path to the HCL file that is the source of truth for this job.
+  // Empty when operation is DEREGISTER (no HCL file for the job).
+  string hcl_file = 3;
+
+  // Git commit hash that triggered this update.
+  string git_commit = 4;
+
+  // Operation to perform on the Nomad cluster.
+  JobUpdateOperation operation = 5;
+
+  // Current status of this update.
+  JobUpdateStatus status = 6;
+
+  // Nomad's JobModifyIndex at the time the drift was detected.
+  // Used as a CAS (check-and-set) token when calling Jobs.Register().
+  // Zero means the job did not exist in Nomad at detection time.
+  uint64 nomad_job_modify_index = 7;
+
+  // Nomad's cluster Raft index (QueryMeta.LastIndex from Jobs.List())
+  // at the time the diff check ran. Recorded for auditability.
+  uint64 nomad_raft_index = 8;
+
+  // RFC3339 timestamp when the diff was detected and this update was created.
+  string detected_at = 9;
+
+  // RFC3339 timestamp when the update was applied (or failed). Empty until then.
+  string applied_at = 10;
+
+  // Human-readable error message if status is FAILED. Empty otherwise.
+  string error = 11;
+}
+
+enum JobUpdateOperation {
+  JOB_UPDATE_OPERATION_UNSPECIFIED = 0;
+  REGISTER   = 1;  // Jobs.Register() — covers both first-time and modify
+  DEREGISTER = 2;  // Jobs.Deregister()
+}
+
+enum JobUpdateStatus {
+  JOB_UPDATE_STATUS_UNSPECIFIED = 0;
+  PENDING     = 1;  // Created, not yet attempted
+  IN_PROGRESS = 2;  // Apply call in flight
+  SUCCEEDED   = 3;  // Nomad accepted the change
+  FAILED      = 4;  // Nomad rejected or returned an error
+  SUPERSEDED  = 5;  // A newer update for the same job was created before this one applied
+}
+```
+
+A new gRPC method gives operators visibility into the update queue:
+
+```protobuf
+service NomadBotherer {
+  // ... existing methods ...
+
+  // ListUpdates returns the current set of pending and recently completed
+  // job updates.
+  rpc ListUpdates(ListUpdatesRequest) returns (ListUpdatesResponse);
+}
+
+message ListUpdatesRequest {
+  // If true, include SUCCEEDED and FAILED updates, not just PENDING/IN_PROGRESS.
+  bool include_completed = 1;
+}
+
+message ListUpdatesResponse {
+  repeated JobUpdate updates = 1;
+}
+```
+
+---
+
+## Using Nomad cluster state
+
+### JobModifyIndex as a CAS token
+
+Nomad's `Jobs.Register()` accepts an `EnforceIndex` flag and a
+`JobModifyIndex` value. When `EnforceIndex` is true, Nomad rejects the write
+if the job's current `ModifyIndex` does not match the supplied value. This
+prevents a stale update from overwriting a change that happened in Nomad between
+the time of detection and the time of apply.
+
+The flow is:
+
+1. `Check()` calls `Jobs.Info()` to detect drift; the response includes
+   `Job.JobModifyIndex`. Store this in `JobUpdate.nomad_job_modify_index`.
+2. When applying, call `Jobs.Register()` with `EnforceIndex=true` and
+   `JobModifyIndex` set to the stored value.
+3. If Nomad returns a conflict error (HTTP 409), the job changed between
+   detection and apply. Mark the update `FAILED`, re-run `Check()` immediately,
+   and let the next cycle create a fresh update with current state.
+
+For `missing_from_nomad` jobs, `nomad_job_modify_index` is 0 (job does not
+exist). Nomad treats index 0 as "job must not already exist", which is correct.
+
+### LastIndex for skipping redundant work
+
+The existing `Differ` already caches `lastNomadIndex` from `Jobs.List()` and
+skips per-job checks when both the Raft index and the git commit are unchanged.
+The update machinery should respect the same signal: if a job's `JobModifyIndex`
+has not advanced since the last successful apply, there is nothing new to apply.
+
+Concretely: after a successful `REGISTER`, record the `JobModifyIndex` returned
+by Nomad in the completed `JobUpdate`. On the next diff cycle, if
+`Jobs.Info()` returns the same `JobModifyIndex`, the update for that job was
+already applied and can be skipped.
+
+### Job version for rollback awareness
+
+Each job in Nomad has a `Version` field that increments on every registered
+change. We do not use this for the apply decision, but it is worth recording in
+the update so that a future rollback operator (not in scope here) can target a
+specific version with `Jobs.Revert()`.
+
+---
+
+## Architecture alternatives
+
+### Alternative A: in-process eager apply
+
+**How it works**
+
+`Check()` is extended to accept an optional `applier` interface. When drift is
+detected, instead of (or in addition to) recording a `JobDiff`, it immediately
+calls `applier.Apply(update)`. The apply happens synchronously within the same
+goroutine that runs the diff check.
+
+```
+git pull → Check() → detect diff → Apply() → Jobs.Register/Deregister
+                                 → record JobUpdate (SUCCEEDED or FAILED)
+```
+
+There is no separate queue and no background worker. The update is fire-and-forget
+within the check loop.
+
+**Nomad state use**: `EnforceIndex` CAS on register; re-check on conflict.
+
+**Pros**
+
+- Minimal new code. The applier is a thin wrapper around the existing Nomad
+  client.
+- Fastest convergence: drift is corrected in the same cycle it is detected.
+- No state to manage beyond the existing `Differ` fields.
+
+**Cons**
+
+- Apply failures block or delay subsequent checks (if synchronous).
+- No visibility into what was applied and when without external logging.
+- Difficult to add approval gates or dry-run modes later.
+- A misbehaving apply (e.g., long network timeout) holds the diff check mutex,
+  delaying the next observation.
+
+**Verdict**: good for a simple first pass but does not scale to approval
+workflows or per-job apply rate limits.
+
+---
+
+### Alternative B: async update queue with reconciliation loop
+
+**How it works**
+
+`Check()` produces `JobUpdate` records with status `PENDING` and places them in
+an in-memory queue. A separate goroutine, the reconciler, drains the queue and
+applies updates to Nomad. The reconciler and the checker communicate through the
+queue; neither blocks the other.
+
+```
+git pull → Check() → enqueue JobUpdate (PENDING)
+                           ↓
+                    reconciler goroutine
+                           ↓
+                    dequeue → Apply() → update status (SUCCEEDED/FAILED)
+                                      → re-enqueue with backoff on transient failure
+```
+
+The queue is a simple slice protected by a mutex, or a buffered channel if
+ordering guarantees are not needed. Updates for the same job are deduplicated:
+if a `PENDING` update for job X already exists and a new diff cycle produces
+another update for job X, the old one is marked `SUPERSEDED` and the new one
+takes its place. This handles rapid Git pushes cleanly.
+
+**Nomad state use**: `EnforceIndex` CAS; `JobModifyIndex` stored in the update
+at detection time. On CAS conflict, update is marked `FAILED` and a fresh diff
+check is triggered.
+
+**Pros**
+
+- Diff checks and applies are decoupled. A slow or failing apply does not affect
+  detection latency.
+- Per-update status is first-class: `ListUpdates` gRPC method has meaningful
+  data.
+- Natural place to add apply rate limiting (one update per N seconds per job)
+  or dry-run mode (process queue but skip the actual `Jobs.Register()` call).
+- The `SUPERSEDED` status handles pushes that arrive faster than applies finish.
+
+**Cons**
+
+- More goroutines and synchronisation primitives to reason about.
+- The queue is in-memory: a restart loses all `PENDING` updates. They will be
+  recreated on the next diff cycle, but there is a window where an operator
+  looking at `ListUpdates` sees no pending work despite a live drift.
+- Ordering between jobs is not guaranteed. If job B depends on job A being
+  registered first, the reconciler may apply B before A.
+
+**Verdict**: the right default choice. Decoupling detection from application is
+worth the complexity, and the restart gap is acceptable given the diff loop will
+recreate pending updates within one cycle.
+
+---
+
+### Alternative C: plan-and-approve with GitHub as control plane
+
+**How it works**
+
+nomad-botherer does not apply changes autonomously. Instead, it posts a Nomad
+plan output as a GitHub commit status or pull request check whenever drift is
+detected on a push event. A human (or a separate CI job) approves or rejects
+the plan. Approval triggers a webhook back to nomad-botherer (or directly
+triggers a Nomad job run) that performs the actual apply.
+
+```
+git push → webhook → Check() → nomad plan → post plan as GitHub status/check
+                                                     ↓ approved
+                               ← approval webhook ←
+                                     ↓
+                               Apply() → Jobs.Register()
+```
+
+The approval signal can be a GitHub environment protection rule, a separate
+approval workflow, or a simple comment-based trigger parsed from the webhook
+payload. The plan output is stored transiently in nomad-botherer memory between
+the push and the approval; on restart it is re-generated from the current diff.
+
+**Nomad state use**: plan is run against the cluster at detection time.
+`JobModifyIndex` from the plan response is stored and used as a CAS token when
+the approval arrives. If the cluster state has changed by then, the apply is
+rejected and a new plan must be posted.
+
+**Pros**
+
+- Humans review every change before it reaches the cluster. Suitable for
+  regulated environments or production clusters shared by multiple teams.
+- The plan output (already rendered by nomad-botherer's `render.go`) is a
+  natural review artefact.
+- No persistent state needed: on restart, re-plan and re-post.
+- GitHub becomes the audit log for who approved what.
+
+**Cons**
+
+- Requires GitHub API write access (commit status or checks API).
+- Convergence latency is bounded by human review time, not machine time.
+- Stale approvals: if the cluster changes between plan and approve, the CAS
+  rejection means the approval is wasted and the cycle must repeat.
+- Does not work for automated rollouts (e.g., CD pipelines) without an
+  automatic approver, at which point it collapses to Alternative B with extra steps.
+
+**Verdict**: worth building on top of Alternative B for teams that need
+approval gates, but not the right default starting point.
+
+---
+
+## Recommended path
+
+Implement Alternative B (async queue) first. It gives immediate operational
+value, is the most compatible with the existing Differ/Watcher architecture,
+and provides the hooks needed to add Alternative C's approval layer later without
+restructuring the core.
+
+The protobuf additions above should land in the same change as the queue
+implementation. The `ListUpdates` gRPC method makes the queue observable without
+requiring log scraping.
+
+---
+
+## Open questions
+
+- **Deregister behaviour**: should `missing_from_hcl` trigger a deregister
+  unconditionally, or should it require an explicit `gitops: deregister` flag in
+  the job meta to prevent accidental deletions when a file is renamed?
+- **Apply ordering**: if multiple jobs change in one commit, should they be
+  applied in dependency order? Nomad does not expose a dependency graph, so this
+  would require an explicit ordering field in HCL or job meta.
+- **Rollback**: if a registered job's health checks fail after apply, should
+  nomad-botherer trigger `Jobs.Revert()`? This needs a separate health-check
+  polling loop and is out of scope for an initial implementation.


### PR DESCRIPTION
Two design documents in docs/proposals/:

gitops-job-updates.md covers how to extend nomad-botherer from drift
detection into a GitOps operator that applies changes. It defines a
JobUpdate protobuf message (with operation and status enums, CAS tokens
from Nomad's JobModifyIndex, and Raft index recording), a ListUpdates
gRPC method, and three architecture alternatives: in-process eager apply
(simple, no decoupling), async update queue with reconciliation loop
(recommended), and plan-and-approve via GitHub as control plane (for
environments needing human review gates).

change-checkpointing.md covers how to survive a process restart without
a database. Three alternatives: Nomad Variables (Raft-backed KV, CAS
on ModifyIndex, requires Nomad 1.4+), a dedicated Git state branch
(full audit trail via commit history, requires repo write access), and
per-job Meta fields (zero infrastructure, reuses existing diff-cycle
API calls, but requires differ to strip gitops.* keys to avoid spurious
diffs). Recommends Nomad Variables as default with job-meta as fallback.

https://claude.ai/code/session_01PL8mRsHrX2XbcP8hBY3Hoc