### PR TITLE
Add Getting Started section and example Nomad job HCL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Three kinds of drift are tracked:
 
 ## Contents
 
+- [Getting started](#getting-started)
+  - [Run as a Nomad job](#run-as-a-nomad-job)
+  - [Run the binary directly](#run-the-binary-directly)
+  - [Opt jobs in to monitoring](#opt-jobs-in-to-monitoring)
 - [Design and prior art](#design-and-prior-art)
 - [How it works](#how-it-works)
 - [Job selection](#job-selection)
@@ -35,6 +39,82 @@ Three kinds of drift are tracked:
   - [Sample Prometheus configuration](#sample-prometheus-configuration)
 - [Docker](#docker)
 - [Development](#development)
+
+---
+
+## Getting started
+
+nomad-botherer needs two things: a git repo containing your Nomad HCL job
+definitions, and a Nomad cluster to compare them against.
+
+### Run as a Nomad job
+
+The most common deployment is to run nomad-botherer as a Nomad job on the
+same cluster it watches. [`examples/nomad-botherer.hcl`](examples/nomad-botherer.hcl)
+is a ready-to-use job definition with every configuration option commented.
+
+1. Copy `examples/nomad-botherer.hcl` into your job repo (or download it).
+
+2. Set the two required values in the `env {}` block:
+   - `GIT_REPO_URL` — the URL of your HCL repo
+   - `GRPC_API_KEY` — a long random string (used to authenticate `nbctl` and `grpcurl`)
+
+3. For a private repo, also set `GIT_TOKEN` (HTTPS) or mount an SSH key and
+   set `GIT_SSH_KEY`. The example file has commented instructions for both,
+   including how to read secrets from a Nomad Variable rather than hardcoding
+   them.
+
+4. If your cluster has ACLs enabled, set `NOMAD_TOKEN` to a token with
+   `list-jobs` and `read-job` capabilities on the target namespace.
+
+5. Submit the job:
+   ```bash
+   nomad job run nomad-botherer.hcl
+   ```
+
+6. Watch startup — nomad-botherer clones the repo and runs its first diff
+   check before reporting healthy:
+   ```bash
+   nomad job status nomad-botherer
+   curl http://<alloc-ip>:8080/healthz
+   ```
+   `/healthz` returns `HTTP 503` with `"status": "starting"` until the first
+   check completes, then `HTTP 200` with a JSON drift summary.
+
+### Run the binary directly
+
+```bash
+./nomad-botherer \
+  --repo-url https://github.com/myorg/nomad-jobs.git \
+  --nomad-addr http://nomad.example.com:4646 \
+  --grpc-api-key your-api-key
+```
+
+For a private HTTPS repo add `--git-token ghp_...`; for SSH add
+`--git-ssh-key ~/.ssh/id_ed25519`. See [Quick start](#quick-start) for
+more examples and [Configuration](#configuration) for the full flag reference.
+
+### Opt jobs in to monitoring
+
+By default, nomad-botherer only watches jobs that declare a `gitops.managed`
+meta key. Add this to any job you want monitored:
+
+```hcl
+job "my-service" {
+  meta = {
+    "gitops.managed" = "true"
+  }
+  # ...
+}
+```
+
+Jobs without this key are silently ignored, even if they are running on the
+cluster. This is intentional — it prevents nomad-botherer from reporting drift
+on manually-managed or third-party jobs that are not in your HCL repo.
+
+To instead watch jobs by name pattern (or watch everything), use
+`--job-selector-glob`. Both criteria are a union: a job matching either is
+watched. See [Job selection](#job-selection) for details.
 
 ---
 

--- a/examples/nomad-botherer.hcl
+++ b/examples/nomad-botherer.hcl
@@ -1,0 +1,238 @@
+# nomad-botherer — example Nomad job definition
+#
+# Run nomad-botherer as a Nomad service job on the same cluster it watches.
+# This file is intended as a starting point: copy it into your job repo,
+# edit the env {} block for your environment, and submit with:
+#
+#   nomad job run nomad-botherer.hcl
+#
+# The only required settings are GIT_REPO_URL and (when gRPC is enabled)
+# GRPC_API_KEY. Everything else has a sensible default.
+
+job "nomad-botherer" {
+  # Run in the same namespace as the jobs you want to watch. nomad-botherer
+  # does not need elevated privileges: read access (list-jobs, read-job) is
+  # all that is required.
+  namespace   = "default"
+  datacenters = ["dc1"]
+  type        = "service"
+
+  # Opt this job in to its own monitoring so nomad-botherer watches itself
+  # for drift. The meta key name is controlled by MANAGED_META_PREFIX below;
+  # with the default prefix of "gitops" the key is "gitops.managed".
+  meta = {
+    "gitops.managed" = "true"
+  }
+
+  group "botherer" {
+    # nomad-botherer stores all git state in memory and writes nothing to
+    # disk. A single allocation is correct; running more than one produces
+    # duplicate drift reports.
+    count = 1
+
+    # Restart policy: allow a few quick retries before backing off, so a
+    # transient startup error (e.g. git clone timing out) recovers quickly.
+    restart {
+      attempts = 5
+      interval = "5m"
+      delay    = "15s"
+      mode     = "delay"
+    }
+
+    network {
+      # HTTP port: /healthz, /metrics, /diffs, /webhook, and the status page.
+      port "http" { to = 8080 }
+
+      # gRPC port: used by nbctl and grpcurl. Remove this port and set
+      # GRPC_LISTEN_ADDR = "" below if you do not need the gRPC API.
+      port "grpc" { to = 9090 }
+    }
+
+    task "nomad-botherer" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/gerrowadat/nomad-botherer:latest"
+        ports = ["http", "grpc"]
+      }
+
+      env {
+        # ── Git source ──────────────────────────────────────────────────────
+        #
+        # URL of the repository containing your Nomad HCL job definitions.
+        # HTTPS with a token (GIT_TOKEN) or SSH with a key file (GIT_SSH_KEY)
+        # are both supported. Public repos need no auth.
+        GIT_REPO_URL = "https://github.com/myorg/nomad-jobs.git"
+
+        # Branch to watch. Defaults to "main" if not set.
+        GIT_BRANCH = "main"
+
+        # Subdirectory within the repo that contains HCL job files.
+        # Leave empty (or omit) to use the repo root.
+        # HCL_DIR = "jobs"
+
+        # How often to poll the remote for new commits. The default is 5m.
+        # Set this shorter only if you are not using webhooks — polling more
+        # frequently than your git host rate-limits is counterproductive.
+        POLL_INTERVAL = "5m"
+
+        # ── Git authentication ──────────────────────────────────────────────
+        #
+        # For HTTPS repos: a GitHub PAT, GitLab deploy token, or similar.
+        # Pass via a Nomad Variable (recommended) rather than hardcoding here:
+        #
+        #   nomad var put nomad/jobs/nomad-botherer GIT_TOKEN=ghp_...
+        #
+        # Then reference it in a template block (see the template section below
+        # for an example of reading Nomad Variables into env vars).
+        #
+        # GIT_TOKEN = "ghp_..."
+
+        # For SSH repos: path to a mounted private key file.
+        # Mount the key from a Nomad Variable or Vault secret and point here.
+        # GIT_SSH_KEY          = "/secrets/id_ed25519"
+        # GIT_SSH_KEY_PASSWORD = ""
+
+        # ── Nomad connection ────────────────────────────────────────────────
+        #
+        # Address of the Nomad HTTP API. Inside a Nomad cluster the local agent
+        # is reachable on the loopback address.
+        NOMAD_ADDR = "http://127.0.0.1:4646"
+
+        # ACL token. Required when ACLs are enabled on the cluster.
+        # Minimum required capabilities for the token's policy:
+        #
+        #   namespace "default" {
+        #     capabilities = ["list-jobs", "read-job"]
+        #   }
+        #
+        # Use a Nomad Variable or Vault secret rather than hardcoding here.
+        # NOMAD_TOKEN = ""
+
+        # Namespace to watch. Defaults to "default".
+        # NOMAD_NAMESPACE = "default"
+
+        # ── HTTP server ─────────────────────────────────────────────────────
+
+        LISTEN_ADDR = ":8080"
+
+        # GitHub/GitLab webhook HMAC-SHA256 secret. When set, incoming webhook
+        # deliveries are rejected unless their X-Hub-Signature-256 header
+        # matches. Without this, any caller can trigger a git fetch.
+        # Configure the same value in your git host's webhook settings.
+        # WEBHOOK_SECRET = ""
+
+        # URL path for the webhook endpoint. Defaults to /webhook.
+        # WEBHOOK_PATH = "/webhook"
+
+        # ── gRPC server ─────────────────────────────────────────────────────
+        #
+        # The gRPC server is used by nbctl and grpcurl. To disable it, set
+        # GRPC_LISTEN_ADDR to an empty string and remove the "grpc" port above.
+
+        GRPC_LISTEN_ADDR = ":9090"
+
+        # Pre-shared API key for gRPC authentication. Required when
+        # GRPC_LISTEN_ADDR is non-empty. Clients pass this as:
+        #   -H 'authorization: Bearer <key>'
+        # Choose a long random value and store it in a Nomad Variable.
+        GRPC_API_KEY = "change-me"
+
+        # ── Job selection ───────────────────────────────────────────────────
+        #
+        # nomad-botherer does not watch every job on the cluster by default.
+        # A job must match at least one of the two criteria below.
+        #
+        # Meta key (on by default): any job with
+        #   meta = { "gitops.managed" = "true" }
+        # in its HCL definition is automatically watched. The prefix before
+        # ".managed" is controlled by MANAGED_META_PREFIX; change it if
+        # another tool already owns "gitops.*" on your cluster.
+        MANAGED_META_PREFIX = "gitops"
+
+        # Glob: watch all jobs whose name matches a shell glob pattern.
+        # Use "*" to watch every job in the namespace, or "production-*" to
+        # watch all jobs whose names start with "production-". The glob and
+        # the meta key are a union: a job is selected if it matches either.
+        # Unset (empty string) means no glob selection.
+        # JOB_SELECTOR_GLOB = ""
+
+        # ── Diff behaviour ──────────────────────────────────────────────────
+
+        # How often to compare Nomad state against the git repo, regardless of
+        # whether a git push has occurred. Defaults to 1m.
+        DIFF_INTERVAL = "1m"
+
+        # By default, dead (stopped) Nomad jobs are treated as
+        # missing_from_nomad — a job that was intentionally stopped is expected
+        # to be absent. Set to "true" to compare dead jobs' specs against their
+        # HCL definitions instead.
+        # INCLUDE_DEAD_JOBS = "false"
+
+        # ── Staleness guards ────────────────────────────────────────────────
+        #
+        # These settings force a refresh if the normal polling or webhook path
+        # falls behind. Both default to 0 (disabled).
+        #
+        # Force a git fetch if the last successful fetch is older than this:
+        # MAX_GIT_STALENESS = "30m"
+        #
+        # Force a diff check if the last successful check is older than this:
+        # MAX_NOMAD_STALENESS = "10m"
+
+        # ── Logging ─────────────────────────────────────────────────────────
+        #
+        # Structured JSON logs are written to stderr. Valid levels:
+        # debug, info, warn, error. "info" is appropriate for production.
+        LOG_LEVEL = "info"
+      }
+
+      # ── Reading secrets from Nomad Variables ──────────────────────────────
+      #
+      # Uncomment and adapt this block to pull GIT_TOKEN and GRPC_API_KEY from
+      # a Nomad Variable rather than hardcoding them in env {}.
+      #
+      # First, create the variable:
+      #   nomad var put nomad/jobs/nomad-botherer \
+      #     GIT_TOKEN=ghp_... \
+      #     GRPC_API_KEY=your-long-random-key
+      #
+      # template {
+      #   data        = <<-EOT
+      #     {{ with nomadVar "nomad/jobs/nomad-botherer" }}
+      #     GIT_TOKEN={{ .GIT_TOKEN }}
+      #     GRPC_API_KEY={{ .GRPC_API_KEY }}
+      #     {{ end }}
+      #   EOT
+      #   destination = "secrets/env"
+      #   env         = true
+      # }
+
+      resources {
+        # nomad-botherer is lightweight: it holds a single in-memory git clone
+        # and makes periodic API calls. 128 MiB is ample for most repos; raise
+        # it if your repo is very large or contains many large binary files.
+        cpu    = 100
+        memory = 128
+      }
+
+      service {
+        name     = "nomad-botherer"
+        port     = "http"
+
+        # Change to "consul" if you are using Consul service discovery.
+        provider = "nomad"
+
+        check {
+          type     = "http"
+          path     = "/healthz"
+          interval = "15s"
+          timeout  = "3s"
+          # /healthz returns HTTP 503 while the initial git clone and first
+          # diff check are in progress. This is normal on first deploy; the
+          # check will pass once startup completes (typically 10–30 seconds).
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds two things for new users landing on the repo for the first time.

## README: Getting Started section

A new section immediately after the table of contents, covering the three
things someone needs to know to get up and running:

- How to deploy nomad-botherer as a Nomad job on their existing cluster
  (step-by-step walkthrough referencing the new example file)
- How to run the binary directly (one-liner with pointers to Quick start
  and Configuration for detail)
- How to opt jobs in with the gitops.managed meta key, and why jobs are
  not watched by default

Each step links down to the relevant deeper section rather than duplicating
the reference material.

## examples/nomad-botherer.hcl

A complete, ready-to-submit Nomad job definition. The intent is that
someone can copy this file, edit two lines (GIT_REPO_URL and GRPC_API_KEY),
and have a working deployment.

Every configuration option appears in the env {} block. Uncommented lines
are the values that most deployments need to change. Everything else is
commented out with its default and a brief explanation of when to set it.
Includes a commented template {} block showing how to read GIT_TOKEN and
GRPC_API_KEY from a Nomad Variable rather than hardcoding them.