### PR TITLE
Add job selection: glob pattern and managed meta key

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The design proposals for job application and change checkpointing are in
 5. All jobs **currently running in Nomad** (non-dead) that match the selection criteria but have no corresponding HCL file → `missing_from_hcl`
 
    Dead jobs are excluded from both checks by default because a stopped job is expected state — it was intentionally halted. Pass `--include-dead-jobs` to treat dead jobs like running ones.
-5. Results are stored in memory and exposed via `/healthz` (JSON), `/metrics` (Prometheus), and the gRPC API.
-6. The repo is re-checked on every `--poll-interval` (git fetch), on every `--diff-interval` (Nomad-side drift), and immediately on a webhook push event or a `TriggerRefresh` gRPC call. When `--max-git-staleness` or `--max-nomad-staleness` is set, a dedicated background goroutine for each forces a refresh if the respective source has not been updated within the configured window — useful when webhooks are unreliable or paused. The two timers are independent and can be set or disabled individually.
+6. Results are stored in memory and exposed via `/healthz` (JSON), `/metrics` (Prometheus), and the gRPC API.
+7. The repo is re-checked on every `--poll-interval` (git fetch), on every `--diff-interval` (Nomad-side drift), and immediately on a webhook push event or a `TriggerRefresh` gRPC call. When `--max-git-staleness` or `--max-nomad-staleness` is set, a dedicated background goroutine for each forces a refresh if the respective source has not been updated within the configured window — useful when webhooks are unreliable or paused. The two timers are independent and can be set or disabled individually.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The design proposals for job application and change checkpointing are in
 
 1. On startup, the repo is cloned entirely into memory using [go-git](https://github.com/go-git/go-git).
 2. All `.hcl` files under `--hcl-dir` (default: repo root) are sent to Nomad's `/v1/jobs/parse` endpoint to produce canonical `Job` structs.
-3. Each parsed job is checked against the configured **job selection criteria** (see [Job selection](#job-selection)). Jobs that do not match are ignored.
+3. Each parsed job is checked against the configured **job selection criteria** (see [Job selection](#job-selection)). Jobs that match neither the glob nor the `<prefix>.managed` meta key are ignored.
 4. For each selected job:
    - If the job is **not registered** in Nomad, or is registered but in **`dead` state** → `missing_from_nomad`
    - If the job **is registered and live**, `nomad job plan` is run → if the plan shows changes → `modified`
@@ -77,9 +77,11 @@ nomad-botherer does not watch every job in a cluster by default. A job must matc
 | Criterion | Flag | Default |
 |-----------|------|---------|
 | Name glob | `--job-selector-glob` | *(empty — no glob selection)* |
-| Meta tag | `--managed-meta-key` | `gitops.managed` |
+| Meta prefix | `--managed-meta-prefix` | `gitops` |
 
-The two criteria are a **union**: a job is selected if it matches the glob *or* has the meta key set to `"true"`. With the defaults (no glob, meta key `gitops.managed`), only jobs that declare the meta key in their HCL are watched.
+The two criteria are a **union**: a job is selected if it matches the glob *or* has the `<prefix>.managed` meta key set to `"true"`. With the defaults (no glob, prefix `gitops`), only jobs declaring `gitops.managed = "true"` in their HCL meta stanza are watched.
+
+The prefix is a namespace for all meta keys nomad-botherer reads or writes. Using `gitops` means the opt-in key is `gitops.managed`, and future attributes will follow the same `gitops.<attribute>` pattern. Use a different prefix if another team or tool already owns `gitops.*` on your cluster.
 
 **Opting a job in via meta tag (default method):**
 
@@ -104,19 +106,20 @@ job "my-service" {
 ./nomad-botherer --job-selector-glob='production-*' ...
 ```
 
-**Changing the meta key name** (useful when sharing a cluster with multiple teams or tools):
+**Changing the meta prefix** (useful when sharing a cluster with multiple teams or tools):
 
 ```bash
-./nomad-botherer --managed-meta-key='myorg.managed' ...
+./nomad-botherer --managed-meta-prefix='myorg' ...
+# opts in jobs with meta { "myorg.managed" = "true" }
 ```
 
 **Disabling meta-based selection entirely** (glob only):
 
 ```bash
-./nomad-botherer --managed-meta-key='' --job-selector-glob='myprefix-*' ...
+./nomad-botherer --managed-meta-prefix='' --job-selector-glob='myprefix-*' ...
 ```
 
-If both `--job-selector-glob` and `--managed-meta-key` are empty, no jobs are selected and no diffs will be reported. The current selection criteria are shown on the `/` status page.
+If both `--job-selector-glob` and `--managed-meta-prefix` are empty, no jobs are selected and no diffs will be reported. The current selection criteria are shown on the `/` status page.
 
 ---
 
@@ -199,8 +202,8 @@ Every flag has a corresponding environment variable. Environment variables are r
 | `--grpc-api-key` | `GRPC_API_KEY` | | Pre-shared API key for gRPC authentication. Required when `--grpc-listen-addr` is non-empty |
 | `--diff-interval` | `DIFF_INTERVAL` | `1m` | Periodic Nomad-side drift check interval |
 | `--include-dead-jobs` | `INCLUDE_DEAD_JOBS` | `false` | Treat dead Nomad jobs like running ones (by default dead jobs count as missing) |
-| `--job-selector-glob` | `JOB_SELECTOR_GLOB` | *(empty — no glob)* | Glob pattern selecting jobs to watch by name (e.g. `myprefix-*`, `*` for all). Combined with `--managed-meta-key` as a union. |
-| `--managed-meta-key` | `MANAGED_META_KEY` | `gitops.managed` | Job HCL meta key that opts a job into management. The value must be `"true"`. Set to empty string to disable meta-based selection. |
+| `--job-selector-glob` | `JOB_SELECTOR_GLOB` | *(empty — no glob)* | Glob pattern selecting jobs to watch by name (e.g. `myprefix-*`, `*` for all). Combined with `--managed-meta-prefix` as a union. |
+| `--managed-meta-prefix` | `MANAGED_META_PREFIX` | `gitops` | Prefix for job meta keys used by nomad-botherer. With prefix `gitops`, the key `gitops.managed=true` opts a job in. Empty disables meta-based selection. |
 | `--max-git-staleness` | `MAX_GIT_STALENESS` | `0` (disabled) | If the git repo has not been successfully fetched within this window, force an immediate fetch. Set to `0` to disable. E.g. `--max-git-staleness=30m` |
 | `--max-nomad-staleness` | `MAX_NOMAD_STALENESS` | `0` (disabled) | If the Nomad diff check has not run within this window, force an immediate check. Set to `0` to disable. E.g. `--max-nomad-staleness=10m` |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Three kinds of drift are tracked:
 
 - [Design and prior art](#design-and-prior-art)
 - [How it works](#how-it-works)
+- [Job selection](#job-selection)
 - [Installation](#installation)
 - [Quick start](#quick-start)
 - [Configuration](#configuration)
@@ -57,14 +58,65 @@ The design proposals for job application and change checkpointing are in
 
 1. On startup, the repo is cloned entirely into memory using [go-git](https://github.com/go-git/go-git).
 2. All `.hcl` files under `--hcl-dir` (default: repo root) are sent to Nomad's `/v1/jobs/parse` endpoint to produce canonical `Job` structs.
-3. For each parsed job:
+3. Each parsed job is checked against the configured **job selection criteria** (see [Job selection](#job-selection)). Jobs that do not match are ignored.
+4. For each selected job:
    - If the job is **not registered** in Nomad, or is registered but in **`dead` state** → `missing_from_nomad`
    - If the job **is registered and live**, `nomad job plan` is run → if the plan shows changes → `modified`
-4. All jobs **currently running in Nomad** (non-dead) that have no corresponding HCL file → `missing_from_hcl`
+5. All jobs **currently running in Nomad** (non-dead) that match the selection criteria but have no corresponding HCL file → `missing_from_hcl`
 
    Dead jobs are excluded from both checks by default because a stopped job is expected state — it was intentionally halted. Pass `--include-dead-jobs` to treat dead jobs like running ones.
 5. Results are stored in memory and exposed via `/healthz` (JSON), `/metrics` (Prometheus), and the gRPC API.
 6. The repo is re-checked on every `--poll-interval` (git fetch), on every `--diff-interval` (Nomad-side drift), and immediately on a webhook push event or a `TriggerRefresh` gRPC call. When `--max-git-staleness` or `--max-nomad-staleness` is set, a dedicated background goroutine for each forces a refresh if the respective source has not been updated within the configured window — useful when webhooks are unreliable or paused. The two timers are independent and can be set or disabled individually.
+
+---
+
+## Job selection
+
+nomad-botherer does not watch every job in a cluster by default. A job must match at least one of the configured selection criteria to be diffed:
+
+| Criterion | Flag | Default |
+|-----------|------|---------|
+| Name glob | `--job-selector-glob` | *(empty — no glob selection)* |
+| Meta tag | `--managed-meta-key` | `gitops.managed` |
+
+The two criteria are a **union**: a job is selected if it matches the glob *or* has the meta key set to `"true"`. With the defaults (no glob, meta key `gitops.managed`), only jobs that declare the meta key in their HCL are watched.
+
+**Opting a job in via meta tag (default method):**
+
+```hcl
+job "my-service" {
+  meta {
+    "gitops.managed" = "true"
+  }
+  # ...rest of job definition
+}
+```
+
+**Watching all jobs in a directory:**
+
+```bash
+./nomad-botherer --job-selector-glob='*' ...
+```
+
+**Watching a named prefix:**
+
+```bash
+./nomad-botherer --job-selector-glob='production-*' ...
+```
+
+**Changing the meta key name** (useful when sharing a cluster with multiple teams or tools):
+
+```bash
+./nomad-botherer --managed-meta-key='myorg.managed' ...
+```
+
+**Disabling meta-based selection entirely** (glob only):
+
+```bash
+./nomad-botherer --managed-meta-key='' --job-selector-glob='myprefix-*' ...
+```
+
+If both `--job-selector-glob` and `--managed-meta-key` are empty, no jobs are selected and no diffs will be reported. The current selection criteria are shown on the `/` status page.
 
 ---
 
@@ -147,6 +199,8 @@ Every flag has a corresponding environment variable. Environment variables are r
 | `--grpc-api-key` | `GRPC_API_KEY` | | Pre-shared API key for gRPC authentication. Required when `--grpc-listen-addr` is non-empty |
 | `--diff-interval` | `DIFF_INTERVAL` | `1m` | Periodic Nomad-side drift check interval |
 | `--include-dead-jobs` | `INCLUDE_DEAD_JOBS` | `false` | Treat dead Nomad jobs like running ones (by default dead jobs count as missing) |
+| `--job-selector-glob` | `JOB_SELECTOR_GLOB` | *(empty — no glob)* | Glob pattern selecting jobs to watch by name (e.g. `myprefix-*`, `*` for all). Combined with `--managed-meta-key` as a union. |
+| `--managed-meta-key` | `MANAGED_META_KEY` | `gitops.managed` | Job HCL meta key that opts a job into management. The value must be `"true"`. Set to empty string to disable meta-based selection. |
 | `--max-git-staleness` | `MAX_GIT_STALENESS` | `0` (disabled) | If the git repo has not been successfully fetched within this window, force an immediate fetch. Set to `0` to disable. E.g. `--max-git-staleness=30m` |
 | `--max-nomad-staleness` | `MAX_NOMAD_STALENESS` | `0` (disabled) | If the Nomad diff check has not run within this window, force an immediate check. Set to `0` to disable. E.g. `--max-nomad-staleness=10m` |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,10 @@ type Config struct {
 	DiffInterval    time.Duration
 	IncludeDeadJobs bool
 
+	// Job selection
+	JobSelectorGlob string
+	ManagedMetaKey  string
+
 	// Staleness
 	MaxGitStaleness   time.Duration
 	MaxNomadStaleness time.Duration
@@ -75,6 +79,8 @@ func LoadFromArgs(fs *flag.FlagSet, args []string) (*Config, error) {
 
 	fs.DurationVar(&c.DiffInterval, "diff-interval", envDurationOrDefault("DIFF_INTERVAL", time.Minute), "How often to run a diff check regardless of git changes")
 	fs.BoolVar(&c.IncludeDeadJobs, "include-dead-jobs", envBoolOrDefault("INCLUDE_DEAD_JOBS", false), "Treat dead Nomad jobs like running ones (by default dead jobs are treated as missing)")
+	fs.StringVar(&c.JobSelectorGlob, "job-selector-glob", envOrDefault("JOB_SELECTOR_GLOB", ""), "Glob pattern selecting jobs by name (e.g. 'myprefix-*', '*' for all). Jobs matching either this or --managed-meta-key are watched. Empty means no glob selection.")
+	fs.StringVar(&c.ManagedMetaKey, "managed-meta-key", envOrDefault("MANAGED_META_KEY", "gitops.managed"), "Job meta key that opts a job into management (value must be 'true'). Empty disables meta-based selection.")
 	fs.DurationVar(&c.MaxGitStaleness, "max-git-staleness", envDurationOrDefault("MAX_GIT_STALENESS", 0), "Maximum time since last successful git fetch before forcing a refresh (0 disables)")
 	fs.DurationVar(&c.MaxNomadStaleness, "max-nomad-staleness", envDurationOrDefault("MAX_NOMAD_STALENESS", 0), "Maximum time since last successful Nomad diff check before forcing a refresh (0 disables)")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,8 +37,8 @@ type Config struct {
 	IncludeDeadJobs bool
 
 	// Job selection
-	JobSelectorGlob string
-	ManagedMetaKey  string
+	JobSelectorGlob   string
+	ManagedMetaPrefix string
 
 	// Staleness
 	MaxGitStaleness   time.Duration
@@ -79,8 +79,8 @@ func LoadFromArgs(fs *flag.FlagSet, args []string) (*Config, error) {
 
 	fs.DurationVar(&c.DiffInterval, "diff-interval", envDurationOrDefault("DIFF_INTERVAL", time.Minute), "How often to run a diff check regardless of git changes")
 	fs.BoolVar(&c.IncludeDeadJobs, "include-dead-jobs", envBoolOrDefault("INCLUDE_DEAD_JOBS", false), "Treat dead Nomad jobs like running ones (by default dead jobs are treated as missing)")
-	fs.StringVar(&c.JobSelectorGlob, "job-selector-glob", envOrDefault("JOB_SELECTOR_GLOB", ""), "Glob pattern selecting jobs by name (e.g. 'myprefix-*', '*' for all). Jobs matching either this or --managed-meta-key are watched. Empty means no glob selection.")
-	fs.StringVar(&c.ManagedMetaKey, "managed-meta-key", envOrDefault("MANAGED_META_KEY", "gitops.managed"), "Job meta key that opts a job into management (value must be 'true'). Empty disables meta-based selection.")
+	fs.StringVar(&c.JobSelectorGlob, "job-selector-glob", envOrDefault("JOB_SELECTOR_GLOB", ""), "Glob pattern selecting jobs by name (e.g. 'myprefix-*', '*' for all). Jobs matching either this or --managed-meta-prefix are watched. Empty means no glob selection.")
+	fs.StringVar(&c.ManagedMetaPrefix, "managed-meta-prefix", envOrDefault("MANAGED_META_PREFIX", "gitops"), "Prefix for job meta keys used by nomad-botherer (e.g. 'gitops' means 'gitops.managed' opts a job in). Empty disables meta-based selection.")
 	fs.DurationVar(&c.MaxGitStaleness, "max-git-staleness", envDurationOrDefault("MAX_GIT_STALENESS", 0), "Maximum time since last successful git fetch before forcing a refresh (0 disables)")
 	fs.DurationVar(&c.MaxNomadStaleness, "max-nomad-staleness", envDurationOrDefault("MAX_NOMAD_STALENESS", 0), "Maximum time since last successful Nomad diff check before forcing a refresh (0 disables)")
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -110,7 +110,7 @@ func TestLoadFromArgs_Defaults(t *testing.T) {
 	for _, k := range []string{
 		"GIT_REPO_URL", "GIT_BRANCH", "NOMAD_ADDR", "NOMAD_NAMESPACE",
 		"LISTEN_ADDR", "WEBHOOK_PATH", "LOG_LEVEL", "POLL_INTERVAL", "DIFF_INTERVAL",
-		"JOB_SELECTOR_GLOB", "MANAGED_META_KEY",
+		"JOB_SELECTOR_GLOB", "MANAGED_META_PREFIX",
 	} {
 		os.Unsetenv(k)
 	}
@@ -132,7 +132,7 @@ func TestLoadFromArgs_Defaults(t *testing.T) {
 		{"WebhookPath", cfg.WebhookPath, "/webhook"},
 		{"LogLevel", cfg.LogLevel, "info"},
 		{"JobSelectorGlob", cfg.JobSelectorGlob, ""},
-		{"ManagedMetaKey", cfg.ManagedMetaKey, "gitops.managed"},
+		{"ManagedMetaPrefix", cfg.ManagedMetaPrefix, "gitops"},
 	}
 	for _, c := range checks {
 		if c.got != c.want {
@@ -403,54 +403,54 @@ func TestLoadFromArgs_GRPCDisabled(t *testing.T) {
 	}
 }
 
-func TestLoadFromArgs_ManagedMetaKeyDefault(t *testing.T) {
-	os.Unsetenv("MANAGED_META_KEY")
+func TestLoadFromArgs_ManagedMetaPrefixDefault(t *testing.T) {
+	os.Unsetenv("MANAGED_META_PREFIX")
 	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.ManagedMetaKey != "gitops.managed" {
-		t.Errorf("ManagedMetaKey: want gitops.managed, got %q", cfg.ManagedMetaKey)
+	if cfg.ManagedMetaPrefix != "gitops" {
+		t.Errorf("ManagedMetaPrefix: want gitops, got %q", cfg.ManagedMetaPrefix)
 	}
 }
 
-func TestLoadFromArgs_ManagedMetaKeyFlag(t *testing.T) {
-	os.Unsetenv("MANAGED_META_KEY")
+func TestLoadFromArgs_ManagedMetaPrefixFlag(t *testing.T) {
+	os.Unsetenv("MANAGED_META_PREFIX")
 	cfg, err := LoadFromArgs(newFS(), []string{
 		"--repo-url", "https://example.com/r.git",
-		"--managed-meta-key", "myorg.managed",
+		"--managed-meta-prefix", "myorg",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.ManagedMetaKey != "myorg.managed" {
-		t.Errorf("ManagedMetaKey: want myorg.managed, got %q", cfg.ManagedMetaKey)
+	if cfg.ManagedMetaPrefix != "myorg" {
+		t.Errorf("ManagedMetaPrefix: want myorg, got %q", cfg.ManagedMetaPrefix)
 	}
 }
 
-func TestLoadFromArgs_ManagedMetaKeyEnv(t *testing.T) {
-	os.Setenv("MANAGED_META_KEY", "acme.gitops")
-	t.Cleanup(func() { os.Unsetenv("MANAGED_META_KEY") })
+func TestLoadFromArgs_ManagedMetaPrefixEnv(t *testing.T) {
+	os.Setenv("MANAGED_META_PREFIX", "acme")
+	t.Cleanup(func() { os.Unsetenv("MANAGED_META_PREFIX") })
 	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.ManagedMetaKey != "acme.gitops" {
-		t.Errorf("ManagedMetaKey: want acme.gitops, got %q", cfg.ManagedMetaKey)
+	if cfg.ManagedMetaPrefix != "acme" {
+		t.Errorf("ManagedMetaPrefix: want acme, got %q", cfg.ManagedMetaPrefix)
 	}
 }
 
-func TestLoadFromArgs_ManagedMetaKeyEmpty(t *testing.T) {
-	os.Unsetenv("MANAGED_META_KEY")
+func TestLoadFromArgs_ManagedMetaPrefixEmpty(t *testing.T) {
+	os.Unsetenv("MANAGED_META_PREFIX")
 	cfg, err := LoadFromArgs(newFS(), []string{
 		"--repo-url", "https://example.com/r.git",
-		"--managed-meta-key", "",
+		"--managed-meta-prefix", "",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.ManagedMetaKey != "" {
-		t.Errorf("ManagedMetaKey: want empty (disabled), got %q", cfg.ManagedMetaKey)
+	if cfg.ManagedMetaPrefix != "" {
+		t.Errorf("ManagedMetaPrefix: want empty (disabled), got %q", cfg.ManagedMetaPrefix)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -110,6 +110,7 @@ func TestLoadFromArgs_Defaults(t *testing.T) {
 	for _, k := range []string{
 		"GIT_REPO_URL", "GIT_BRANCH", "NOMAD_ADDR", "NOMAD_NAMESPACE",
 		"LISTEN_ADDR", "WEBHOOK_PATH", "LOG_LEVEL", "POLL_INTERVAL", "DIFF_INTERVAL",
+		"JOB_SELECTOR_GLOB", "MANAGED_META_KEY",
 	} {
 		os.Unsetenv(k)
 	}
@@ -130,6 +131,8 @@ func TestLoadFromArgs_Defaults(t *testing.T) {
 		{"ListenAddr", cfg.ListenAddr, ":8080"},
 		{"WebhookPath", cfg.WebhookPath, "/webhook"},
 		{"LogLevel", cfg.LogLevel, "info"},
+		{"JobSelectorGlob", cfg.JobSelectorGlob, ""},
+		{"ManagedMetaKey", cfg.ManagedMetaKey, "gitops.managed"},
 	}
 	for _, c := range checks {
 		if c.got != c.want {
@@ -397,5 +400,93 @@ func TestLoadFromArgs_GRPCDisabled(t *testing.T) {
 	}
 	if cfg.GRPCListenAddr != "" {
 		t.Errorf("GRPCListenAddr: want empty (disabled), got %q", cfg.GRPCListenAddr)
+	}
+}
+
+func TestLoadFromArgs_ManagedMetaKeyDefault(t *testing.T) {
+	os.Unsetenv("MANAGED_META_KEY")
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ManagedMetaKey != "gitops.managed" {
+		t.Errorf("ManagedMetaKey: want gitops.managed, got %q", cfg.ManagedMetaKey)
+	}
+}
+
+func TestLoadFromArgs_ManagedMetaKeyFlag(t *testing.T) {
+	os.Unsetenv("MANAGED_META_KEY")
+	cfg, err := LoadFromArgs(newFS(), []string{
+		"--repo-url", "https://example.com/r.git",
+		"--managed-meta-key", "myorg.managed",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ManagedMetaKey != "myorg.managed" {
+		t.Errorf("ManagedMetaKey: want myorg.managed, got %q", cfg.ManagedMetaKey)
+	}
+}
+
+func TestLoadFromArgs_ManagedMetaKeyEnv(t *testing.T) {
+	os.Setenv("MANAGED_META_KEY", "acme.gitops")
+	t.Cleanup(func() { os.Unsetenv("MANAGED_META_KEY") })
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ManagedMetaKey != "acme.gitops" {
+		t.Errorf("ManagedMetaKey: want acme.gitops, got %q", cfg.ManagedMetaKey)
+	}
+}
+
+func TestLoadFromArgs_ManagedMetaKeyEmpty(t *testing.T) {
+	os.Unsetenv("MANAGED_META_KEY")
+	cfg, err := LoadFromArgs(newFS(), []string{
+		"--repo-url", "https://example.com/r.git",
+		"--managed-meta-key", "",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ManagedMetaKey != "" {
+		t.Errorf("ManagedMetaKey: want empty (disabled), got %q", cfg.ManagedMetaKey)
+	}
+}
+
+func TestLoadFromArgs_JobSelectorGlobDefault(t *testing.T) {
+	os.Unsetenv("JOB_SELECTOR_GLOB")
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.JobSelectorGlob != "" {
+		t.Errorf("JobSelectorGlob: want empty (no glob), got %q", cfg.JobSelectorGlob)
+	}
+}
+
+func TestLoadFromArgs_JobSelectorGlobFlag(t *testing.T) {
+	os.Unsetenv("JOB_SELECTOR_GLOB")
+	cfg, err := LoadFromArgs(newFS(), []string{
+		"--repo-url", "https://example.com/r.git",
+		"--job-selector-glob", "prod-*",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.JobSelectorGlob != "prod-*" {
+		t.Errorf("JobSelectorGlob: want prod-*, got %q", cfg.JobSelectorGlob)
+	}
+}
+
+func TestLoadFromArgs_JobSelectorGlobEnv(t *testing.T) {
+	os.Setenv("JOB_SELECTOR_GLOB", "myapp-*")
+	t.Cleanup(func() { os.Unsetenv("JOB_SELECTOR_GLOB") })
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.JobSelectorGlob != "myapp-*" {
+		t.Errorf("JobSelectorGlob: want myapp-*, got %q", cfg.JobSelectorGlob)
 	}
 }

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -65,8 +65,8 @@ type Differ struct {
 	jobs            NomadJobsClient
 	namespace       string
 	includeDeadJobs bool
-	jobSelectorGlob string
-	managedMetaKey  string
+	jobSelectorGlob   string
+	managedMetaPrefix string
 
 	mu              sync.RWMutex
 	diffs           []JobDiff
@@ -89,14 +89,14 @@ type Differ struct {
 }
 
 // newDifferBase constructs a Differ with metrics registered into reg.
-func newDifferBase(jobs NomadJobsClient, namespace string, includeDeadJobs bool, jobSelectorGlob, managedMetaKey string, reg prometheus.Registerer) *Differ {
+func newDifferBase(jobs NomadJobsClient, namespace string, includeDeadJobs bool, jobSelectorGlob, managedMetaPrefix string, reg prometheus.Registerer) *Differ {
 	f := promauto.With(reg)
 	return &Differ{
-		jobs:            jobs,
-		namespace:       namespace,
-		includeDeadJobs: includeDeadJobs,
-		jobSelectorGlob: jobSelectorGlob,
-		managedMetaKey:  managedMetaKey,
+		jobs:              jobs,
+		namespace:         namespace,
+		includeDeadJobs:   includeDeadJobs,
+		jobSelectorGlob:   jobSelectorGlob,
+		managedMetaPrefix: managedMetaPrefix,
 		driftFirstSeen:  make(map[string]time.Time),
 		hclParseErrors: f.NewCounter(prometheus.CounterOpts{
 			Name: "nomad_botherer_hcl_parse_errors_total",
@@ -158,31 +158,31 @@ func NewDiffer(cfg *config.Config) (*Differ, error) {
 		return nil, fmt.Errorf("creating nomad client: %w", err)
 	}
 
-	return newDifferBase(client.Jobs(), cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaKey, prometheus.DefaultRegisterer), nil
+	return newDifferBase(client.Jobs(), cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaPrefix, prometheus.DefaultRegisterer), nil
 }
 
 // NewWithClient creates a Differ with a custom jobs client, intended for tests.
 func NewWithClient(cfg *config.Config, jobs NomadJobsClient) *Differ {
-	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaKey, prometheus.NewRegistry())
+	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaPrefix, prometheus.NewRegistry())
 }
 
 // NewWithClientAndRegistry creates a Differ with a custom jobs client and Prometheus
 // registry. Use this in tests that need to inspect metric values.
 func NewWithClientAndRegistry(cfg *config.Config, jobs NomadJobsClient, reg prometheus.Registerer) *Differ {
-	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaKey, reg)
+	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaPrefix, reg)
 }
 
 // jobIsSelected reports whether a job should be watched. A job is selected when
-// its ID matches the configured glob pattern, or when its meta map contains the
-// configured managed meta key with the value "true". If both glob and meta key
-// are empty, no jobs are selected.
+// its ID matches the configured glob pattern, or when its meta map contains
+// "<managedMetaPrefix>.managed" set to "true". If both are empty, no jobs
+// are selected.
 func (d *Differ) jobIsSelected(jobID string, meta map[string]string) bool {
 	if d.jobSelectorGlob != "" {
 		if matched, _ := path.Match(d.jobSelectorGlob, jobID); matched {
 			return true
 		}
 	}
-	if d.managedMetaKey != "" && meta[d.managedMetaKey] == "true" {
+	if d.managedMetaPrefix != "" && meta[d.managedMetaPrefix+".managed"] == "true" {
 		return true
 	}
 	return false

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -5,6 +5,7 @@ package nomad
 import (
 	"fmt"
 	"log/slog"
+	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -64,6 +65,8 @@ type Differ struct {
 	jobs            NomadJobsClient
 	namespace       string
 	includeDeadJobs bool
+	jobSelectorGlob string
+	managedMetaKey  string
 
 	mu              sync.RWMutex
 	diffs           []JobDiff
@@ -72,25 +75,28 @@ type Differ struct {
 	lastNomadIndex  uint64            // Raft index from the last successful List(); protected by mu
 	driftFirstSeen  map[string]time.Time // key: driftKey(jobID, diffType); protected by mu
 
-	hclParseErrors    prometheus.Counter
-	hclFilesSkipped   prometheus.Counter
-	diffChecks        prometheus.Counter
-	diffChecksSkipped prometheus.Counter
-	staleChecks       prometheus.Counter
-	nomadAPIErrors    *prometheus.CounterVec
-	lastCheck         prometheus.Gauge
-	jobDiffs          *prometheus.GaugeVec
-	driftedJobs       *prometheus.GaugeVec
-	jobDriftSince     *prometheus.GaugeVec
+	hclParseErrors      prometheus.Counter
+	hclFilesSkipped     prometheus.Counter
+	diffChecks          prometheus.Counter
+	diffChecksSkipped   prometheus.Counter
+	staleChecks         prometheus.Counter
+	jobsSkippedBySel    *prometheus.CounterVec
+	nomadAPIErrors      *prometheus.CounterVec
+	lastCheck           prometheus.Gauge
+	jobDiffs            *prometheus.GaugeVec
+	driftedJobs         *prometheus.GaugeVec
+	jobDriftSince       *prometheus.GaugeVec
 }
 
 // newDifferBase constructs a Differ with metrics registered into reg.
-func newDifferBase(jobs NomadJobsClient, namespace string, includeDeadJobs bool, reg prometheus.Registerer) *Differ {
+func newDifferBase(jobs NomadJobsClient, namespace string, includeDeadJobs bool, jobSelectorGlob, managedMetaKey string, reg prometheus.Registerer) *Differ {
 	f := promauto.With(reg)
 	return &Differ{
 		jobs:            jobs,
 		namespace:       namespace,
 		includeDeadJobs: includeDeadJobs,
+		jobSelectorGlob: jobSelectorGlob,
+		managedMetaKey:  managedMetaKey,
 		driftFirstSeen:  make(map[string]time.Time),
 		hclParseErrors: f.NewCounter(prometheus.CounterOpts{
 			Name: "nomad_botherer_hcl_parse_errors_total",
@@ -112,6 +118,10 @@ func newDifferBase(jobs NomadJobsClient, namespace string, includeDeadJobs bool,
 			Name: "nomad_botherer_nomad_staleness_checks_total",
 			Help: "Total number of Nomad diff checks triggered by the staleness check.",
 		}),
+		jobsSkippedBySel: f.NewCounterVec(prometheus.CounterOpts{
+			Name: "nomad_botherer_jobs_skipped_by_selector_total",
+			Help: "Total number of jobs skipped because they did not match the configured selection criteria, by source (hcl or nomad).",
+		}, []string{"source"}),
 		nomadAPIErrors: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "nomad_botherer_nomad_api_errors_total",
 			Help: "Total number of Nomad API errors by operation.",
@@ -148,18 +158,34 @@ func NewDiffer(cfg *config.Config) (*Differ, error) {
 		return nil, fmt.Errorf("creating nomad client: %w", err)
 	}
 
-	return newDifferBase(client.Jobs(), cfg.NomadNamespace, cfg.IncludeDeadJobs, prometheus.DefaultRegisterer), nil
+	return newDifferBase(client.Jobs(), cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaKey, prometheus.DefaultRegisterer), nil
 }
 
 // NewWithClient creates a Differ with a custom jobs client, intended for tests.
 func NewWithClient(cfg *config.Config, jobs NomadJobsClient) *Differ {
-	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, prometheus.NewRegistry())
+	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaKey, prometheus.NewRegistry())
 }
 
 // NewWithClientAndRegistry creates a Differ with a custom jobs client and Prometheus
 // registry. Use this in tests that need to inspect metric values.
 func NewWithClientAndRegistry(cfg *config.Config, jobs NomadJobsClient, reg prometheus.Registerer) *Differ {
-	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, reg)
+	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaKey, reg)
+}
+
+// jobIsSelected reports whether a job should be watched. A job is selected when
+// its ID matches the configured glob pattern, or when its meta map contains the
+// configured managed meta key with the value "true". If both glob and meta key
+// are empty, no jobs are selected.
+func (d *Differ) jobIsSelected(jobID string, meta map[string]string) bool {
+	if d.jobSelectorGlob != "" {
+		if matched, _ := path.Match(d.jobSelectorGlob, jobID); matched {
+			return true
+		}
+	}
+	if d.managedMetaKey != "" && meta[d.managedMetaKey] == "true" {
+		return true
+	}
+	return false
 }
 
 // Check compares the given HCL files (path → content) against the live Nomad
@@ -215,6 +241,11 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 			continue
 		}
 		jobID := *job.ID
+		if !d.jobIsSelected(jobID, job.Meta) {
+			slog.Debug("Skipping job not matching selection criteria", "job", jobID, "file", filename)
+			d.jobsSkippedBySel.WithLabelValues("hcl").Inc()
+			continue
+		}
 		hclJobs[jobID] = job
 		hclJobFile[jobID] = filename
 		slog.Debug("Parsed HCL file", "file", filename, "job_id", jobID)
@@ -277,8 +308,13 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 	// Find jobs in Nomad that have no corresponding HCL file.
 	// Dead jobs are skipped unless --include-dead-jobs is set, since a dead
 	// job without HCL is expected (it was stopped intentionally).
+	// Only jobs that match the configured selection criteria are considered managed.
 	for _, j := range allJobs {
 		if !d.includeDeadJobs && j.Status == "dead" {
+			continue
+		}
+		if !d.jobIsSelected(j.ID, j.Meta) {
+			d.jobsSkippedBySel.WithLabelValues("nomad").Inc()
 			continue
 		}
 		if _, ok := hclJobs[j.ID]; !ok {

--- a/internal/nomad/differ_test.go
+++ b/internal/nomad/differ_test.go
@@ -63,12 +63,12 @@ func newTestDifferWithDeadJobs(mock *mockJobsClient) *nomad.Differ {
 	return nomad.NewWithClient(cfg, mock)
 }
 
-func newTestDifferWithSelection(mock *mockJobsClient, glob, metaKey string) *nomad.Differ {
+func newTestDifferWithSelection(mock *mockJobsClient, glob, metaPrefix string) *nomad.Differ {
 	cfg := &config.Config{
-		NomadAddr:       "http://localhost:4646",
-		NomadNamespace:  "default",
-		JobSelectorGlob: glob,
-		ManagedMetaKey:  metaKey,
+		NomadAddr:         "http://localhost:4646",
+		NomadNamespace:    "default",
+		JobSelectorGlob:   glob,
+		ManagedMetaPrefix: metaPrefix,
 	}
 	return nomad.NewWithClient(cfg, mock)
 }
@@ -821,7 +821,7 @@ func TestDiffer_GlobSelection_WildcardMatchesAll(t *testing.T) {
 	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
 		return nil, nil, fmt.Errorf("404: not found")
 	}
-	d := newTestDifferWithSelection(mock, "*", "")
+	d := newTestDifferWithSelection(mock, "*", "" /* no meta prefix */)
 
 	if err := d.Check(map[string]string{"job.hcl": `job "any-job" {}`}, "abc"); err != nil {
 		t.Fatal(err)
@@ -844,7 +844,7 @@ func TestDiffer_GlobSelection_PrefixMatch(t *testing.T) {
 	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
 		return nil, nil, fmt.Errorf("404: not found")
 	}
-	d := newTestDifferWithSelection(mock, "prod-*", "")
+	d := newTestDifferWithSelection(mock, "prod-*", "" /* no meta prefix */)
 
 	files := map[string]string{
 		"prod-web.hcl":    `job "prod-web" {}`,
@@ -866,7 +866,7 @@ func TestDiffer_GlobSelection_PrefixMatch(t *testing.T) {
 // silently excluded and produces no diff.
 func TestDiffer_GlobSelection_NoMatch_JobSkipped(t *testing.T) {
 	mock := defaultMock()
-	d := newTestDifferWithSelection(mock, "prod-*", "")
+	d := newTestDifferWithSelection(mock, "prod-*", "" /* no meta prefix */)
 
 	if err := d.Check(map[string]string{"job.hcl": `job "staging-job" {}`}, "abc"); err != nil {
 		t.Fatal(err)
@@ -890,7 +890,7 @@ func TestDiffer_MetaSelection_Matches(t *testing.T) {
 	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
 		return nil, nil, fmt.Errorf("404: not found")
 	}
-	d := newTestDifferWithSelection(mock, "", "gitops.managed")
+	d := newTestDifferWithSelection(mock, "", "gitops")
 
 	if err := d.Check(map[string]string{"job.hcl": `job "managed-job" {}`}, "abc"); err != nil {
 		t.Fatal(err)
@@ -908,7 +908,7 @@ func TestDiffer_MetaSelection_NoTag_JobSkipped(t *testing.T) {
 	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
 		return &nomadapi.Job{ID: strPtr("unmanaged-job"), Meta: nil}, nil
 	}
-	d := newTestDifferWithSelection(mock, "", "gitops.managed")
+	d := newTestDifferWithSelection(mock, "", "gitops")
 
 	if err := d.Check(map[string]string{"job.hcl": `job "unmanaged-job" {}`}, "abc"); err != nil {
 		t.Fatal(err)
@@ -919,19 +919,20 @@ func TestDiffer_MetaSelection_NoTag_JobSkipped(t *testing.T) {
 	}
 }
 
-// TestDiffer_MetaSelection_CustomKey verifies that a custom meta key name works.
-func TestDiffer_MetaSelection_CustomKey(t *testing.T) {
+// TestDiffer_MetaSelection_CustomPrefix verifies that a custom meta prefix works,
+// deriving the full key as "<prefix>.managed".
+func TestDiffer_MetaSelection_CustomPrefix(t *testing.T) {
 	mock := defaultMock()
 	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
 		return &nomadapi.Job{
 			ID:   strPtr("my-job"),
-			Meta: map[string]string{"myorg.watched": "true"},
+			Meta: map[string]string{"myorg.managed": "true"},
 		}, nil
 	}
 	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
 		return nil, nil, fmt.Errorf("404: not found")
 	}
-	d := newTestDifferWithSelection(mock, "", "myorg.watched")
+	d := newTestDifferWithSelection(mock, "", "myorg")
 
 	if err := d.Check(map[string]string{"job.hcl": `job "my-job" {}`}, "abc"); err != nil {
 		t.Fatal(err)
@@ -958,7 +959,7 @@ func TestDiffer_GlobOrMeta_EitherSelects(t *testing.T) {
 	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
 		return nil, nil, fmt.Errorf("404: not found")
 	}
-	d := newTestDifferWithSelection(mock, "by-glob", "gitops.managed")
+	d := newTestDifferWithSelection(mock, "by-glob", "gitops")
 
 	files := map[string]string{
 		"by-glob.hcl": `job "by-glob" {}`,
@@ -982,7 +983,7 @@ func TestDiffer_MissingFromHCL_ManagedByMeta_Reported(t *testing.T) {
 			{ID: "managed-orphan", Status: "running", Meta: map[string]string{"gitops.managed": "true"}},
 		}, nil, nil
 	}
-	d := newTestDifferWithSelection(mock, "", "gitops.managed")
+	d := newTestDifferWithSelection(mock, "", "gitops")
 
 	if err := d.Check(map[string]string{}, "abc"); err != nil {
 		t.Fatal(err)
@@ -1002,7 +1003,7 @@ func TestDiffer_MissingFromHCL_UnmanagedByMeta_NotReported(t *testing.T) {
 			{ID: "unmanaged-job", Status: "running", Meta: nil},
 		}, nil, nil
 	}
-	d := newTestDifferWithSelection(mock, "", "gitops.managed")
+	d := newTestDifferWithSelection(mock, "", "gitops")
 
 	if err := d.Check(map[string]string{}, "abc"); err != nil {
 		t.Fatal(err)
@@ -1043,7 +1044,7 @@ func TestDiffer_NoSelection_NoJobsWatched(t *testing.T) {
 	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
 		return []*nomadapi.JobListStub{{ID: "some-job", Status: "running"}}, nil, nil
 	}
-	d := newTestDifferWithSelection(mock, "", "")
+	d := newTestDifferWithSelection(mock, "", "" /* both empty — nothing selected */)
 
 	if err := d.Check(map[string]string{"job.hcl": `job "some-job" {}`}, "abc"); err != nil {
 		t.Fatal(err)

--- a/internal/nomad/differ_test.go
+++ b/internal/nomad/differ_test.go
@@ -54,12 +54,22 @@ func defaultMock() *mockJobsClient {
 }
 
 func newTestDiffer(mock *mockJobsClient) *nomad.Differ {
-	cfg := &config.Config{NomadAddr: "http://localhost:4646", NomadNamespace: "default"}
+	cfg := &config.Config{NomadAddr: "http://localhost:4646", NomadNamespace: "default", JobSelectorGlob: "*"}
 	return nomad.NewWithClient(cfg, mock)
 }
 
 func newTestDifferWithDeadJobs(mock *mockJobsClient) *nomad.Differ {
-	cfg := &config.Config{NomadAddr: "http://localhost:4646", NomadNamespace: "default", IncludeDeadJobs: true}
+	cfg := &config.Config{NomadAddr: "http://localhost:4646", NomadNamespace: "default", JobSelectorGlob: "*", IncludeDeadJobs: true}
+	return nomad.NewWithClient(cfg, mock)
+}
+
+func newTestDifferWithSelection(mock *mockJobsClient, glob, metaKey string) *nomad.Differ {
+	cfg := &config.Config{
+		NomadAddr:       "http://localhost:4646",
+		NomadNamespace:  "default",
+		JobSelectorGlob: glob,
+		ManagedMetaKey:  metaKey,
+	}
 	return nomad.NewWithClient(cfg, mock)
 }
 
@@ -378,7 +388,7 @@ func TestDiffer_ListError_Skipped(t *testing.T) {
 }
 
 func newTestDifferWithRegistry(mock *mockJobsClient, reg prometheus.Registerer) *nomad.Differ {
-	cfg := &config.Config{NomadAddr: "http://localhost:4646", NomadNamespace: "default"}
+	cfg := &config.Config{NomadAddr: "http://localhost:4646", NomadNamespace: "default", JobSelectorGlob: "*"}
 	return nomad.NewWithClientAndRegistry(cfg, mock, reg)
 }
 
@@ -800,5 +810,246 @@ func TestDiffer_ForceCheck_BypassesSkipOptimization(t *testing.T) {
 	}
 	if infoCalls != firstCalls {
 		t.Errorf("second ForceCheck should have been skipped by Check(); infoCalls went from %d to %d", firstCalls, infoCalls)
+	}
+}
+
+// ── Job selection tests ──────────────────────────────────────────────────────
+
+// TestDiffer_GlobSelection_WildcardMatchesAll verifies that glob="*" selects all jobs.
+func TestDiffer_GlobSelection_WildcardMatchesAll(t *testing.T) {
+	mock := defaultMock()
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return nil, nil, fmt.Errorf("404: not found")
+	}
+	d := newTestDifferWithSelection(mock, "*", "")
+
+	if err := d.Check(map[string]string{"job.hcl": `job "any-job" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 1 || diffs[0].DiffType != nomad.DiffTypeMissingFromNomad {
+		t.Errorf("expected 1 missing_from_nomad diff with wildcard glob, got %+v", diffs)
+	}
+}
+
+// TestDiffer_GlobSelection_PrefixMatch verifies that a prefix glob selects matching jobs.
+func TestDiffer_GlobSelection_PrefixMatch(t *testing.T) {
+	mock := defaultMock()
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		if strings.Contains(jobHCL, "prod-web") {
+			return &nomadapi.Job{ID: strPtr("prod-web")}, nil
+		}
+		return &nomadapi.Job{ID: strPtr("staging-web")}, nil
+	}
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return nil, nil, fmt.Errorf("404: not found")
+	}
+	d := newTestDifferWithSelection(mock, "prod-*", "")
+
+	files := map[string]string{
+		"prod-web.hcl":    `job "prod-web" {}`,
+		"staging-web.hcl": `job "staging-web" {}`,
+	}
+	if err := d.Check(files, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff (only prod-web), got %d: %+v", len(diffs), diffs)
+	}
+	if diffs[0].JobID != "prod-web" {
+		t.Errorf("expected diff for prod-web, got %q", diffs[0].JobID)
+	}
+}
+
+// TestDiffer_GlobSelection_NoMatch_JobSkipped verifies that a non-matching job is
+// silently excluded and produces no diff.
+func TestDiffer_GlobSelection_NoMatch_JobSkipped(t *testing.T) {
+	mock := defaultMock()
+	d := newTestDifferWithSelection(mock, "prod-*", "")
+
+	if err := d.Check(map[string]string{"job.hcl": `job "staging-job" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 0 {
+		t.Errorf("expected 0 diffs for non-matching glob, got %d: %+v", len(diffs), diffs)
+	}
+}
+
+// TestDiffer_MetaSelection_Matches verifies that a job with the managed meta key
+// is selected even when no glob is configured.
+func TestDiffer_MetaSelection_Matches(t *testing.T) {
+	mock := defaultMock()
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		return &nomadapi.Job{
+			ID:   strPtr("managed-job"),
+			Meta: map[string]string{"gitops.managed": "true"},
+		}, nil
+	}
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return nil, nil, fmt.Errorf("404: not found")
+	}
+	d := newTestDifferWithSelection(mock, "", "gitops.managed")
+
+	if err := d.Check(map[string]string{"job.hcl": `job "managed-job" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 1 || diffs[0].DiffType != nomad.DiffTypeMissingFromNomad {
+		t.Errorf("expected 1 missing_from_nomad diff for managed job, got %+v", diffs)
+	}
+}
+
+// TestDiffer_MetaSelection_NoTag_JobSkipped verifies that a job without the managed
+// meta key is excluded when no glob is configured.
+func TestDiffer_MetaSelection_NoTag_JobSkipped(t *testing.T) {
+	mock := defaultMock()
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		return &nomadapi.Job{ID: strPtr("unmanaged-job"), Meta: nil}, nil
+	}
+	d := newTestDifferWithSelection(mock, "", "gitops.managed")
+
+	if err := d.Check(map[string]string{"job.hcl": `job "unmanaged-job" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 0 {
+		t.Errorf("expected 0 diffs for job without meta tag, got %d: %+v", len(diffs), diffs)
+	}
+}
+
+// TestDiffer_MetaSelection_CustomKey verifies that a custom meta key name works.
+func TestDiffer_MetaSelection_CustomKey(t *testing.T) {
+	mock := defaultMock()
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		return &nomadapi.Job{
+			ID:   strPtr("my-job"),
+			Meta: map[string]string{"myorg.watched": "true"},
+		}, nil
+	}
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return nil, nil, fmt.Errorf("404: not found")
+	}
+	d := newTestDifferWithSelection(mock, "", "myorg.watched")
+
+	if err := d.Check(map[string]string{"job.hcl": `job "my-job" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 1 {
+		t.Errorf("expected 1 diff with custom meta key, got %d: %+v", len(diffs), diffs)
+	}
+}
+
+// TestDiffer_GlobOrMeta_EitherSelects verifies that a job matching either the
+// glob or the meta key is included (union, not intersection).
+func TestDiffer_GlobOrMeta_EitherSelects(t *testing.T) {
+	mock := defaultMock()
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		if strings.Contains(jobHCL, "by-glob") {
+			return &nomadapi.Job{ID: strPtr("by-glob"), Meta: nil}, nil
+		}
+		return &nomadapi.Job{
+			ID:   strPtr("by-meta"),
+			Meta: map[string]string{"gitops.managed": "true"},
+		}, nil
+	}
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return nil, nil, fmt.Errorf("404: not found")
+	}
+	d := newTestDifferWithSelection(mock, "by-glob", "gitops.managed")
+
+	files := map[string]string{
+		"by-glob.hcl": `job "by-glob" {}`,
+		"by-meta.hcl": `job "by-meta" {}`,
+	}
+	if err := d.Check(files, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 2 {
+		t.Errorf("expected 2 diffs (one per selector), got %d: %+v", len(diffs), diffs)
+	}
+}
+
+// TestDiffer_MissingFromHCL_ManagedByMeta_Reported verifies that a Nomad job
+// with the managed meta key and no HCL file is reported as missing_from_hcl.
+func TestDiffer_MissingFromHCL_ManagedByMeta_Reported(t *testing.T) {
+	mock := defaultMock()
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return []*nomadapi.JobListStub{
+			{ID: "managed-orphan", Status: "running", Meta: map[string]string{"gitops.managed": "true"}},
+		}, nil, nil
+	}
+	d := newTestDifferWithSelection(mock, "", "gitops.managed")
+
+	if err := d.Check(map[string]string{}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 1 || diffs[0].DiffType != nomad.DiffTypeMissingFromHCL {
+		t.Errorf("expected 1 missing_from_hcl diff for managed orphan, got %+v", diffs)
+	}
+}
+
+// TestDiffer_MissingFromHCL_UnmanagedByMeta_NotReported verifies that a Nomad
+// job without the managed meta key is not reported as missing_from_hcl.
+func TestDiffer_MissingFromHCL_UnmanagedByMeta_NotReported(t *testing.T) {
+	mock := defaultMock()
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return []*nomadapi.JobListStub{
+			{ID: "unmanaged-job", Status: "running", Meta: nil},
+		}, nil, nil
+	}
+	d := newTestDifferWithSelection(mock, "", "gitops.managed")
+
+	if err := d.Check(map[string]string{}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 0 {
+		t.Errorf("expected 0 diffs for unmanaged Nomad job, got %d: %+v", len(diffs), diffs)
+	}
+}
+
+// TestDiffer_MissingFromHCL_ManagedByGlob_Reported verifies that a Nomad job
+// matching the glob but with no HCL file is reported as missing_from_hcl.
+func TestDiffer_MissingFromHCL_ManagedByGlob_Reported(t *testing.T) {
+	mock := defaultMock()
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return []*nomadapi.JobListStub{
+			{ID: "prod-web", Status: "running"},
+		}, nil, nil
+	}
+	d := newTestDifferWithSelection(mock, "prod-*", "")
+
+	if err := d.Check(map[string]string{}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 1 || diffs[0].DiffType != nomad.DiffTypeMissingFromHCL {
+		t.Errorf("expected 1 missing_from_hcl for glob-matched job, got %+v", diffs)
+	}
+}
+
+// TestDiffer_NoSelection_NoJobsWatched verifies that with both glob and meta key
+// empty, no jobs are selected and no diffs are reported.
+func TestDiffer_NoSelection_NoJobsWatched(t *testing.T) {
+	mock := defaultMock()
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return nil, nil, fmt.Errorf("404: not found")
+	}
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return []*nomadapi.JobListStub{{ID: "some-job", Status: "running"}}, nil, nil
+	}
+	d := newTestDifferWithSelection(mock, "", "")
+
+	if err := d.Check(map[string]string{"job.hcl": `job "some-job" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 0 {
+		t.Errorf("expected 0 diffs with no selection criteria, got %d: %+v", len(diffs), diffs)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,6 +203,11 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	lastFail := s.lastWebhookFailure
 	s.webhookMu.RUnlock()
 
+	managedMetaKey := ""
+	if s.cfg.ManagedMetaPrefix != "" {
+		managedMetaKey = s.cfg.ManagedMetaPrefix + ".managed"
+	}
+
 	data := struct {
 		Version         string
 		Starting        bool
@@ -219,7 +224,7 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		DiffCount:      len(diffs),
 		Commit:         commit,
 		SelectionGlob:  s.cfg.JobSelectorGlob,
-		ManagedMetaKey: s.cfg.ManagedMetaKey,
+		ManagedMetaKey: managedMetaKey,
 	}
 	if !lastCheck.IsZero() {
 		data.LastCheck = lastCheck.Format(time.RFC3339)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -161,6 +161,15 @@ var indexTmpl = template.Must(template.New("index").Parse(`<!DOCTYPE html>
     <span class="ok">OK — no differences</span>
     {{- end}}
   </p>
+  <p>Watching:
+    {{- if .SelectionGlob}} jobs matching <code>{{.SelectionGlob}}</code>{{end}}
+    {{- if and .SelectionGlob .ManagedMetaKey}}, or{{end}}
+    {{- if .ManagedMetaKey}} jobs with <code>{{.ManagedMetaKey}}=true</code> in job meta{{end}}
+    {{- if not (or .SelectionGlob .ManagedMetaKey)}} <em>no jobs — no selection criteria configured</em>{{end}}
+  </p>
+  {{- if .ManagedMetaKey}}
+  <p><small>To include a job, add <code>meta { &#34;{{.ManagedMetaKey}}&#34; = &#34;true&#34; }</code> to its HCL definition.</small></p>
+  {{- end}}
   {{- if .LastCheck}}
   <p>Last diff check: {{.LastCheck}}{{if .Commit}} (commit <code>{{.Commit}}</code>){{end}}</p>
   {{- end}}
@@ -202,11 +211,15 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		Commit          string
 		LastWebhookOK   string
 		LastWebhookFail string
+		SelectionGlob   string
+		ManagedMetaKey  string
 	}{
-		Version:   s.version,
-		Starting:  starting,
-		DiffCount: len(diffs),
-		Commit:    commit,
+		Version:        s.version,
+		Starting:       starting,
+		DiffCount:      len(diffs),
+		Commit:         commit,
+		SelectionGlob:  s.cfg.JobSelectorGlob,
+		ManagedMetaKey: s.cfg.ManagedMetaKey,
 	}
 	if !lastCheck.IsZero() {
 		data.LastCheck = lastCheck.Format(time.RFC3339)


### PR DESCRIPTION
## What changed

Two new flags control which jobs nomad-botherer watches:

- `--job-selector-glob` / `JOB_SELECTOR_GLOB` — a `path.Match` glob on job ID (e.g. `prod-*`, `*` for all). Default: empty (no glob selection).
- `--managed-meta-prefix` / `MANAGED_META_PREFIX` — a meta key prefix; jobs where `<prefix>.managed = "true"` in their HCL meta stanza are opted in. Default: `gitops` (derived key: `gitops.managed`). Empty disables meta-based selection.

The two criteria are a union: a job is selected if it matches either one.

With the defaults (no glob, meta prefix `gitops`), only jobs that declare `meta { "gitops.managed" = "true" }` are diffed. This is the design described in CLAUDE.md and the proposals docs — explicit opt-in, no accidental touching of manually-managed jobs.

## How selection is applied

- **HCL side**: after parsing a job from git, if it doesn't match the selection criteria the job is silently skipped (debug log, counter incremented).
- **Nomad side**: in the `missing_from_hcl` loop, jobs that don't match are excluded. `JobListStub.Meta` is used directly so no extra `Jobs.Info()` calls are needed.

## Web UI

The `/` status page now shows a one-line "Watching:" summary of the active criteria. When meta-based selection is active it also shows a short note explaining how to opt a job in via the meta stanza.

## Metrics

New counter: `nomad_botherer_jobs_skipped_by_selector_total{source}` — tracks skips by source (`hcl` or `nomad`).

## Tests

11 new tests covering: wildcard glob, prefix glob, non-matching glob, meta key match, meta key miss, custom meta prefix, glob-or-meta union, missing_from_hcl with managed/unmanaged jobs, and the no-selection-no-diffs edge case.

Existing tests were updated to use `JobSelectorGlob: "*"` so they remain selection-agnostic.

## Docs

New "Job selection" section in README with examples for common configurations. Updated "How it works" step 3. Updated configuration table.

## What to test

- Run with no flags: only jobs with `meta { "gitops.managed" = "true" }` should appear in diffs.
- Run with `--job-selector-glob='*'`: all jobs in the HCL dir should be diffed.
- Run with `--job-selector-glob='myprefix-*'`: only matching jobs.
- Run with `--managed-meta-prefix=''` and a glob: only glob-matched jobs.
- Check the `/` page shows the active criteria and the meta hint when applicable.