### PR TITLE
Change meta key separator from dot to underscore (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@
   previous key format will no longer be selected after this change.
 
   The custom prefix configured via `--managed-meta-prefix` / `MANAGED_META_PREFIX`
-  works the same way: a prefix of `myorg` now produces `myorg_managed`.
+  works the same way: a prefix of `myorg` now produces `myorg_managed`. When
+  choosing a custom prefix, keeping `gitops` as a root (e.g. `gitops_myteam`)
+  is recommended so all nomad-botherer keys remain visually grouped.
 
 ## v0.1.2 — 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.2.0 — 2026-06-02
+
+### Breaking changes
+
+- **Meta key separator changed from `.` to `_`.** The opt-in meta key is now
+  `gitops_managed = "true"` (previously `"gitops.managed" = "true"`). This
+  makes the key a valid HCL2 identifier, allowing the cleaner block form:
+
+  ```hcl
+  meta {
+    gitops_managed = "true"
+  }
+  ```
+
+  instead of the object-expression form with quoted keys. Any existing job HCL
+  using the old dotted key must be updated before upgrading. Jobs using the
+  previous key format will no longer be selected after this change.
+
+  The custom prefix configured via `--managed-meta-prefix` / `MANAGED_META_PREFIX`
+  works the same way: a prefix of `myorg` now produces `myorg_managed`.
+
 ## v0.1.2 — 2026-06-02
 
 ### Security fixes
@@ -11,7 +32,7 @@
 
 ### New features
 
-- **Job selection** (`--job-selector-glob`, `--managed-meta-prefix`): Two independent mechanisms for scoping which jobs nomad-botherer watches. `--job-selector-glob` selects by name pattern (e.g. `myteam-*`); `--managed-meta-prefix` selects jobs that carry a meta key with the given prefix (default `gitops`, meaning `gitops.managed = "true"` opts a job in). Jobs matching either selector are watched; jobs matching neither are ignored.
+- **Job selection** (`--job-selector-glob`, `--managed-meta-prefix`): Two independent mechanisms for scoping which jobs nomad-botherer watches. `--job-selector-glob` selects by name pattern (e.g. `myteam-*`); `--managed-meta-prefix` selects jobs that carry a meta key with the given prefix (default `gitops`, meaning `gitops.managed = "true"` opts a job in — note: renamed to `gitops_managed` in v0.2.0). Jobs matching either selector are watched; jobs matching neither are ignored.
 - **gRPC server disabled by default**: The gRPC server no longer binds to `:9090` on startup. Set `--grpc-listen-addr` (or `GRPC_LISTEN_ADDR`) to enable it. This avoids unexpected port conflicts and makes the `--grpc-api-key` requirement easier to enforce.
 
 ### Correctness

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Never register without a CAS token. The apply path is:
 the write because the index changed, mark the update failed, trigger a fresh
 diff, and let the next cycle produce a new update with current state.
 
-**Opt-in scope via job meta.** Jobs must declare `meta { "gitops.managed" =
+**Opt-in scope via job meta.** Jobs must declare `meta { "gitops_managed" =
 "true" }` in their HCL to be managed by nomad-botherer. A job without this key
 is never diffed for application purposes, never registered, and never
 deregistered — even if it is running in Nomad without a corresponding HCL file.
@@ -66,7 +66,7 @@ This is the "Operator Pattern in Nomad" (see scalad, Pondidum/nomad-operator).
 Do not change this default without a strong reason; it is what prevents
 nomad-botherer from touching manually-managed jobs on a shared cluster.
 
-**Separate the two uses of job meta.** The `gitops.managed` flag is set by
+**Separate the two uses of job meta.** The `gitops_managed` flag is set by
 humans in HCL and read by the tool — that is fine. Writing tool state (applied
 commit, timestamps, status) back into the live job's meta is a different thing
 and causes the meta-drift problem: the next `nomad job run` from plain HCL
@@ -87,7 +87,7 @@ shape. Updates for the same job that arrive while a prior update is still pendin
 should be marked `SUPERSEDED`; the most recent intended state wins.
 
 **Conservative deletion.** `missing_from_hcl` is an observation today. When
-deregister is implemented, it should require: (a) `gitops.managed = "true"` on
+deregister is implemented, it should require: (a) `gitops_managed = "true"` on
 the live job (confirming the operator previously registered it), and (b) probably
 an explicit config flag to enable deregister at all. Purge (`purge=true` in the
 Nomad API) should not be the default.
@@ -138,7 +138,7 @@ Use these terms consistently so the code and docs match:
 | `JobUpdate` | An intended transition: a planned change to apply to Nomad. Not yet implemented. |
 | `JobUpdateOperation` | `REGISTER` or `DEREGISTER` |
 | `JobUpdateStatus` | `PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `SUPERSEDED` |
-| opt-in key | `gitops.managed = "true"` in job HCL meta — scope selector, never written by the tool |
+| opt-in key | `gitops_managed = "true"` in job HCL meta — scope selector, never written by the tool |
 | meta-drift | The problem of tool-written meta keys being clobbered by the next human `nomad job run` |
 | `CheckpointStore` | Interface for persisting update queue state across restarts |
 | Raft index | `QueryMeta.LastIndex` from `Jobs.List()` — used for skip optimisation, not locking |

--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ nomad-botherer does not watch every job in a cluster by default. A job must matc
 
 The two criteria are a **union**: a job is selected if it matches the glob *or* has the `<prefix>_managed` meta key set to `"true"`. With the defaults (no glob, prefix `gitops`), only jobs declaring `gitops_managed = "true"` in their HCL meta stanza are watched.
 
-The prefix is a namespace for all meta keys nomad-botherer reads or writes. Using `gitops` means the opt-in key is `gitops_managed`, and future attributes will follow the same `gitops_<attribute>` pattern. Use a different prefix if another team or tool already owns `gitops_*` keys on your cluster.
+The prefix is a namespace for all meta keys nomad-botherer reads or writes. Using `gitops` means the opt-in key is `gitops_managed`, and future attributes will follow the same `gitops_<attribute>` pattern.
+
+If you need to change the prefix — for example because another team already owns `gitops_*` on the cluster — keep `gitops` as a root and append your qualifier: `gitops_myteam`, `gitops_platform`, etc. This keeps all nomad-botherer keys visually grouped across teams and avoids conflicts with unrelated meta keys.
 
 **Opting a job in via meta tag (default method):**
 
@@ -199,9 +201,11 @@ job "my-service" {
 **Changing the meta prefix** (useful when sharing a cluster with multiple teams or tools):
 
 ```bash
-./nomad-botherer --managed-meta-prefix='myorg' ...
-# opts in jobs with meta { myorg_managed = "true" }
+./nomad-botherer --managed-meta-prefix='gitops_myteam' ...
+# opts in jobs with meta { gitops_myteam_managed = "true" }
 ```
+
+Keeping `gitops` as the root of a custom prefix makes all nomad-botherer keys easy to identify across a shared cluster.
 
 **Disabling meta-based selection entirely** (glob only):
 

--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ more examples and [Configuration](#configuration) for the full flag reference.
 
 ### Opt jobs in to monitoring
 
-By default, nomad-botherer only watches jobs that declare a `gitops.managed`
+By default, nomad-botherer only watches jobs that declare a `gitops_managed`
 meta key. Add this to any job you want monitored:
 
 ```hcl
 job "my-service" {
-  meta = {
-    "gitops.managed" = "true"
+  meta {
+    gitops_managed = "true"
   }
   # ...
 }
@@ -169,16 +169,16 @@ nomad-botherer does not watch every job in a cluster by default. A job must matc
 | Name glob | `--job-selector-glob` | *(empty — no glob selection)* |
 | Meta prefix | `--managed-meta-prefix` | `gitops` |
 
-The two criteria are a **union**: a job is selected if it matches the glob *or* has the `<prefix>.managed` meta key set to `"true"`. With the defaults (no glob, prefix `gitops`), only jobs declaring `gitops.managed = "true"` in their HCL meta stanza are watched.
+The two criteria are a **union**: a job is selected if it matches the glob *or* has the `<prefix>_managed` meta key set to `"true"`. With the defaults (no glob, prefix `gitops`), only jobs declaring `gitops_managed = "true"` in their HCL meta stanza are watched.
 
-The prefix is a namespace for all meta keys nomad-botherer reads or writes. Using `gitops` means the opt-in key is `gitops.managed`, and future attributes will follow the same `gitops.<attribute>` pattern. Use a different prefix if another team or tool already owns `gitops.*` on your cluster.
+The prefix is a namespace for all meta keys nomad-botherer reads or writes. Using `gitops` means the opt-in key is `gitops_managed`, and future attributes will follow the same `gitops_<attribute>` pattern. Use a different prefix if another team or tool already owns `gitops_*` keys on your cluster.
 
 **Opting a job in via meta tag (default method):**
 
 ```hcl
 job "my-service" {
   meta {
-    "gitops.managed" = "true"
+    gitops_managed = "true"
   }
   # ...rest of job definition
 }
@@ -200,7 +200,7 @@ job "my-service" {
 
 ```bash
 ./nomad-botherer --managed-meta-prefix='myorg' ...
-# opts in jobs with meta { "myorg.managed" = "true" }
+# opts in jobs with meta { myorg_managed = "true" }
 ```
 
 **Disabling meta-based selection entirely** (glob only):
@@ -294,7 +294,7 @@ Every flag has a corresponding environment variable. Environment variables are r
 | `--diff-interval` | `DIFF_INTERVAL` | `1m` | Periodic Nomad-side drift check interval |
 | `--include-dead-jobs` | `INCLUDE_DEAD_JOBS` | `false` | Treat dead Nomad jobs like running ones (by default dead jobs count as missing) |
 | `--job-selector-glob` | `JOB_SELECTOR_GLOB` | *(empty — no glob)* | Glob pattern selecting jobs to watch by name (e.g. `myprefix-*`, `*` for all). Combined with `--managed-meta-prefix` as a union. |
-| `--managed-meta-prefix` | `MANAGED_META_PREFIX` | `gitops` | Prefix for job meta keys used by nomad-botherer. With prefix `gitops`, the key `gitops.managed=true` opts a job in. Empty disables meta-based selection. |
+| `--managed-meta-prefix` | `MANAGED_META_PREFIX` | `gitops` | Prefix for job meta keys used by nomad-botherer. With prefix `gitops`, the key `gitops_managed = "true"` opts a job in. Empty disables meta-based selection. |
 | `--max-git-staleness` | `MAX_GIT_STALENESS` | `0` (disabled) | If the git repo has not been successfully fetched within this window, force an immediate fetch. Set to `0` to disable. E.g. `--max-git-staleness=30m` |
 | `--max-nomad-staleness` | `MAX_NOMAD_STALENESS` | `0` (disabled) | If the Nomad diff check has not run within this window, force an immediate check. Set to `0` to disable. E.g. `--max-nomad-staleness=10m` |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -141,7 +141,7 @@ prevents the plan-then-register race that neither existing operator handles.
 
 **Opt-in scope via job meta.** Rather than managing every job found in the repo
 or every job tagged with an operator-specific key the tool wrote, the intent is
-to require an explicit `gitops.managed = "true"` key in the job's HCL meta
+to require an explicit `gitops_managed = "true"` key in the job's HCL meta
 stanza. This is the "Operator Pattern in Nomad" — the same model that scalad
 (trivago) uses for autoscaling opt-in and that Pondidum/nomad-operator
 documented for backup automation in 2021. A job without the opt-in key is never

--- a/docs/proposals/change-checkpointing.md
+++ b/docs/proposals/change-checkpointing.md
@@ -408,6 +408,8 @@ alternative is an implementation of that interface; the update queue does not
 need to know which backend is active. The opt-in flag is orthogonal to this
 interface and should be a config-level default (`--gitops-opt-in-key`, default:
 `gitops_managed`) so teams can rename it if they have a key naming convention.
+When customising the prefix, keeping `gitops` as a root (e.g. `gitops_myteam`)
+is recommended so all nomad-botherer keys remain visually grouped across teams.
 
 ---
 

--- a/docs/proposals/change-checkpointing.md
+++ b/docs/proposals/change-checkpointing.md
@@ -210,7 +210,7 @@ to GitOps management by declaring a meta key in their HCL:
 ```hcl
 job "api-server" {
   meta {
-    "gitops.managed" = "true"
+    gitops_managed = "true"
   }
   # rest of job spec
 }
@@ -218,7 +218,7 @@ job "api-server" {
 
 nomad-botherer reads this key from both the parsed HCL and the live job
 (`Jobs.Info()`) to decide whether to include a job in its reconciliation scope.
-A job without `gitops.managed = "true"` is skipped entirely — no diff, no
+A job without `gitops_managed = "true"` is skipped entirely — no diff, no
 apply, no deregister. The meta key is a scope selector, not a state store.
 
 This is a direct application of what the Nomad community calls the **Operator
@@ -261,18 +261,19 @@ for identity and selection (controllers use `labelSelector` to query), while
 annotations carry per-object configuration. It also mandates DNS-subdomain
 prefixes (e.g., `cert-manager.io/`) to prevent key collisions between tools.
 Nomad has no equivalent formal convention. The observed practice across the
-tools above is a short tool-name prefix with a dot separator (`gitops.managed`,
-`scaler`, `auto-backup`). Key naming is worth being deliberate about: keys
-containing characters outside `[A-Za-z0-9_.]` are silently converted to
-underscores when exposed as `NOMAD_META_*` environment variables inside tasks,
-though the original form is preserved in the API response.
+tools above is a short tool-name prefix with a separator (`gitops_managed`,
+`scaler`, `auto_backup`). Key naming is worth being deliberate about: using
+underscores keeps meta keys valid HCL2 identifiers, allowing the block form
+(`meta { gitops_managed = "true" }`) rather than the object-expression form with
+quoted keys. Keys are exposed as `NOMAD_META_*` environment variables inside
+tasks using the original form.
 
 **Separating opt-in from state storage**
 
 The version of this alternative described in earlier drafts conflated two
 distinct uses of the `Meta` map:
 
-1. **Opt-in flag** (set by humans in HCL, read by the tool): `gitops.managed =
+1. **Opt-in flag** (set by humans in HCL, read by the tool): `gitops_managed =
    "true"`. The human controls this; it lives in the HCL file and is therefore
    version-controlled. Safe and stable.
 
@@ -298,7 +299,7 @@ and controls; store applied state in Nomad Variables (Alternative 1).
 // jobs/api-server.hcl (human-controlled, version-controlled)
 job "api-server" {
   meta {
-    "gitops.managed" = "true"
+    gitops_managed = "true"
   }
 }
 ```
@@ -306,10 +307,10 @@ job "api-server" {
 nomad-botherer behaviour with this flag:
 
 - Include a job in the diff scope if and only if its HCL file or its live
-  `Jobs.Info()` response contains `meta["gitops.managed"] == "true"`.
+  `Jobs.Info()` response contains `meta["gitops_managed"] == "true"`.
 - Store checkpoint state in Nomad Variables (Alternative 1). Never write back
   to the job's `meta` stanza.
-- A live job that does not have `gitops.managed` is never flagged as
+- A live job that does not have `gitops_managed` is never flagged as
   `missing_from_hcl`, even if it has no corresponding HCL file. This prevents
   nomad-botherer from attempting to deregister manually-registered jobs.
 
@@ -319,8 +320,8 @@ nomad-botherer behaviour with this flag:
 narrower scope:
 
 - For HCL files: include only files whose parsed job spec has
-  `meta["gitops.managed"] == "true"`.
-- For live Nomad jobs: include only jobs with `meta["gitops.managed"] == "true"`
+  `meta["gitops_managed"] == "true"`.
+- For live Nomad jobs: include only jobs with `meta["gitops_managed"] == "true"`
   in their live spec.
 - The `missing_from_hcl` drift type becomes "a managed job (live meta has the
   flag) has no HCL file". This is a meaningful and intentional signal, not "any
@@ -328,7 +329,7 @@ narrower scope:
 
 The `missingFromNomad` type changes to "an HCL file has the opt-in key but the
 job does not exist in Nomad yet". The first registration also writes
-`gitops.managed = "true"` to the live job, which is already in the HCL, so
+`gitops_managed = "true"` to the live job, which is already in the HCL, so
 there is no meta drift from this write.
 
 **Pros**
@@ -346,7 +347,7 @@ there is no meta drift from this write.
 
 **Cons**
 
-- Every job that should be managed must have `gitops.managed = "true"` in its
+- Every job that should be managed must have `gitops_managed = "true"` in its
   HCL. Easy to forget; there is no directory-level default.
 - The key appears as `NOMAD_META_gitops_managed` in every allocation's
   environment, which is minor but visible noise.
@@ -390,7 +391,7 @@ layers on top of either of the other two rather than replacing them.
 
 Implement the hybrid of Alternative 3 + Alternative 1:
 
-1. Gate all GitOps behaviour behind the `gitops.managed = "true"` meta opt-in
+1. Gate all GitOps behaviour behind the `gitops_managed = "true"` meta opt-in
    (Alternative 3). This scopes the operator and prevents accidental deregistration
    of manually-managed jobs. It requires no infrastructure and works on any Nomad
    version.
@@ -406,7 +407,7 @@ The `CheckpointStore` interface above is the right abstraction boundary. Each
 alternative is an implementation of that interface; the update queue does not
 need to know which backend is active. The opt-in flag is orthogonal to this
 interface and should be a config-level default (`--gitops-opt-in-key`, default:
-`gitops.managed`) so teams can rename it if they have a key naming convention.
+`gitops_managed`) so teams can rename it if they have a key naming convention.
 
 ---
 

--- a/examples/nomad-botherer.hcl
+++ b/examples/nomad-botherer.hcl
@@ -146,8 +146,9 @@ job "nomad-botherer" {
         # Meta key (on by default): any job with
         #   meta { gitops_managed = "true" }
         # in its HCL definition is automatically watched. The prefix before
-        # "_managed" is controlled by MANAGED_META_PREFIX; change it if
-        # another team already owns "gitops_*" keys on your cluster.
+        # "_managed" is controlled by MANAGED_META_PREFIX. If you need to
+        # change it, keep "gitops" as a root (e.g. "gitops_myteam") so all
+        # nomad-botherer keys remain visually grouped on a shared cluster.
         MANAGED_META_PREFIX = "gitops"
 
         # Glob: watch all jobs whose name matches a shell glob pattern.

--- a/examples/nomad-botherer.hcl
+++ b/examples/nomad-botherer.hcl
@@ -19,9 +19,9 @@ job "nomad-botherer" {
 
   # Opt this job in to its own monitoring so nomad-botherer watches itself
   # for drift. The meta key name is controlled by MANAGED_META_PREFIX below;
-  # with the default prefix of "gitops" the key is "gitops.managed".
-  meta = {
-    "gitops.managed" = "true"
+  # with the default prefix of "gitops" the key is "gitops_managed".
+  meta {
+    gitops_managed = "true"
   }
 
   group "botherer" {
@@ -144,10 +144,10 @@ job "nomad-botherer" {
         # A job must match at least one of the two criteria below.
         #
         # Meta key (on by default): any job with
-        #   meta = { "gitops.managed" = "true" }
+        #   meta { gitops_managed = "true" }
         # in its HCL definition is automatically watched. The prefix before
-        # ".managed" is controlled by MANAGED_META_PREFIX; change it if
-        # another tool already owns "gitops.*" on your cluster.
+        # "_managed" is controlled by MANAGED_META_PREFIX; change it if
+        # another team already owns "gitops_*" keys on your cluster.
         MANAGED_META_PREFIX = "gitops"
 
         # Glob: watch all jobs whose name matches a shell glob pattern.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,7 +82,7 @@ func LoadFromArgs(fs *flag.FlagSet, args []string) (*Config, error) {
 	fs.DurationVar(&c.DiffInterval, "diff-interval", envDurationOrDefault("DIFF_INTERVAL", time.Minute), "How often to run a diff check regardless of git changes")
 	fs.BoolVar(&c.IncludeDeadJobs, "include-dead-jobs", envBoolOrDefault("INCLUDE_DEAD_JOBS", false), "Treat dead Nomad jobs like running ones (by default dead jobs are treated as missing)")
 	fs.StringVar(&c.JobSelectorGlob, "job-selector-glob", envOrDefault("JOB_SELECTOR_GLOB", ""), "Glob pattern selecting jobs by name (e.g. 'myprefix-*', '*' for all). Jobs matching either this or --managed-meta-prefix are watched. Empty means no glob selection.")
-	fs.StringVar(&c.ManagedMetaPrefix, "managed-meta-prefix", envOrDefault("MANAGED_META_PREFIX", "gitops"), "Prefix for job meta keys used by nomad-botherer (e.g. 'gitops' means 'gitops.managed' opts a job in). Empty disables meta-based selection.")
+	fs.StringVar(&c.ManagedMetaPrefix, "managed-meta-prefix", envOrDefault("MANAGED_META_PREFIX", "gitops"), "Prefix for job meta keys used by nomad-botherer (e.g. 'gitops' means 'gitops_managed = true' opts a job in). Empty disables meta-based selection.")
 	fs.DurationVar(&c.MaxGitStaleness, "max-git-staleness", envDurationOrDefault("MAX_GIT_STALENESS", 0), "Maximum time since last successful git fetch before forcing a refresh (0 disables)")
 	fs.DurationVar(&c.MaxNomadStaleness, "max-nomad-staleness", envDurationOrDefault("MAX_NOMAD_STALENESS", 0), "Maximum time since last successful Nomad diff check before forcing a refresh (0 disables)")
 

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -188,7 +188,7 @@ func NewWithClientAndRegistry(cfg *config.Config, jobs NomadJobsClient, reg prom
 
 // jobIsSelected reports whether a job should be watched. A job is selected when
 // its ID matches the configured glob pattern, or when its meta map contains
-// "<managedMetaPrefix>.managed" set to "true". If both are empty, no jobs
+// "<managedMetaPrefix>_managed" set to "true". If both are empty, no jobs
 // are selected.
 func (d *Differ) jobIsSelected(jobID string, meta map[string]string) bool {
 	if d.jobSelectorGlob != "" {
@@ -196,7 +196,7 @@ func (d *Differ) jobIsSelected(jobID string, meta map[string]string) bool {
 			return true
 		}
 	}
-	if d.managedMetaPrefix != "" && meta[d.managedMetaPrefix+".managed"] == "true" {
+	if d.managedMetaPrefix != "" && meta[d.managedMetaPrefix+"_managed"] == "true" {
 		return true
 	}
 	return false

--- a/internal/nomad/differ_test.go
+++ b/internal/nomad/differ_test.go
@@ -884,7 +884,7 @@ func TestDiffer_MetaSelection_Matches(t *testing.T) {
 	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
 		return &nomadapi.Job{
 			ID:   strPtr("managed-job"),
-			Meta: map[string]string{"gitops.managed": "true"},
+			Meta: map[string]string{"gitops_managed": "true"},
 		}, nil
 	}
 	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
@@ -920,13 +920,13 @@ func TestDiffer_MetaSelection_NoTag_JobSkipped(t *testing.T) {
 }
 
 // TestDiffer_MetaSelection_CustomPrefix verifies that a custom meta prefix works,
-// deriving the full key as "<prefix>.managed".
+// deriving the full key as "<prefix>_managed".
 func TestDiffer_MetaSelection_CustomPrefix(t *testing.T) {
 	mock := defaultMock()
 	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
 		return &nomadapi.Job{
 			ID:   strPtr("my-job"),
-			Meta: map[string]string{"myorg.managed": "true"},
+			Meta: map[string]string{"myorg_managed": "true"},
 		}, nil
 	}
 	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
@@ -953,7 +953,7 @@ func TestDiffer_GlobOrMeta_EitherSelects(t *testing.T) {
 		}
 		return &nomadapi.Job{
 			ID:   strPtr("by-meta"),
-			Meta: map[string]string{"gitops.managed": "true"},
+			Meta: map[string]string{"gitops_managed": "true"},
 		}, nil
 	}
 	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
@@ -980,7 +980,7 @@ func TestDiffer_MissingFromHCL_ManagedByMeta_Reported(t *testing.T) {
 	mock := defaultMock()
 	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
 		return []*nomadapi.JobListStub{
-			{ID: "managed-orphan", Status: "running", Meta: map[string]string{"gitops.managed": "true"}},
+			{ID: "managed-orphan", Status: "running", Meta: map[string]string{"gitops_managed": "true"}},
 		}, nil, nil
 	}
 	d := newTestDifferWithSelection(mock, "", "gitops")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -214,7 +214,7 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 
 	managedMetaKey := ""
 	if s.cfg.ManagedMetaPrefix != "" {
-		managedMetaKey = s.cfg.ManagedMetaPrefix + ".managed"
+		managedMetaKey = s.cfg.ManagedMetaPrefix + "_managed"
 	}
 
 	data := struct {

--- a/tests/regression/infra_test.go
+++ b/tests/regression/infra_test.go
@@ -396,19 +396,17 @@ job %q {
 `, jobID)
 }
 
-// testJobHCLWithMeta adds a gitops meta key that marks the job as managed.
-// The meta key contains a dot (e.g. "gitops.managed"), which is not a valid
-// HCL2 identifier and therefore cannot appear as an unquoted attribute name in
-// a block body. Using the object-expression form (meta = { ... }) allows
-// quoted keys and is accepted by Nomad's ParseHCL endpoint.
+// testJobHCLWithMeta produces HCL that opts a job in to nomad-botherer via the
+// meta block. The key name is "<prefix>_managed" — a valid HCL2 identifier, so
+// the block form (meta { ... }) can be used without quoting.
 func testJobHCLWithMeta(jobID, metaPrefix string) string {
 	return fmt.Sprintf(`
 job %q {
   datacenters = ["dc1"]
   type        = "service"
 
-  meta = {
-    %q = "true"
+  meta {
+    %s = "true"
   }
 
   group "main" {
@@ -427,7 +425,7 @@ job %q {
     }
   }
 }
-`, jobID, metaPrefix+".managed")
+`, jobID, metaPrefix+"_managed")
 }
 
 // ── Differ helpers ────────────────────────────────────────────────────────────

--- a/tests/regression/selection_test.go
+++ b/tests/regression/selection_test.go
@@ -96,7 +96,7 @@ func TestSelection_GlobNoMatch(t *testing.T) {
 	}
 }
 
-// TestSelection_MetaKey verifies that a job with the gitops.managed=true meta
+// TestSelection_MetaKey verifies that a job with the gitops_managed=true meta
 // key is selected by the meta-prefix selector.
 func TestSelection_MetaKey(t *testing.T) {
 	jobID := uniqueJobID("meta-sel")


### PR DESCRIPTION
## What

Changes the opt-in meta key from `"gitops.managed" = "true"` (dotted, requires quoted key) to `gitops_managed = "true"` (underscore, valid HCL2 identifier).

## Why

Dotted keys are not valid HCL2 identifiers. They require the object-expression form of `meta` with quoted keys:

```hcl
meta = {
  "gitops.managed" = "true"
}
```

Underscore makes it a valid identifier, so the idiomatic block form works:

```hcl
meta {
  gitops_managed = "true"
}
```

This is consistent with how every other Nomad meta key looks in practice, and how HCL is written everywhere else in a job spec.

## Breaking change

Any job HCL currently using `"gitops.managed" = "true"` must be updated to `gitops_managed = "true"` before upgrading. Jobs using the old key will not be selected after this change. The CHANGELOG documents the migration.

Custom prefixes (via `--managed-meta-prefix` / `MANAGED_META_PREFIX`) follow the same pattern: a prefix of `myorg` now produces `myorg_managed` rather than `myorg.managed`.

## Files changed

- `internal/nomad/differ.go` — key lookup changed from `prefix+".managed"` to `prefix+"_managed"`
- `internal/server/server.go` — same
- `internal/config/config.go` — flag description updated
- All tests updated to use the new key form
- `tests/regression/infra_test.go` — HCL generator updated to block form
- `examples/nomad-botherer.hcl` — updated to block form
- `README.md`, `CLAUDE.md`, `docs/` — all references updated
- `CHANGELOG.md` — v0.2.0 entry added