### PR TITLE
Add selected-jobs query: list watched jobs with selection reason

### DIFF
--- a/cmd/nbctl/commands.go
+++ b/cmd/nbctl/commands.go
@@ -59,6 +59,45 @@ func newDiffsCmd(cfg *rootConfig) *cobra.Command {
 	}
 }
 
+func newSelectedJobsCmd(cfg *rootConfig) *cobra.Command {
+	return &cobra.Command{
+		Use:   "selected-jobs",
+		Short: "List jobs currently selected for monitoring, and why each matched",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, close, err := cfg.dial()
+			if err != nil {
+				return err
+			}
+			defer close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+			defer cancel()
+
+			resp, err := client.GetSelectedJobs(ctx, &grpcapi.GetSelectedJobsRequest{})
+			if err != nil {
+				return fmt.Errorf("GetSelectedJobs: %w", err)
+			}
+
+			return printOutput(cmd.OutOrStdout(), cfg.outFmt, resp, func(w io.Writer) {
+				if len(resp.Jobs) == 0 {
+					fmt.Fprintln(w, "no jobs currently selected")
+				} else {
+					fmt.Fprintf(w, "%d job(s) selected\n", len(resp.Jobs))
+				}
+				if resp.LastCheckTime != "" {
+					fmt.Fprintf(w, "last check:  %s\n", resp.LastCheckTime)
+				}
+				if resp.LastCommit != "" {
+					fmt.Fprintf(w, "last commit: %s\n", resp.LastCommit)
+				}
+				for _, j := range resp.Jobs {
+					fmt.Fprintf(w, "  %-40s  %s\n", j.JobId, j.SelectionReason)
+				}
+			})
+		},
+	}
+}
+
 func newStatusCmd(cfg *rootConfig) *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",

--- a/cmd/nbctl/commands_test.go
+++ b/cmd/nbctl/commands_test.go
@@ -18,13 +18,18 @@ const testKey = "test-secret"
 
 // mockDiffSource implements grpcserver.DiffSource for tests.
 type mockDiffSource struct {
-	diffs      []nomad.JobDiff
-	lastCheck  time.Time
-	lastCommit string
+	diffs        []nomad.JobDiff
+	selectedJobs []nomad.SelectedJob
+	lastCheck    time.Time
+	lastCommit   string
 }
 
 func (m *mockDiffSource) Diffs() ([]nomad.JobDiff, time.Time, string) {
 	return m.diffs, m.lastCheck, m.lastCommit
+}
+
+func (m *mockDiffSource) SelectedJobs() ([]nomad.SelectedJob, time.Time, string) {
+	return m.selectedJobs, m.lastCheck, m.lastCommit
 }
 
 func (m *mockDiffSource) Ready() bool { return !m.lastCheck.IsZero() }
@@ -146,6 +151,48 @@ func TestDiffsCmd_JSON(t *testing.T) {
 }
 
 // ── status ───────────────────────────────────────────────────────────────────
