### PR TITLE
Disable gRPC server by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ Every flag has a corresponding environment variable. Environment variables are r
 | `--listen-addr` | `LISTEN_ADDR` | `:8080` | HTTP listen address |
 | `--webhook-secret` | `WEBHOOK_SECRET` | | GitHub webhook HMAC secret |
 | `--webhook-path` | `WEBHOOK_PATH` | `/webhook` | Webhook endpoint path |
-| `--grpc-listen-addr` | `GRPC_LISTEN_ADDR` | `:9090` | gRPC listen address. Set to empty string (`""`) to disable the gRPC server |
-| `--grpc-api-key` | `GRPC_API_KEY` | | Pre-shared API key for gRPC authentication. Required when `--grpc-listen-addr` is non-empty |
+| `--grpc-listen-addr` | `GRPC_LISTEN_ADDR` | *(empty — disabled)* | gRPC listen address. Set to a non-empty value (e.g. `:9090`) to enable the gRPC server. Requires `--grpc-api-key`. |
+| `--grpc-api-key` | `GRPC_API_KEY` | | Pre-shared API key for gRPC authentication. Required when `--grpc-listen-addr` is set. |
 | `--diff-interval` | `DIFF_INTERVAL` | `1m` | Periodic Nomad-side drift check interval |
 | `--include-dead-jobs` | `INCLUDE_DEAD_JOBS` | `false` | Treat dead Nomad jobs like running ones (by default dead jobs count as missing) |
 | `--job-selector-glob` | `JOB_SELECTOR_GLOB` | *(empty — no glob)* | Glob pattern selecting jobs to watch by name (e.g. `myprefix-*`, `*` for all). Combined with `--managed-meta-prefix` as a union. |
@@ -234,9 +234,9 @@ If `--webhook-secret` is empty, signature verification is skipped. In production
 
 ## gRPC API
 
-nomad-botherer exposes a gRPC server on `--grpc-listen-addr` (default `:9090`).
-The server starts automatically unless the address is set to an empty string.
-Setting a non-empty address without also setting an API key is a startup error.
+The gRPC server is disabled by default. Enable it by setting `--grpc-listen-addr`
+to a listen address (e.g. `:9090`) and providing an API key via `--grpc-api-key`.
+Setting an address without an API key is a startup error.
 
 The service is defined in [`proto/nomad_botherer.proto`](proto/nomad_botherer.proto).
 Go bindings are pre-generated in `internal/grpcapi/` — no code generation is required
@@ -624,9 +624,7 @@ docker run -d \
   -e GIT_TOKEN=ghp_... \
   -e NOMAD_ADDR=http://nomad.example.com:4646 \
   -e NOMAD_TOKEN=... \
-  -e GRPC_API_KEY=your-api-key \
   -p 8080:8080 \
-  -p 9090:9090 \
   ghcr.io/gerrowadat/nomad-botherer:latest
 ```
 
@@ -638,13 +636,11 @@ docker run -d \
   -e GIT_SSH_KEY=/run/secrets/ssh_key \
   -v /path/to/id_ed25519:/run/secrets/ssh_key:ro \
   -e NOMAD_ADDR=http://nomad.example.com:4646 \
-  -e GRPC_API_KEY=your-api-key \
   -p 8080:8080 \
-  -p 9090:9090 \
   ghcr.io/gerrowadat/nomad-botherer:latest
 ```
 
-Omit `-e GRPC_API_KEY` and `-p 9090:9090` if you do not need the gRPC API.
+To enable the gRPC API, add `-e GRPC_LISTEN_ADDR=:9090 -e GRPC_API_KEY=your-api-key -p 9090:9090`.
 
 Supported platforms: `linux/amd64`, `linux/arm64` (Raspberry Pi 4+).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,8 +76,8 @@ func LoadFromArgs(fs *flag.FlagSet, args []string) (*Config, error) {
 	fs.StringVar(&c.WebhookSecret, "webhook-secret", envOrDefault("WEBHOOK_SECRET", ""), "GitHub webhook HMAC secret")
 	fs.StringVar(&c.WebhookPath, "webhook-path", envOrDefault("WEBHOOK_PATH", "/webhook"), "HTTP path for webhook endpoint")
 
-	fs.StringVar(&c.GRPCListenAddr, "grpc-listen-addr", envOrDefault("GRPC_LISTEN_ADDR", ":9090"), "gRPC listen address (empty string disables gRPC)")
-	fs.StringVar(&c.GRPCAPIKey, "grpc-api-key", envOrDefault("GRPC_API_KEY", ""), "Pre-shared API key for gRPC authentication (required when gRPC is enabled)")
+	fs.StringVar(&c.GRPCListenAddr, "grpc-listen-addr", envOrDefault("GRPC_LISTEN_ADDR", ""), "gRPC listen address (e.g. :9090). Empty (the default) disables the gRPC server. Requires --grpc-api-key when set.")
+	fs.StringVar(&c.GRPCAPIKey, "grpc-api-key", envOrDefault("GRPC_API_KEY", ""), "Pre-shared API key for gRPC authentication (required when --grpc-listen-addr is set)")
 
 	fs.DurationVar(&c.DiffInterval, "diff-interval", envDurationOrDefault("DIFF_INTERVAL", time.Minute), "How often to run a diff check regardless of git changes")
 	fs.BoolVar(&c.IncludeDeadJobs, "include-dead-jobs", envBoolOrDefault("INCLUDE_DEAD_JOBS", false), "Treat dead Nomad jobs like running ones (by default dead jobs are treated as missing)")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -250,8 +250,8 @@ func TestLoadFromArgs_GRPCDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.GRPCListenAddr != ":9090" {
-		t.Errorf("GRPCListenAddr: want :9090, got %q", cfg.GRPCListenAddr)
+	if cfg.GRPCListenAddr != "" {
+		t.Errorf("GRPCListenAddr: want empty (disabled by default), got %q", cfg.GRPCListenAddr)
 	}
 	if cfg.GRPCAPIKey != "" {
 		t.Errorf("GRPCAPIKey: want empty, got %q", cfg.GRPCAPIKey)


### PR DESCRIPTION
The gRPC server previously bound to :9090 on every startup unless
explicitly disabled. A deployment that didn't set GRPC_API_KEY got a
startup error; a deployment that set the key but didn't intend to expose
gRPC got an open port. Neither is what you'd expect from a default.

## Change

`GRPC_LISTEN_ADDR` default changed from `":9090"` to `""`. The server
now only starts when `--grpc-listen-addr` is explicitly set to a
non-empty address. The existing guard — refusing to start if an address
is set without an API key — is unchanged.

## Files

- `internal/config/config.go` — default changed, flag help text updated
- `internal/config/config_test.go` — `TestLoadFromArgs_GRPCDefaults` updated to expect empty
- `README.md` — configuration table default updated; gRPC section intro
  reworded ("disabled by default, enable by setting..."); Docker examples
  no longer include `-e GRPC_API_KEY` and `-p 9090:9090` as standard, with
  a note on how to add them when needed