### PR TITLE
Update Go to 1.25.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-platform build: linux/amd64 and linux/arm64 (Raspberry Pi 4+).
 # Build via the Makefile: make docker (local) or make docker-push (push to registry).
 
-FROM --platform=${BUILDPLATFORM} golang:1.25-alpine AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.25.6-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gerrowadat/nomad-botherer
 
-go 1.25.0
+go 1.25.6
 
 require (
 	github.com/go-git/go-billy/v5 v5.9.0


### PR DESCRIPTION
Bumps the go directive in go.mod and the builder image in Dockerfile from
1.25.0/1.25-alpine to 1.25.6/1.25.6-alpine. The CI workflow already reads
the version from go.mod, so no changes there are needed.