+
+func TestSelectedJobsCmd_NoJobs(t *testing.T) {
+	now := time.Now()
+	addr, stop := startServer(t, &mockDiffSource{lastCheck: now}, &mockGitSource{lastUpdate: now}, defaultInfo)
+	defer stop()
+
+	out, err := runCmd(t, addr, testKey, "selected-jobs")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "no jobs currently selected") {
+		t.Errorf("want 'no jobs currently selected', got: %q", out)
+	}
+}
+
+func TestSelectedJobsCmd_WithJobs(t *testing.T) {
+	src := &mockDiffSource{
+		selectedJobs: []nomad.SelectedJob{
+			{JobID: "api", Reason: nomad.SelectionReasonMeta},
+			{JobID: "worker", Reason: nomad.SelectionReasonGlob},
+		},
+		lastCheck:  time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC),
+		lastCommit: "abc123",
+	}
+	git := &mockGitSource{lastUpdate: time.Now()}
+	addr, stop := startServer(t, src, git, defaultInfo)
+	defer stop()
+
+	out, err := runCmd(t, addr, testKey, "selected-jobs")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "2 job(s) selected") {
+		t.Errorf("want job count, got: %q", out)
+	}
+	if !strings.Contains(out, "api") || !strings.Contains(out, "meta") {
+		t.Errorf("want api/meta line, got: %q", out)
+	}
+	if !strings.Contains(out, "worker") || !strings.Contains(out, "glob") {
+		t.Errorf("want worker/glob line, got: %q", out)
+	}
+}
 
 func TestStatusCmd(t *testing.T) {
 	git := &mockGitSource{

--- a/cmd/nbctl/root.go
+++ b/cmd/nbctl/root.go
@@ -51,6 +51,7 @@ func newRootCmd() *cobra.Command {
 
 	root.AddCommand(
 		newDiffsCmd(cfg),
+		newSelectedJobsCmd(cfg),
 		newStatusCmd(cfg),
 		newRefreshCmd(cfg),
 		newVersionCmd(cfg),

--- a/internal/grpcapi/nomad_botherer.pb.go
+++ b/internal/grpcapi/nomad_botherer.pb.go
@@ -190,6 +190,158 @@ func (x *JobDiff) GetDetail() string {
 	return ""
 }
 
+type GetSelectedJobsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSelectedJobsRequest) Reset() {
+	*x = GetSelectedJobsRequest{}
+	mi := &file_nomad_botherer_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSelectedJobsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSelectedJobsRequest) ProtoMessage() {}
+
+func (x *GetSelectedJobsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_nomad_botherer_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSelectedJobsRequest.ProtoReflect.Descriptor instead.
+func (*GetSelectedJobsRequest) Descriptor() ([]byte, []int) {
+	return file_nomad_botherer_proto_rawDescGZIP(), []int{3}
+}
+
+type GetSelectedJobsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Jobs  []*SelectedJob         `protobuf:"bytes,1,rep,name=jobs,proto3" json:"jobs,omitempty"`
+	// RFC3339 timestamp of the last diff check.
+	LastCheckTime string `protobuf:"bytes,2,opt,name=last_check_time,json=lastCheckTime,proto3" json:"last_check_time,omitempty"`
+	// Git commit hash that was current during the last diff check.
+	LastCommit    string `protobuf:"bytes,3,opt,name=last_commit,json=lastCommit,proto3" json:"last_commit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSelectedJobsResponse) Reset() {
+	*x = GetSelectedJobsResponse{}
+	mi := &file_nomad_botherer_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSelectedJobsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSelectedJobsResponse) ProtoMessage() {}
+
+func (x *GetSelectedJobsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_nomad_botherer_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSelectedJobsResponse.ProtoReflect.Descriptor instead.
+func (*GetSelectedJobsResponse) Descriptor() ([]byte, []int) {
+	return file_nomad_botherer_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *GetSelectedJobsResponse) GetJobs() []*SelectedJob {
+	if x != nil {
+		return x.Jobs
+	}
+	return nil
+}
+
+func (x *GetSelectedJobsResponse) GetLastCheckTime() string {
+	if x != nil {
+		return x.LastCheckTime
+	}
+	return ""
+}
+
+func (x *GetSelectedJobsResponse) GetLastCommit() string {
+	if x != nil {
+		return x.LastCommit
+	}
+	return ""
+}
+
+// SelectedJob records a job that matched the configured selection criteria.
+type SelectedJob struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	JobId string                 `protobuf:"bytes,1,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
+	// One of: glob, meta, both.
+	SelectionReason string `protobuf:"bytes,2,opt,name=selection_reason,json=selectionReason,proto3" json:"selection_reason,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *SelectedJob) Reset() {
+	*x = SelectedJob{}
+	mi := &file_nomad_botherer_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SelectedJob) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SelectedJob) ProtoMessage() {}
+
+func (x *SelectedJob) ProtoReflect() protoreflect.Message {
+	mi := &file_nomad_botherer_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SelectedJob.ProtoReflect.Descriptor instead.
+func (*SelectedJob) Descriptor() ([]byte, []int) {
+	return file_nomad_botherer_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SelectedJob) GetJobId() string {
+	if x != nil {
+		return x.JobId
+	}
+	return ""
+}
+
+func (x *SelectedJob) GetSelectionReason() string {
+	if x != nil {
+		return x.SelectionReason
+	}
+	return ""
+}
+
 type GetStatusRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -198,7 +350,7 @@ type GetStatusRequest struct {
 
 func (x *GetStatusRequest) Reset() {
 	*x = GetStatusRequest{}
-	mi := &file_nomad_botherer_proto_msgTypes[3]
+	mi := &file_nomad_botherer_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -210,7 +362,7 @@ func (x *GetStatusRequest) String() string {
 func (*GetStatusRequest) ProtoMessage() {}
 
 func (x *GetStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_nomad_botherer_proto_msgTypes[3]
+	mi := &file_nomad_botherer_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -223,7 +375,7 @@ func (x *GetStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetStatusRequest) Descriptor() ([]byte, []int) {
-	return file_nomad_botherer_proto_rawDescGZIP(), []int{3}
+	return file_nomad_botherer_proto_rawDescGZIP(), []int{6}
 }
 
 type GetStatusResponse struct {
@@ -237,7 +389,7 @@ type GetStatusResponse struct {
 
 func (x *GetStatusResponse) Reset() {
 	*x = GetStatusResponse{}
-	mi := &file_nomad_botherer_proto_msgTypes[4]
+	mi := &file_nomad_botherer_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -249,7 +401,7 @@ func (x *GetStatusResponse) String() string {
 func (*GetStatusResponse) ProtoMessage() {}
 
 func (x *GetStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_nomad_botherer_proto_msgTypes[4]
+	mi := &file_nomad_botherer_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -262,7 +414,7 @@ func (x *GetStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetStatusResponse) Descriptor() ([]byte, []int) {
-	return file_nomad_botherer_proto_rawDescGZIP(), []int{4}
+	return file_nomad_botherer_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetStatusResponse) GetLastCommit() string {
@@ -287,7 +439,7 @@ type TriggerRefreshRequest struct {
 
 func (x *TriggerRefreshRequest) Reset() {
 	*x = TriggerRefreshRequest{}
-	mi := &file_nomad_botherer_proto_msgTypes[5]
+	mi := &file_nomad_botherer_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -299,7 +451,7 @@ func (x *TriggerRefreshRequest) String() string {
 func (*TriggerRefreshRequest) ProtoMessage() {}
 
 func (x *TriggerRefreshRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_nomad_botherer_proto_msgTypes[5]
+	mi := &file_nomad_botherer_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -312,7 +464,7 @@ func (x *TriggerRefreshRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerRefreshRequest.ProtoReflect.Descriptor instead.
 func (*TriggerRefreshRequest) Descriptor() ([]byte, []int) {
-	return file_nomad_botherer_proto_rawDescGZIP(), []int{5}
+	return file_nomad_botherer_proto_rawDescGZIP(), []int{8}
 }
 
 type TriggerRefreshResponse struct {
@@ -324,7 +476,7 @@ type TriggerRefreshResponse struct {
 
 func (x *TriggerRefreshResponse) Reset() {
 	*x = TriggerRefreshResponse{}
-	mi := &file_nomad_botherer_proto_msgTypes[6]
+	mi := &file_nomad_botherer_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -336,7 +488,7 @@ func (x *TriggerRefreshResponse) String() string {
 func (*TriggerRefreshResponse) ProtoMessage() {}
 
 func (x *TriggerRefreshResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_nomad_botherer_proto_msgTypes[6]
+	mi := &file_nomad_botherer_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -349,7 +501,7 @@ func (x *TriggerRefreshResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerRefreshResponse.ProtoReflect.Descriptor instead.
 func (*TriggerRefreshResponse) Descriptor() ([]byte, []int) {
-	return file_nomad_botherer_proto_rawDescGZIP(), []int{6}
+	return file_nomad_botherer_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *TriggerRefreshResponse) GetMessage() string {
@@ -367,7 +519,7 @@ type GetVersionRequest struct {
 
 func (x *GetVersionRequest) Reset() {
 	*x = GetVersionRequest{}
-	mi := &file_nomad_botherer_proto_msgTypes[7]
+	mi := &file_nomad_botherer_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -379,7 +531,7 @@ func (x *GetVersionRequest) String() string {
 func (*GetVersionRequest) ProtoMessage() {}
 
 func (x *GetVersionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_nomad_botherer_proto_msgTypes[7]
+	mi := &file_nomad_botherer_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -392,7 +544,7 @@ func (x *GetVersionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVersionRequest.ProtoReflect.Descriptor instead.
 func (*GetVersionRequest) Descriptor() ([]byte, []int) {
-	return file_nomad_botherer_proto_rawDescGZIP(), []int{7}
+	return file_nomad_botherer_proto_rawDescGZIP(), []int{10}
 }
 
 type GetVersionResponse struct {
@@ -409,7 +561,7 @@ type GetVersionResponse struct {
 
 func (x *GetVersionResponse) Reset() {
 	*x = GetVersionResponse{}
-	mi := &file_nomad_botherer_proto_msgTypes[8]
+	mi := &file_nomad_botherer_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -421,7 +573,7 @@ func (x *GetVersionResponse) String() string {
 func (*GetVersionResponse) ProtoMessage() {}
 
 func (x *GetVersionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_nomad_botherer_proto_msgTypes[8]
+	mi := &file_nomad_botherer_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -434,7 +586,7 @@ func (x *GetVersionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVersionResponse.ProtoReflect.Descriptor instead.
 func (*GetVersionResponse) Descriptor() ([]byte, []int) {
-	return file_nomad_botherer_proto_rawDescGZIP(), []int{8}
+	return file_nomad_botherer_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GetVersionResponse) GetVersion() string {
@@ -473,7 +625,16 @@ const file_nomad_botherer_proto_rawDesc = "" +
 	"\x06job_id\x18\x01 \x01(\tR\x05jobId\x12\x19\n" +
 	"\bhcl_file\x18\x02 \x01(\tR\ahclFile\x12\x1b\n" +
 	"\tdiff_type\x18\x03 \x01(\tR\bdiffType\x12\x16\n" +
-	"\x06detail\x18\x04 \x01(\tR\x06detail\"\x12\n" +
+	"\x06detail\x18\x04 \x01(\tR\x06detail\"\x18\n" +
+	"\x16GetSelectedJobsRequest\"\x96\x01\n" +
+	"\x17GetSelectedJobsResponse\x122\n" +
+	"\x04jobs\x18\x01 \x03(\v2\x1e.nomad_botherer.v1.SelectedJobR\x04jobs\x12&\n" +
+	"\x0flast_check_time\x18\x02 \x01(\tR\rlastCheckTime\x12\x1f\n" +
+	"\vlast_commit\x18\x03 \x01(\tR\n" +
+	"lastCommit\"O\n" +
+	"\vSelectedJob\x12\x15\n" +
+	"\x06job_id\x18\x01 \x01(\tR\x05jobId\x12)\n" +
+	"\x10selection_reason\x18\x02 \x01(\tR\x0fselectionReason\"\x12\n" +
 	"\x10GetStatusRequest\"^\n" +
 	"\x11GetStatusResponse\x12\x1f\n" +
 	"\vlast_commit\x18\x01 \x01(\tR\n" +
@@ -487,9 +648,10 @@ const file_nomad_botherer_proto_rawDesc = "" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x16\n" +
 	"\x06commit\x18\x02 \x01(\tR\x06commit\x12\x1d\n" +
 	"\n" +
-	"build_date\x18\x03 \x01(\tR\tbuildDate2\xfe\x02\n" +
+	"build_date\x18\x03 \x01(\tR\tbuildDate2\xe8\x03\n" +
 	"\rNomadBotherer\x12S\n" +
-	"\bGetDiffs\x12\".nomad_botherer.v1.GetDiffsRequest\x1a#.nomad_botherer.v1.GetDiffsResponse\x12V\n" +
+	"\bGetDiffs\x12\".nomad_botherer.v1.GetDiffsRequest\x1a#.nomad_botherer.v1.GetDiffsResponse\x12h\n" +
+	"\x0fGetSelectedJobs\x12).nomad_botherer.v1.GetSelectedJobsRequest\x1a*.nomad_botherer.v1.GetSelectedJobsResponse\x12V\n" +
 	"\tGetStatus\x12#.nomad_botherer.v1.GetStatusRequest\x1a$.nomad_botherer.v1.GetStatusResponse\x12e\n" +
 	"\x0eTriggerRefresh\x12(.nomad_botherer.v1.TriggerRefreshRequest\x1a).nomad_botherer.v1.TriggerRefreshResponse\x12Y\n" +
 	"\n" +
@@ -507,33 +669,39 @@ func file_nomad_botherer_proto_rawDescGZIP() []byte {
 	return file_nomad_botherer_proto_rawDescData
 }
 
-var file_nomad_botherer_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_nomad_botherer_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_nomad_botherer_proto_goTypes = []any{
-	(*GetDiffsRequest)(nil),        // 0: nomad_botherer.v1.GetDiffsRequest
-	(*GetDiffsResponse)(nil),       // 1: nomad_botherer.v1.GetDiffsResponse
-	(*JobDiff)(nil),                // 2: nomad_botherer.v1.JobDiff
-	(*GetStatusRequest)(nil),       // 3: nomad_botherer.v1.GetStatusRequest
-	(*GetStatusResponse)(nil),      // 4: nomad_botherer.v1.GetStatusResponse
-	(*TriggerRefreshRequest)(nil),  // 5: nomad_botherer.v1.TriggerRefreshRequest
-	(*TriggerRefreshResponse)(nil), // 6: nomad_botherer.v1.TriggerRefreshResponse
-	(*GetVersionRequest)(nil),      // 7: nomad_botherer.v1.GetVersionRequest
-	(*GetVersionResponse)(nil),     // 8: nomad_botherer.v1.GetVersionResponse
+	(*GetDiffsRequest)(nil),         // 0: nomad_botherer.v1.GetDiffsRequest
+	(*GetDiffsResponse)(nil),        // 1: nomad_botherer.v1.GetDiffsResponse
+	(*JobDiff)(nil),                 // 2: nomad_botherer.v1.JobDiff
+	(*GetSelectedJobsRequest)(nil),  // 3: nomad_botherer.v1.GetSelectedJobsRequest
+	(*GetSelectedJobsResponse)(nil), // 4: nomad_botherer.v1.GetSelectedJobsResponse
+	(*SelectedJob)(nil),             // 5: nomad_botherer.v1.SelectedJob
+	(*GetStatusRequest)(nil),        // 6: nomad_botherer.v1.GetStatusRequest
+	(*GetStatusResponse)(nil),       // 7: nomad_botherer.v1.GetStatusResponse
+	(*TriggerRefreshRequest)(nil),   // 8: nomad_botherer.v1.TriggerRefreshRequest
+	(*TriggerRefreshResponse)(nil),  // 9: nomad_botherer.v1.TriggerRefreshResponse
+	(*GetVersionRequest)(nil),       // 10: nomad_botherer.v1.GetVersionRequest
+	(*GetVersionResponse)(nil),      // 11: nomad_botherer.v1.GetVersionResponse
 }
 var file_nomad_botherer_proto_depIdxs = []int32{
-	2, // 0: nomad_botherer.v1.GetDiffsResponse.diffs:type_name -> nomad_botherer.v1.JobDiff
-	0, // 1: nomad_botherer.v1.NomadBotherer.GetDiffs:input_type -> nomad_botherer.v1.GetDiffsRequest
-	3, // 2: nomad_botherer.v1.NomadBotherer.GetStatus:input_type -> nomad_botherer.v1.GetStatusRequest
-	5, // 3: nomad_botherer.v1.NomadBotherer.TriggerRefresh:input_type -> nomad_botherer.v1.TriggerRefreshRequest
-	7, // 4: nomad_botherer.v1.NomadBotherer.GetVersion:input_type -> nomad_botherer.v1.GetVersionRequest
-	1, // 5: nomad_botherer.v1.NomadBotherer.GetDiffs:output_type -> nomad_botherer.v1.GetDiffsResponse
-	4, // 6: nomad_botherer.v1.NomadBotherer.GetStatus:output_type -> nomad_botherer.v1.GetStatusResponse
-	6, // 7: nomad_botherer.v1.NomadBotherer.TriggerRefresh:output_type -> nomad_botherer.v1.TriggerRefreshResponse
-	8, // 8: nomad_botherer.v1.NomadBotherer.GetVersion:output_type -> nomad_botherer.v1.GetVersionResponse
-	5, // [5:9] is the sub-list for method output_type
-	1, // [1:5] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2,  // 0: nomad_botherer.v1.GetDiffsResponse.diffs:type_name -> nomad_botherer.v1.JobDiff
+	5,  // 1: nomad_botherer.v1.GetSelectedJobsResponse.jobs:type_name -> nomad_botherer.v1.SelectedJob
+	0,  // 2: nomad_botherer.v1.NomadBotherer.GetDiffs:input_type -> nomad_botherer.v1.GetDiffsRequest
+	3,  // 3: nomad_botherer.v1.NomadBotherer.GetSelectedJobs:input_type -> nomad_botherer.v1.GetSelectedJobsRequest
+	6,  // 4: nomad_botherer.v1.NomadBotherer.GetStatus:input_type -> nomad_botherer.v1.GetStatusRequest
+	8,  // 5: nomad_botherer.v1.NomadBotherer.TriggerRefresh:input_type -> nomad_botherer.v1.TriggerRefreshRequest
+	10, // 6: nomad_botherer.v1.NomadBotherer.GetVersion:input_type -> nomad_botherer.v1.GetVersionRequest
+	1,  // 7: nomad_botherer.v1.NomadBotherer.GetDiffs:output_type -> nomad_botherer.v1.GetDiffsResponse
+	4,  // 8: nomad_botherer.v1.NomadBotherer.GetSelectedJobs:output_type -> nomad_botherer.v1.GetSelectedJobsResponse
+	7,  // 9: nomad_botherer.v1.NomadBotherer.GetStatus:output_type -> nomad_botherer.v1.GetStatusResponse
+	9,  // 10: nomad_botherer.v1.NomadBotherer.TriggerRefresh:output_type -> nomad_botherer.v1.TriggerRefreshResponse
+	11, // 11: nomad_botherer.v1.NomadBotherer.GetVersion:output_type -> nomad_botherer.v1.GetVersionResponse
+	7,  // [7:12] is the sub-list for method output_type
+	2,  // [2:7] is the sub-list for method input_type
+	2,  // [2:2] is the sub-list for extension type_name
+	2,  // [2:2] is the sub-list for extension extendee
+	0,  // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_nomad_botherer_proto_init() }
@@ -547,7 +715,7 @@ func file_nomad_botherer_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_nomad_botherer_proto_rawDesc), len(file_nomad_botherer_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/grpcapi/nomad_botherer_grpc.pb.go
+++ b/internal/grpcapi/nomad_botherer_grpc.pb.go
@@ -19,10 +19,11 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	NomadBotherer_GetDiffs_FullMethodName       = "/nomad_botherer.v1.NomadBotherer/GetDiffs"
-	NomadBotherer_GetStatus_FullMethodName      = "/nomad_botherer.v1.NomadBotherer/GetStatus"
-	NomadBotherer_TriggerRefresh_FullMethodName = "/nomad_botherer.v1.NomadBotherer/TriggerRefresh"
-	NomadBotherer_GetVersion_FullMethodName     = "/nomad_botherer.v1.NomadBotherer/GetVersion"
+	NomadBotherer_GetDiffs_FullMethodName        = "/nomad_botherer.v1.NomadBotherer/GetDiffs"
+	NomadBotherer_GetSelectedJobs_FullMethodName = "/nomad_botherer.v1.NomadBotherer/GetSelectedJobs"
+	NomadBotherer_GetStatus_FullMethodName       = "/nomad_botherer.v1.NomadBotherer/GetStatus"
+	NomadBotherer_TriggerRefresh_FullMethodName  = "/nomad_botherer.v1.NomadBotherer/TriggerRefresh"
+	NomadBotherer_GetVersion_FullMethodName      = "/nomad_botherer.v1.NomadBotherer/GetVersion"
 )
 
 // NomadBothererClient is the client API for NomadBotherer service.
@@ -33,6 +34,9 @@ const (
 type NomadBothererClient interface {
 	// GetDiffs returns the current set of job diffs detected between git and Nomad.
 	GetDiffs(ctx context.Context, in *GetDiffsRequest, opts ...grpc.CallOption) (*GetDiffsResponse, error)
+	// GetSelectedJobs returns all jobs that matched the configured selection
+	// criteria during the last check, together with the reason each was included.
+	GetSelectedJobs(ctx context.Context, in *GetSelectedJobsRequest, opts ...grpc.CallOption) (*GetSelectedJobsResponse, error)
 	// GetStatus returns git watcher status (last commit, last update time).
 	GetStatus(ctx context.Context, in *GetStatusRequest, opts ...grpc.CallOption) (*GetStatusResponse, error)
 	// TriggerRefresh causes an immediate git pull and diff check.
@@ -53,6 +57,16 @@ func (c *nomadBothererClient) GetDiffs(ctx context.Context, in *GetDiffsRequest,
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetDiffsResponse)
 	err := c.cc.Invoke(ctx, NomadBotherer_GetDiffs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *nomadBothererClient) GetSelectedJobs(ctx context.Context, in *GetSelectedJobsRequest, opts ...grpc.CallOption) (*GetSelectedJobsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetSelectedJobsResponse)
+	err := c.cc.Invoke(ctx, NomadBotherer_GetSelectedJobs_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -97,6 +111,9 @@ func (c *nomadBothererClient) GetVersion(ctx context.Context, in *GetVersionRequ
 type NomadBothererServer interface {
 	// GetDiffs returns the current set of job diffs detected between git and Nomad.
 	GetDiffs(context.Context, *GetDiffsRequest) (*GetDiffsResponse, error)
+	// GetSelectedJobs returns all jobs that matched the configured selection
+	// criteria during the last check, together with the reason each was included.
+	GetSelectedJobs(context.Context, *GetSelectedJobsRequest) (*GetSelectedJobsResponse, error)
 	// GetStatus returns git watcher status (last commit, last update time).
 	GetStatus(context.Context, *GetStatusRequest) (*GetStatusResponse, error)
 	// TriggerRefresh causes an immediate git pull and diff check.
@@ -115,6 +132,9 @@ type UnimplementedNomadBothererServer struct{}
 
 func (UnimplementedNomadBothererServer) GetDiffs(context.Context, *GetDiffsRequest) (*GetDiffsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetDiffs not implemented")
+}
+func (UnimplementedNomadBothererServer) GetSelectedJobs(context.Context, *GetSelectedJobsRequest) (*GetSelectedJobsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSelectedJobs not implemented")
 }
 func (UnimplementedNomadBothererServer) GetStatus(context.Context, *GetStatusRequest) (*GetStatusResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetStatus not implemented")
@@ -160,6 +180,24 @@ func _NomadBotherer_GetDiffs_Handler(srv interface{}, ctx context.Context, dec f
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(NomadBothererServer).GetDiffs(ctx, req.(*GetDiffsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _NomadBotherer_GetSelectedJobs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSelectedJobsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NomadBothererServer).GetSelectedJobs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NomadBotherer_GetSelectedJobs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NomadBothererServer).GetSelectedJobs(ctx, req.(*GetSelectedJobsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -228,6 +266,10 @@ var NomadBotherer_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetDiffs",
 			Handler:    _NomadBotherer_GetDiffs_Handler,
+		},
+		{
+			MethodName: "GetSelectedJobs",
+			Handler:    _NomadBotherer_GetSelectedJobs_Handler,
 		},
 		{
 			MethodName: "GetStatus",

--- a/internal/grpcserver/server.go
+++ b/internal/grpcserver/server.go
@@ -25,6 +25,7 @@ import (
 // DiffSource is satisfied by *nomad.Differ.
 type DiffSource interface {
 	Diffs() ([]nomad.JobDiff, time.Time, string)
+	SelectedJobs() ([]nomad.SelectedJob, time.Time, string)
 	// Ready reports whether at least one diff check has completed.
 	Ready() bool
 }
@@ -169,6 +170,32 @@ func (s *Server) GetDiffs(_ context.Context, _ *grpcapi.GetDiffsRequest) (*grpca
 
 	resp := &grpcapi.GetDiffsResponse{
 		Diffs:      pbDiffs,
+		LastCommit: lastCommit,
+	}
+	if !lastCheck.IsZero() {
+		resp.LastCheckTime = lastCheck.UTC().Format(time.RFC3339)
+	}
+	return resp, nil
+}
+
+// GetSelectedJobs returns the jobs that matched the configured selection criteria
+// during the last check, together with the reason each was included.
+func (s *Server) GetSelectedJobs(_ context.Context, _ *grpcapi.GetSelectedJobsRequest) (*grpcapi.GetSelectedJobsResponse, error) {
+	if !s.git.Ready() || !s.diffs.Ready() {
+		return nil, status.Error(codes.Unavailable, "server is not ready: initial state not yet built")
+	}
+	jobs, lastCheck, lastCommit := s.diffs.SelectedJobs()
+
+	pbJobs := make([]*grpcapi.SelectedJob, 0, len(jobs))
+	for _, j := range jobs {
+		pbJobs = append(pbJobs, &grpcapi.SelectedJob{
+			JobId:           j.JobID,
+			SelectionReason: string(j.Reason),
+		})
+	}
+
+	resp := &grpcapi.GetSelectedJobsResponse{
+		Jobs:       pbJobs,
 		LastCommit: lastCommit,
 	}
 	if !lastCheck.IsZero() {

--- a/internal/grpcserver/server_test.go
+++ b/internal/grpcserver/server_test.go
@@ -22,13 +22,18 @@ const testAPIKey = "test-key-abc123"
 
 // mockDiffSource implements grpcserver.DiffSource.
 type mockDiffSource struct {
-	diffs      []nomad.JobDiff
-	lastCheck  time.Time
-	lastCommit string
+	diffs         []nomad.JobDiff
+	selectedJobs  []nomad.SelectedJob
+	lastCheck     time.Time
+	lastCommit    string
 }
 
 func (m *mockDiffSource) Diffs() ([]nomad.JobDiff, time.Time, string) {
 	return m.diffs, m.lastCheck, m.lastCommit
+}
+
+func (m *mockDiffSource) SelectedJobs() ([]nomad.SelectedJob, time.Time, string) {
+	return m.selectedJobs, m.lastCheck, m.lastCommit
 }
 
 func (m *mockDiffSource) Ready() bool { return !m.lastCheck.IsZero() }
@@ -484,5 +489,77 @@ func TestMetrics_SuccessfulRequestCounted(t *testing.T) {
 	}
 	if total != 1 {
 		t.Fatalf("want 1 request total, got %v", total)
+	}
+}
+
+func TestGetSelectedJobs_Empty(t *testing.T) {
+	diffSrc := &mockDiffSource{
+		lastCheck:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		lastCommit: "abc123",
+	}
+	gitSrc := &mockGitSource{lastCommit: "abc123", lastUpdate: time.Now()}
+	client, stop := startTestServer(t, diffSrc, gitSrc)
+	defer stop()
+
+	resp, err := client.GetSelectedJobs(authCtx(testAPIKey), &grpcapi.GetSelectedJobsRequest{})
+	if err != nil {
+		t.Fatalf("GetSelectedJobs: %v", err)
+	}
+	if len(resp.Jobs) != 0 {
+		t.Errorf("want 0 jobs, got %d", len(resp.Jobs))
+	}
+	if resp.LastCheckTime == "" {
+		t.Errorf("want non-empty last_check_time")
+	}
+	if resp.LastCommit != "abc123" {
+		t.Errorf("want last_commit abc123, got %q", resp.LastCommit)
+	}
+}
+
+func TestGetSelectedJobs_WithJobs(t *testing.T) {
+	diffSrc := &mockDiffSource{
+		lastCheck:  time.Now(),
+		lastCommit: "def456",
+		selectedJobs: []nomad.SelectedJob{
+			{JobID: "api", Reason: nomad.SelectionReasonMeta},
+			{JobID: "worker", Reason: nomad.SelectionReasonGlob},
+			{JobID: "both-job", Reason: nomad.SelectionReasonBoth},
+		},
+	}
+	gitSrc := &mockGitSource{lastCommit: "def456", lastUpdate: time.Now()}
+	client, stop := startTestServer(t, diffSrc, gitSrc)
+	defer stop()
+
+	resp, err := client.GetSelectedJobs(authCtx(testAPIKey), &grpcapi.GetSelectedJobsRequest{})
+	if err != nil {
+		t.Fatalf("GetSelectedJobs: %v", err)
+	}
+	if len(resp.Jobs) != 3 {
+		t.Fatalf("want 3 jobs, got %d: %+v", len(resp.Jobs), resp.Jobs)
+	}
+	byID := make(map[string]string)
+	for _, j := range resp.Jobs {
+		byID[j.JobId] = j.SelectionReason
+	}
+	if byID["api"] != "meta" {
+		t.Errorf("api: want reason meta, got %q", byID["api"])
+	}
+	if byID["worker"] != "glob" {
+		t.Errorf("worker: want reason glob, got %q", byID["worker"])
+	}
+	if byID["both-job"] != "both" {
+		t.Errorf("both-job: want reason both, got %q", byID["both-job"])
+	}
+}
+
+func TestGetSelectedJobs_NotReady(t *testing.T) {
+	diffSrc := &mockDiffSource{} // zero lastCheck → not ready
+	gitSrc := &mockGitSource{lastCommit: "abc", lastUpdate: time.Now()}
+	client, stop := startTestServer(t, diffSrc, gitSrc)
+	defer stop()
+
+	_, err := client.GetSelectedJobs(authCtx(testAPIKey), &grpcapi.GetSelectedJobsRequest{})
+	if status.Code(err) != codes.Unavailable {
+		t.Errorf("want Unavailable, got %v", err)
 	}
 }

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"path"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -39,6 +40,25 @@ const (
 	DiffTypeMissingFromHCL DiffType = "missing_from_hcl"
 )
 
+// SelectionReason describes why a job was included in the watched set.
+type SelectionReason string
+
+const (
+	// SelectionReasonGlob means the job was selected by the job-selector-glob pattern.
+	SelectionReasonGlob SelectionReason = "glob"
+	// SelectionReasonMeta means the job was selected by the managed-meta-prefix key.
+	SelectionReasonMeta SelectionReason = "meta"
+	// SelectionReasonBoth means the job matched both the glob and the meta key.
+	SelectionReasonBoth SelectionReason = "both"
+)
+
+// SelectedJob records a job that matched the configured selection criteria
+// and the reason it was included.
+type SelectedJob struct {
+	JobID  string          `json:"job_id"`
+	Reason SelectionReason `json:"selection_reason"`
+}
+
 // JobDiff describes a single divergence between the git repo and Nomad.
 type JobDiff struct {
 	JobID    string   `json:"job_id"`
@@ -70,9 +90,10 @@ type Differ struct {
 
 	mu              sync.RWMutex
 	diffs           []JobDiff
+	selectedJobs    []SelectedJob
 	lastCheckTime   time.Time
 	lastCommit      string
-	lastNomadIndex  uint64            // Raft index from the last successful List(); protected by mu
+	lastNomadIndex  uint64               // Raft index from the last successful List(); protected by mu
 	driftFirstSeen  map[string]time.Time // key: driftKey(jobID, diffType); protected by mu
 
 	hclParseErrors      prometheus.Counter
@@ -186,20 +207,52 @@ func NewWithClientAndRegistry(cfg *config.Config, jobs NomadJobsClient, reg prom
 	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaPrefix, reg)
 }
 
-// jobIsSelected reports whether a job should be watched. A job is selected when
-// its ID matches the configured glob pattern, or when its meta map contains
-// "<managedMetaPrefix>_managed" set to "true". If both are empty, no jobs
-// are selected.
-func (d *Differ) jobIsSelected(jobID string, meta map[string]string) bool {
-	if d.jobSelectorGlob != "" {
-		if matched, _ := path.Match(d.jobSelectorGlob, jobID); matched {
-			return true
-		}
+// jobSelectionReason reports whether a job should be watched and, if so, why.
+// A job is selected when its ID matches the configured glob pattern, when its
+// meta map contains "<managedMetaPrefix>_managed" set to "true", or both.
+// Returns false and an empty reason when neither criterion matches.
+func (d *Differ) jobSelectionReason(jobID string, meta map[string]string) (bool, SelectionReason) {
+	glob := d.jobSelectorGlob != ""
+	if glob {
+		matched, _ := path.Match(d.jobSelectorGlob, jobID)
+		glob = matched
 	}
-	if d.managedMetaPrefix != "" && meta[d.managedMetaPrefix+"_managed"] == "true" {
-		return true
+	meta_ := d.managedMetaPrefix != "" && meta[d.managedMetaPrefix+"_managed"] == "true"
+	switch {
+	case glob && meta_:
+		return true, SelectionReasonBoth
+	case glob:
+		return true, SelectionReasonGlob
+	case meta_:
+		return true, SelectionReasonMeta
+	default:
+		return false, ""
 	}
-	return false
+}
+
+// mergeSelectionReason returns the combined reason when a job is seen from
+// multiple sources (e.g. HCL phase and Nomad phase). Any combination of two
+// different non-empty reasons upgrades to SelectionReasonBoth.
+func mergeSelectionReason(existing, new SelectionReason) SelectionReason {
+	if existing == "" {
+		return new
+	}
+	if existing == new {
+		return existing
+	}
+	return SelectionReasonBoth
+}
+
+// SelectedJobs returns a snapshot of the jobs that matched the configured
+// selection criteria during the last check, together with the reason each
+// matched. The second and third return values are the same last-check time and
+// commit as Diffs().
+func (d *Differ) SelectedJobs() ([]SelectedJob, time.Time, string) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	result := make([]SelectedJob, len(d.selectedJobs))
+	copy(result, d.selectedJobs)
+	return result, d.lastCheckTime, d.lastCommit
 }
 
 // Check compares the given HCL files (path → content) against the live Nomad
@@ -242,6 +295,9 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 	// Parse all HCL files via the Nomad API.
 	hclJobs := make(map[string]*nomadapi.Job) // jobID → parsed job
 	hclJobFile := make(map[string]string)      // jobID → source HCL file path
+	// selReasons accumulates the selection reason for each matched job across
+	// both the HCL and Nomad phases, deduplicating by job ID.
+	selReasons := make(map[string]SelectionReason)
 
 	for filename, content := range hclFiles {
 		if !jobBlockRe.MatchString(content) {
@@ -261,11 +317,13 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 			continue
 		}
 		jobID := *job.ID
-		if !d.jobIsSelected(jobID, job.Meta) {
+		selected, reason := d.jobSelectionReason(jobID, job.Meta)
+		if !selected {
 			slog.Debug("Skipping job not matching selection criteria", "job", jobID, "file", filename)
 			d.jobsSkippedBySel.WithLabelValues("hcl").Inc()
 			continue
 		}
+		selReasons[jobID] = mergeSelectionReason(selReasons[jobID], reason)
 		hclJobs[jobID] = job
 		hclJobFile[jobID] = filename
 		slog.Debug("Parsed HCL file", "file", filename, "job_id", jobID)
@@ -350,10 +408,12 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 		// Meta is populated because the List call includes ?meta=true.
 		meta := j.Meta
 
-		if !d.jobIsSelected(j.ID, meta) {
+		selected, reason := d.jobSelectionReason(j.ID, meta)
+		if !selected {
 			d.jobsSkippedBySel.WithLabelValues("nomad").Inc()
 			continue
 		}
+		selReasons[j.ID] = mergeSelectionReason(selReasons[j.ID], reason)
 		if _, ok := hclJobs[j.ID]; !ok {
 			diffs = append(diffs, JobDiff{
 				JobID:    j.ID,
@@ -371,8 +431,16 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 		currentKeys[driftKey(diff.JobID, string(diff.DiffType))] = struct{}{}
 	}
 
+	// Build sorted SelectedJob slice from the accumulated reasons map.
+	selectedJobs := make([]SelectedJob, 0, len(selReasons))
+	for jobID, reason := range selReasons {
+		selectedJobs = append(selectedJobs, SelectedJob{JobID: jobID, Reason: reason})
+	}
+	sort.Slice(selectedJobs, func(i, j int) bool { return selectedJobs[i].JobID < selectedJobs[j].JobID })
+
 	d.mu.Lock()
 	d.diffs = diffs
+	d.selectedJobs = selectedJobs
 	d.lastCheckTime = now
 	d.lastCommit = commit
 	if listMeta != nil {

--- a/internal/nomad/differ_test.go
+++ b/internal/nomad/differ_test.go
@@ -1054,3 +1054,96 @@ func TestDiffer_NoSelection_NoJobsWatched(t *testing.T) {
 		t.Errorf("expected 0 diffs with no selection criteria, got %d: %+v", len(diffs), diffs)
 	}
 }
+
+// TestDiffer_SelectedJobs_MetaReason verifies that a job selected via the meta
+// key is returned by SelectedJobs with reason "meta".
+func TestDiffer_SelectedJobs_MetaReason(t *testing.T) {
+	mock := defaultMock()
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		return &nomadapi.Job{ID: strPtr("meta-job"), Meta: map[string]string{"gitops_managed": "true"}}, nil
+	}
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return nil, nil, fmt.Errorf("404: not found")
+	}
+	d := newTestDifferWithSelection(mock, "", "gitops")
+
+	if err := d.Check(map[string]string{"meta-job.hcl": `job "meta-job" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	jobs, _, _ := d.SelectedJobs()
+	if len(jobs) != 1 || jobs[0].JobID != "meta-job" || jobs[0].Reason != nomad.SelectionReasonMeta {
+		t.Errorf("want 1 job with reason meta, got %+v", jobs)
+	}
+}
+
+// TestDiffer_SelectedJobs_GlobReason verifies that a job selected via the glob
+// is returned by SelectedJobs with reason "glob".
+func TestDiffer_SelectedJobs_GlobReason(t *testing.T) {
+	mock := defaultMock()
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		return &nomadapi.Job{ID: strPtr("prod-api"), Meta: nil}, nil
+	}
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return nil, nil, fmt.Errorf("404: not found")
+	}
+	d := newTestDifferWithSelection(mock, "prod-*", "")
+
+	if err := d.Check(map[string]string{"prod-api.hcl": `job "prod-api" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	jobs, _, _ := d.SelectedJobs()
+	if len(jobs) != 1 || jobs[0].JobID != "prod-api" || jobs[0].Reason != nomad.SelectionReasonGlob {
+		t.Errorf("want 1 job with reason glob, got %+v", jobs)
+	}
+}
+
+// TestDiffer_SelectedJobs_BothReason verifies that a job matching both the glob
+// and the meta key is returned with reason "both".
+func TestDiffer_SelectedJobs_BothReason(t *testing.T) {
+	mock := defaultMock()
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		return &nomadapi.Job{ID: strPtr("prod-api"), Meta: map[string]string{"gitops_managed": "true"}}, nil
+	}
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return nil, nil, fmt.Errorf("404: not found")
+	}
+	d := newTestDifferWithSelection(mock, "prod-*", "gitops")
+
+	if err := d.Check(map[string]string{"prod-api.hcl": `job "prod-api" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	jobs, _, _ := d.SelectedJobs()
+	if len(jobs) != 1 || jobs[0].JobID != "prod-api" || jobs[0].Reason != nomad.SelectionReasonBoth {
+		t.Errorf("want 1 job with reason both, got %+v", jobs)
+	}
+}
+
+// TestDiffer_SelectedJobs_NoDuplicates verifies that a job appearing in both the
+// HCL phase and the Nomad list phase is returned only once.
+func TestDiffer_SelectedJobs_NoDuplicates(t *testing.T) {
+	mock := defaultMock()
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		return &nomadapi.Job{ID: strPtr("shared-job"), Meta: map[string]string{"gitops_managed": "true"}}, nil
+	}
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		s := "running"
+		return &nomadapi.Job{ID: strPtr("shared-job"), Status: &s}, nil, nil
+	}
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return []*nomadapi.JobListStub{
+			{ID: "shared-job", Status: "running", Meta: map[string]string{"gitops_managed": "true"}},
+		}, nil, nil
+	}
+	mock.planFn = func(job *nomadapi.Job, diff bool, q *nomadapi.WriteOptions) (*nomadapi.JobPlanResponse, *nomadapi.WriteMeta, error) {
+		return &nomadapi.JobPlanResponse{}, nil, nil
+	}
+	d := newTestDifferWithSelection(mock, "", "gitops")
+
+	if err := d.Check(map[string]string{"shared-job.hcl": `job "shared-job" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	jobs, _, _ := d.SelectedJobs()
+	if len(jobs) != 1 {
+		t.Errorf("want 1 unique selected job, got %d: %+v", len(jobs), jobs)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,6 +25,7 @@ import (
 // DiffSource is satisfied by *nomad.Differ.
 type DiffSource interface {
 	Diffs() ([]nomad.JobDiff, time.Time, string)
+	SelectedJobs() ([]nomad.SelectedJob, time.Time, string)
 	// Ready reports whether at least one diff check has completed.
 	Ready() bool
 }
@@ -188,6 +189,23 @@ var indexTmpl = template.Must(template.New("index").Parse(`<!DOCTYPE html>
     {{- if .LastWebhookFail}} &nbsp; failed <code>{{.LastWebhookFail}}</code>{{end}}
   </p>
   {{- end}}
+  {{- if .SelectedJobs}}
+  <h2>Selected jobs ({{len .SelectedJobs}})</h2>
+  <table style="border-collapse:collapse;width:100%">
+    <thead><tr style="text-align:left;border-bottom:1px solid #ccc">
+      <th style="padding:0.3em 1em 0.3em 0">Job</th>
+      <th style="padding:0.3em 0">Selected by</th>
+    </tr></thead>
+    <tbody>
+    {{- range .SelectedJobs}}
+    <tr>
+      <td style="padding:0.25em 1em 0.25em 0"><code>{{.JobID}}</code></td>
+      <td style="padding:0.25em 0">{{.Reason}}</td>
+    </tr>
+    {{- end}}
+    </tbody>
+  </table>
+  {{- end}}
   <ul>
     <li><a href="/diffs">/diffs</a> — current job diffs (plan-style)</li>
     <li><a href="/healthz">/healthz</a> — JSON health check</li>
@@ -201,10 +219,12 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	starting := !s.git.Ready() || !s.diffs.Ready()
 
 	var diffs []nomad.JobDiff
+	var selectedJobs []nomad.SelectedJob
 	var lastCheck time.Time
 	var commit string
 	if !starting {
 		diffs, lastCheck, commit = s.diffs.Diffs()
+		selectedJobs, _, _ = s.diffs.SelectedJobs()
 	}
 
 	s.webhookMu.RLock()
@@ -221,6 +241,7 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		Version         string
 		Starting        bool
 		DiffCount       int
+		SelectedJobs    []nomad.SelectedJob
 		LastCheck       string
 		Commit          string
 		LastWebhookOK   string
@@ -231,6 +252,7 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		Version:        s.version,
 		Starting:       starting,
 		DiffCount:      len(diffs),
+		SelectedJobs:   selectedJobs,
 		Commit:         commit,
 		SelectionGlob:  s.cfg.JobSelectorGlob,
 		ManagedMetaKey: managedMetaKey,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -23,13 +23,18 @@ import (
 
 // mockDiffSource implements server.DiffSource.
 type mockDiffSource struct {
-	diffs      []nomad.JobDiff
-	lastCheck  time.Time
-	lastCommit string
+	diffs        []nomad.JobDiff
+	selectedJobs []nomad.SelectedJob
+	lastCheck    time.Time
+	lastCommit   string
 }
 
 func (m *mockDiffSource) Diffs() ([]nomad.JobDiff, time.Time, string) {
 	return m.diffs, m.lastCheck, m.lastCommit
+}
+
+func (m *mockDiffSource) SelectedJobs() ([]nomad.SelectedJob, time.Time, string) {
+	return m.selectedJobs, m.lastCheck, m.lastCommit
 }
 
 func (m *mockDiffSource) Ready() bool { return !m.lastCheck.IsZero() }
@@ -702,5 +707,62 @@ func TestHandler_ConsistentReturn(t *testing.T) {
 	h2 := srv.Handler()
 	if h1 != h2 {
 		t.Error("Handler() should return the same http.Handler on repeated calls")
+	}
+}
+
+// ── / selected jobs ───────────────────────────────────────────────────────────
+
+func newTestServerWithSelectedJobs(t *testing.T, jobs []nomad.SelectedJob) *server.Server {
+	t.Helper()
+	cfg := &config.Config{
+		ListenAddr:  ":0",
+		WebhookPath: "/webhook",
+		Branch:      "main",
+	}
+	diffSrc := &mockDiffSource{
+		selectedJobs: jobs,
+		lastCheck:    time.Now(),
+		lastCommit:   "deadbeef",
+	}
+	gitSrc := &mockGitSource{lastCommit: "deadbeef", lastUpdate: time.Now()}
+	return server.NewWithRegistry(cfg, diffSrc, gitSrc, "test", prometheus.NewRegistry())
+}
+
+func TestIndex_SelectedJobs_Shown(t *testing.T) {
+	jobs := []nomad.SelectedJob{
+		{JobID: "api", Reason: nomad.SelectionReasonMeta},
+		{JobID: "worker", Reason: nomad.SelectionReasonGlob},
+	}
+	srv := newTestServerWithSelectedJobs(t, jobs)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "api") {
+		t.Error("index page should list job 'api'")
+	}
+	if !strings.Contains(body, "worker") {
+		t.Error("index page should list job 'worker'")
+	}
+	if !strings.Contains(body, "meta") {
+		t.Error("index page should show selection reason 'meta'")
+	}
+	if !strings.Contains(body, "glob") {
+		t.Error("index page should show selection reason 'glob'")
+	}
+	if !strings.Contains(body, "Selected jobs (2)") {
+		t.Error("index page should show selected jobs count")
+	}
+}
+
+func TestIndex_NoSelectedJobs_SectionAbsent(t *testing.T) {
+	srv := newTestServerWithSelectedJobs(t, nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if strings.Contains(rec.Body.String(), "Selected jobs") {
+		t.Error("index page should not show selected-jobs section when there are no selected jobs")
 	}
 }

--- a/proto/nomad_botherer.proto
+++ b/proto/nomad_botherer.proto
@@ -9,6 +9,10 @@ service NomadBotherer {
   // GetDiffs returns the current set of job diffs detected between git and Nomad.
   rpc GetDiffs(GetDiffsRequest) returns (GetDiffsResponse);
 
+  // GetSelectedJobs returns all jobs that matched the configured selection
+  // criteria during the last check, together with the reason each was included.
+  rpc GetSelectedJobs(GetSelectedJobsRequest) returns (GetSelectedJobsResponse);
+
   // GetStatus returns git watcher status (last commit, last update time).
   rpc GetStatus(GetStatusRequest) returns (GetStatusResponse);
 
@@ -37,6 +41,23 @@ message JobDiff {
   string diff_type = 3;
   // Human-readable summary of the diff (nomad plan output excerpt).
   string detail = 4;
+}
+
+message GetSelectedJobsRequest {}
+
+message GetSelectedJobsResponse {
+  repeated SelectedJob jobs = 1;
+  // RFC3339 timestamp of the last diff check.
+  string last_check_time = 2;
+  // Git commit hash that was current during the last diff check.
+  string last_commit = 3;
+}
+
+// SelectedJob records a job that matched the configured selection criteria.
+message SelectedJob {
+  string job_id = 1;
+  // One of: glob, meta, both.
+  string selection_reason = 2;
 }
 
 message GetStatusRequest {}


### PR DESCRIPTION
## What

Adds a way to query which jobs nomad-botherer is currently watching, and why each was included. Three selection reasons are tracked:

- `glob` — matched the `--job-selector-glob` pattern
- `meta` — matched the `--managed-meta-prefix` key (`gitops_managed = "true"`)  
- `both` — matched on both criteria

This is distinct from `/diffs`, which only shows jobs in a divergent state. Selected-jobs shows every job being watched, including ones that are fully in sync.

## Where it's visible

**Web console (`/`)**: a "Selected jobs" table appears below the status summary when any jobs are selected. Each row shows the job ID and the reason it was matched.

**gRPC**: new `GetSelectedJobs` RPC returns the same data as a structured response. Same ready-check and auth as the existing RPCs.

**`nbctl`**: new `selected-jobs` subcommand, consistent with the `diffs` command in output format and JSON support.

## Implementation notes

`jobIsSelected` in the differ was replaced by `jobSelectionReason`, which returns `(bool, SelectionReason)`. Selected jobs are accumulated in a `map[string]SelectionReason` during `Check()` — covering both the HCL phase and the Nomad list phase — then deduplicated, sorted by job ID, and stored as `[]SelectedJob`. The `mergeSelectionReason` helper upgrades a job's reason to `both` if it appears from multiple sources with different reasons.

`SelectedJobs()` follows the same snapshot pattern as `Diffs()`, returning under the same read lock.

## Tests

- `internal/nomad`: reason-specific tests for meta, glob, both, and deduplication
- `internal/grpcserver`: empty/populated/not-ready cases for `GetSelectedJobs`
- `internal/server`: index table shown/absent based on selected-jobs data
- `cmd/nbctl`: text output tests for `selected-jobs` command