### PR TITLE
Record v0.1.2 regression results against Nomad 1.9.6–2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Testing
 
 - Added a full regression test suite (`tests/regression/`) covering drift detection, end-to-end HTTP and gRPC flows, Prometheus metrics, webhook handling, security behaviours, and job selection. The suite runs against a real Nomad instance and is tagged `//go:build regression` so it does not run in CI by default. See the Testing section of the README for how to run it.
+- Verified against Nomad 1.9.6, 1.10.5, 1.11.3, and 2.0.2. All tests pass on all four versions.
 
 ### Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,14 @@ test:
 	go test -race -timeout 60s ./...
 
 ## test-regression: run the regression suite against a real Nomad cluster (via Docker).
-## Requires Docker. Set NOMAD_VERSION to target a specific version (default: 1.9.3).
+## Requires Docker. Set NOMAD_VERSION to target a specific version (default: 1.9.6).
 ## Set NOMAD_ADDR to use an existing cluster instead of starting one via Docker.
-## Example: make test-regression NOMAD_VERSION=1.10.2
+## Example: make test-regression NOMAD_VERSION=1.11.3
 test-regression:
 	go test -tags=regression -timeout 15m -v -count=1 ./tests/regression/...
 
 ## test-regression-versions: run the regression suite against each NOMAD_VERSIONS entry.
-## Example: make test-regression-versions NOMAD_VERSIONS="1.9.3 1.10.2"
+## Example: make test-regression-versions NOMAD_VERSIONS="1.9.6 1.10.5 1.11.3 2.0.2"
 test-regression-versions:
 	@for ver in $(NOMAD_VERSIONS); do \
 		echo "=== Testing against Nomad $$ver ==="; \

--- a/README.md
+++ b/README.md
@@ -785,13 +785,13 @@ minutes.
 #### Targeting a specific Nomad version
 
 ```bash
-NOMAD_VERSION=1.10.2 make test-regression
+NOMAD_VERSION=1.11.3 make test-regression
 ```
 
 Or directly:
 
 ```bash
-NOMAD_VERSION=1.10.2 go test -tags=regression -timeout 15m -v -count=1 ./tests/regression/...
+NOMAD_VERSION=1.11.3 go test -tags=regression -timeout 15m -v -count=1 ./tests/regression/...
 ```
 
 `NOMAD_VERSION` must match a tag on the official
@@ -800,7 +800,7 @@ NOMAD_VERSION=1.10.2 go test -tags=regression -timeout 15m -v -count=1 ./tests/r
 #### Testing against multiple versions
 
 ```bash
-make test-regression-versions NOMAD_VERSIONS="1.8.7 1.9.3 1.10.2"
+make test-regression-versions NOMAD_VERSIONS="1.9.6 1.10.5 1.11.3 2.0.2"
 ```
 
 This iterates over the list and runs the full suite against each version in

--- a/docs/nomad-versions.md
+++ b/docs/nomad-versions.md
@@ -20,9 +20,9 @@ After a successful run, add a row to the table below and update `tests/regressio
 
 ## Compatibility matrix
 
-| nomad-botherer | Nomad 1.8.x | Nomad 1.9.x | Nomad 1.10.x | Notes |
-|----------------|:-----------:|:-----------:|:------------:|-------|
-| (unreleased)   |             |             |              | Matrix will be filled as releases are cut |
+| nomad-botherer | Nomad 1.9.x | Nomad 1.10.x | Nomad 1.11.x | Nomad 2.0.x | Notes |
+|----------------|:-----------:|:------------:|:------------:|:-----------:|-------|
+| v0.1.2         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    |       |
 
 ### Column key
 

--- a/tests/regression/compat.go
+++ b/tests/regression/compat.go
@@ -26,7 +26,7 @@ package regression
 import "time"
 
 // defaultNomadVersion is used when NOMAD_VERSION is unset and Docker is available.
-const defaultNomadVersion = "1.9.3"
+const defaultNomadVersion = "1.9.6"
 
 // VersionRecord documents the result of running the regression suite against
 // a specific Nomad version. Records are added manually after each release.
@@ -50,5 +50,28 @@ type VersionRecord struct {
 //  2. Add a VersionRecord entry below.
 //  3. Update docs/nomad-versions.md.
 var TestedVersions = []VersionRecord{
-	// Entries will be added here as releases are tested.
+	{
+		NomadVersion:    "2.0.2",
+		BothererRelease: "v0.1.2",
+		TestedAt:        time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.11.3",
+		BothererRelease: "v0.1.2",
+		TestedAt:        time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.10.5",
+		BothererRelease: "v0.1.2",
+		TestedAt:        time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.9.6",
+		BothererRelease: "v0.1.2",
+		TestedAt:        time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
 }


### PR DESCRIPTION
Records the results of running the full regression suite against four Nomad versions before the v0.1.2 release.

All tests passed on all four versions.

## Changes

**`tests/regression/compat.go`**
- Add `VersionRecord` entries for Nomad 2.0.2, 1.11.3, 1.10.5, and 1.9.6 against nomad-botherer v0.1.2.
- Update `defaultNomadVersion` from `1.9.3` to `1.9.6` (the specific patch version tested).

**`docs/nomad-versions.md`**
- Expand the compatibility matrix to include Nomad 1.11.x and 2.0.x columns.
- Add v0.1.2 row with results.

**`CHANGELOG.md`**
- Note the tested Nomad versions in the v0.1.2 Testing section.

**`Makefile`, `README.md`**
- Update example version strings to match the versions actually tested.

Merge this before tagging v0.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)