### PR TITLE
Fix three security bugs: SSH MITM, HTTP slowloris, unsigned webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Every flag has a corresponding environment variable. Environment variables are r
 | `--git-token` | `GIT_TOKEN` | | HTTP token for private repos (GitHub PAT etc.) |
 | `--git-ssh-key` | `GIT_SSH_KEY` | | Path to SSH private key |
 | `--git-ssh-key-password` | `GIT_SSH_KEY_PASSWORD` | | SSH key passphrase |
+| `--git-ssh-known-hosts` | `GIT_SSH_KNOWN_HOSTS` | `~/.ssh/known_hosts` | Path to known_hosts file for SSH host key verification; required when using SSH auth. Defaults to the system known_hosts locations. Omit to allow the default search, or set explicitly to a specific file. |
 | `--nomad-addr` | `NOMAD_ADDR` | `http://127.0.0.1:4646` | Nomad API address |
 | `--nomad-token` | `NOMAD_TOKEN` | | Nomad ACL token |
 | `--nomad-namespace` | `NOMAD_NAMESPACE` | `default` | Nomad namespace |

--- a/cmd/nbctl/root.go
+++ b/cmd/nbctl/root.go
@@ -72,7 +72,7 @@ func (cfg *rootConfig) dial() (grpcapi.NomadBothererClient, func(), error) {
 
 	var tc credentials.TransportCredentials
 	if cfg.useTLS {
-		tc = credentials.NewTLS(&tls.Config{})
+		tc = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
 	} else {
 		tc = insecure.NewCredentials()
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,9 +14,10 @@ type Config struct {
 	Branch        string
 	PollInterval  time.Duration
 	HCLDir        string
-	GitToken      string
-	GitSSHKeyPath string
-	GitSSHKeyPass string
+	GitToken             string
+	GitSSHKeyPath        string
+	GitSSHKeyPass        string
+	GitSSHKnownHostsFile string
 
 	// Nomad
 	NomadAddr      string
@@ -65,6 +66,7 @@ func LoadFromArgs(fs *flag.FlagSet, args []string) (*Config, error) {
 	fs.StringVar(&c.GitToken, "git-token", envOrDefault("GIT_TOKEN", ""), "Git HTTP token for private repos (e.g. GitHub PAT)")
 	fs.StringVar(&c.GitSSHKeyPath, "git-ssh-key", envOrDefault("GIT_SSH_KEY", ""), "Path to SSH private key for git auth")
 	fs.StringVar(&c.GitSSHKeyPass, "git-ssh-key-password", envOrDefault("GIT_SSH_KEY_PASSWORD", ""), "SSH private key passphrase")
+	fs.StringVar(&c.GitSSHKnownHostsFile, "git-ssh-known-hosts", envOrDefault("GIT_SSH_KNOWN_HOSTS", ""), "Path to known_hosts file for SSH host key verification (defaults to ~/.ssh/known_hosts; set to empty string to use system defaults)")
 
 	fs.StringVar(&c.NomadAddr, "nomad-addr", envOrDefault("NOMAD_ADDR", "http://127.0.0.1:4646"), "Nomad API address")
 	fs.StringVar(&c.NomadToken, "nomad-token", envOrDefault("NOMAD_TOKEN", ""), "Nomad ACL token")

--- a/internal/gitwatch/watcher.go
+++ b/internal/gitwatch/watcher.go
@@ -293,6 +293,9 @@ func (w *Watcher) buildAuth() (transport.AuthMethod, error) {
 		if err != nil {
 			return nil, fmt.Errorf("loading SSH key from %s: %w", w.cfg.GitSSHKeyPath, err)
 		}
+		if err := w.setSSHHostKeyCallback(auth); err != nil {
+			return nil, err
+		}
 		return auth, nil
 	}
 	if w.cfg.GitToken != "" {
@@ -302,6 +305,30 @@ func (w *Watcher) buildAuth() (transport.AuthMethod, error) {
 		}, nil
 	}
 	return nil, nil // anonymous / SSH agent
+}
+
+// setSSHHostKeyCallback configures host key verification on auth.
+// When --git-ssh-known-hosts is set the named file is required; if it cannot
+// be opened, an error is returned. Without the flag go-git's default known_hosts
+// locations (~/..ssh/known_hosts, /etc/ssh/ssh_known_hosts) are tried. If none
+// are found, verification is skipped and a warning is logged.
+func (w *Watcher) setSSHHostKeyCallback(auth *gitssh.PublicKeys) error {
+	if w.cfg.GitSSHKnownHostsFile != "" {
+		cb, err := gitssh.NewKnownHostsCallback(w.cfg.GitSSHKnownHostsFile)
+		if err != nil {
+			return fmt.Errorf("loading known_hosts from %s: %w", w.cfg.GitSSHKnownHostsFile, err)
+		}
+		auth.HostKeyCallback = cb
+		return nil
+	}
+	cb, err := gitssh.NewKnownHostsCallback()
+	if err != nil {
+		slog.Warn("SSH host key verification disabled: no known_hosts file found; "+
+			"set --git-ssh-known-hosts / GIT_SSH_KNOWN_HOSTS to enable verification", "err", err)
+		return nil
+	}
+	auth.HostKeyCallback = cb
+	return nil
 }
 
 func headCommit(repo *git.Repository) (string, error) {

--- a/internal/gitwatch/watcher_test.go
+++ b/internal/gitwatch/watcher_test.go
@@ -3,6 +3,7 @@ package gitwatch
 import (
 	"context"
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/prometheus/client_golang/prometheus"
@@ -259,6 +261,42 @@ func TestBuildAuth_SSHKey_NotFound(t *testing.T) {
 	_, err := w.buildAuth()
 	if err == nil {
 		t.Error("expected error for non-existent SSH key path")
+	}
+}
+
+// ── setSSHHostKeyCallback ─────────────────────────────────────────────────────
+
+func TestSetSSHHostKeyCallback_ExplicitFile_Good(t *testing.T) {
+	f, err := os.CreateTemp("", "known_hosts_*")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer os.Remove(f.Name())
+	f.Close()
+
+	w := &Watcher{cfg: &config.Config{GitSSHKnownHostsFile: f.Name()}}
+	auth := &gitssh.PublicKeys{}
+	if err := w.setSSHHostKeyCallback(auth); err != nil {
+		t.Fatalf("unexpected error with valid known_hosts file: %v", err)
+	}
+	if auth.HostKeyCallback == nil {
+		t.Error("HostKeyCallback should be set after loading a valid known_hosts file")
+	}
+}
+
+func TestSetSSHHostKeyCallback_ExplicitFile_Missing(t *testing.T) {
+	w := &Watcher{cfg: &config.Config{GitSSHKnownHostsFile: "/nonexistent/known_hosts"}}
+	auth := &gitssh.PublicKeys{}
+	if err := w.setSSHHostKeyCallback(auth); err == nil {
+		t.Error("expected error when --git-ssh-known-hosts points to a missing file")
+	}
+}
+
+func TestSetSSHHostKeyCallback_NoConfig_DoesNotError(t *testing.T) {
+	w := &Watcher{cfg: &config.Config{}}
+	auth := &gitssh.PublicKeys{}
+	if err := w.setSSHHostKeyCallback(auth); err != nil {
+		t.Errorf("setSSHHostKeyCallback should not error when no known_hosts config is set: %v", err)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -108,12 +108,21 @@ func NewWithRegistry(cfg *config.Config, diffs DiffSource, git GitStatusSource, 
 	return s
 }
 
+// newHTTPServer constructs the http.Server with timeouts to prevent slowloris
+// and other connection-exhaustion attacks.
+func (s *Server) newHTTPServer() *http.Server {
+	return &http.Server{
+		Addr:              s.cfg.ListenAddr,
+		Handler:           s.mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+	}
+}
+
 // Run starts the HTTP server and blocks until ctx is cancelled.
 func (s *Server) Run(ctx context.Context) error {
-	srv := &http.Server{
-		Addr:    s.cfg.ListenAddr,
-		Handler: s.mux,
-	}
+	srv := s.newHTTPServer()
 
 	go func() {
 		<-ctx.Done()
@@ -322,6 +331,10 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleWebhook() http.HandlerFunc {
+	if s.cfg.WebhookSecret == "" {
+		slog.Warn("Webhook secret is empty: webhook endpoint accepts unsigned requests. " +
+			"Set --webhook-secret / WEBHOOK_SECRET to require HMAC-SHA256 signatures.")
+	}
 	hook, err := webhookgithub.New(webhookgithub.Options.Secret(s.cfg.WebhookSecret))
 	if err != nil {
 		// This only errors with an invalid secret; log and serve a stub.

--- a/internal/server/server_security_test.go
+++ b/internal/server/server_security_test.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gerrowadat/nomad-botherer/internal/config"
+)
+
+func TestHTTPServer_HasTimeouts(t *testing.T) {
+	s := &Server{
+		cfg: &config.Config{ListenAddr: ":8080"},
+		mux: http.NewServeMux(),
+	}
+	srv := s.newHTTPServer()
+	if srv.ReadHeaderTimeout == 0 {
+		t.Error("ReadHeaderTimeout not set; server is vulnerable to slowloris attacks")
+	}
+	if srv.ReadTimeout == 0 {
+		t.Error("ReadTimeout not set")
+	}
+	if srv.WriteTimeout == 0 {
+		t.Error("WriteTimeout not set")
+	}
+}


### PR DESCRIPTION
- SSH host key verification: go-git's SSH transport silently uses
  ssh.InsecureIgnoreHostKey() when HostKeyCallback is nil, allowing a
  man-in-the-middle to intercept git traffic. setSSHHostKeyCallback() now
  loads known_hosts via gitssh.NewKnownHostsCallback, defaulting to the
  system locations (~/.ssh/known_hosts, /etc/ssh/ssh_known_hosts). When
  neither file is found it logs a warning rather than silently continuing.
  A new --git-ssh-known-hosts / GIT_SSH_KNOWN_HOSTS flag allows an
  explicit path; that path is required to exist.

- HTTP slowloris: http.Server had no read/write timeouts. Added
  ReadHeaderTimeout (10s), ReadTimeout (30s), and WriteTimeout (30s) via
  a newHTTPServer() helper so the values can be tested.

- Unsigned webhooks: when WebhookSecret is empty the go-playground/webhooks
  handler accepts any request without HMAC verification. Added a startup
  warning so operators know the endpoint is open.

- Minor: set tls.Config{MinVersion: tls.VersionTLS12} in nbctl when
  --tls is used, making the minimum version explicit rather than relying
  on Go's default.

https://claude.ai/code/session_01K6NJGHfW16qJz5njPCXdBD