### PR TITLE
Use live Nomad job meta as source of truth for managed-meta selection (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.3.0 — 2026-06-02
+
+### Breaking changes
+
+- **Nomad job meta is now the source of truth for managed-meta-prefix selection.**
+  Previously, if the HCL file for a job declared `gitops_managed = "true"` but
+  the running Nomad job did not carry that key, the job was still selected and
+  diffed. Now the live Nomad job's meta is checked instead. A job is only
+  selected if the running job carries `gitops_managed = "true"` (or whichever
+  key the configured prefix produces).
+
+  The HCL meta is used as a fallback for jobs that do not yet exist in Nomad
+  (so new jobs are still detected as `missing_from_nomad`).
+
+  To restore the previous behaviour, set `--managed-meta-hcl-canonical`
+  (`MANAGED_META_HCL_CANONICAL=true`).
+
 ## v0.2.0 — 2026-06-02
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -169,11 +169,22 @@ nomad-botherer does not watch every job in a cluster by default. A job must matc
 | Name glob | `--job-selector-glob` | *(empty — no glob selection)* |
 | Meta prefix | `--managed-meta-prefix` | `gitops` |
 
-The two criteria are a **union**: a job is selected if it matches the glob *or* has the `<prefix>_managed` meta key set to `"true"`. With the defaults (no glob, prefix `gitops`), only jobs declaring `gitops_managed = "true"` in their HCL meta stanza are watched.
+The two criteria are a **union**: a job is selected if it matches the glob *or* has the `<prefix>_managed` meta key set to `"true"`. With the defaults (no glob, prefix `gitops`), only jobs declaring `gitops_managed = "true"` in their registered Nomad meta are watched.
 
 The prefix is a namespace for all meta keys nomad-botherer reads or writes. Using `gitops` means the opt-in key is `gitops_managed`, and future attributes will follow the same `gitops_<attribute>` pattern.
 
 If you need to change the prefix — for example because another team already owns `gitops_*` on the cluster — keep `gitops` as a root and append your qualifier: `gitops_myteam`, `gitops_platform`, etc. This keeps all nomad-botherer keys visually grouped across teams and avoids conflicts with unrelated meta keys.
+
+**Source of truth for the meta key**
+
+By default, the live Nomad job is the source of truth: if `gitops_managed = "true"` is present in the HCL file but not in the running job's meta, the job is not selected. This prevents nomad-botherer from silently picking up jobs that were never explicitly opted in to management at the Nomad level. The HCL meta is used as a fallback only when the job does not yet exist in Nomad, so new jobs declared in HCL are still detected as `missing_from_nomad`.
+
+To opt the other way and treat the HCL as canonical for selection (the behaviour prior to v0.3.0), pass `--managed-meta-hcl-canonical`:
+
+```bash
+./nomad-botherer --managed-meta-hcl-canonical ...
+# job is selected if HCL carries gitops_managed = "true", regardless of live Nomad meta
+```
 
 **Opting a job in via meta tag (default method):**
 
@@ -299,6 +310,7 @@ Every flag has a corresponding environment variable. Environment variables are r
 | `--include-dead-jobs` | `INCLUDE_DEAD_JOBS` | `false` | Treat dead Nomad jobs like running ones (by default dead jobs count as missing) |
 | `--job-selector-glob` | `JOB_SELECTOR_GLOB` | *(empty — no glob)* | Glob pattern selecting jobs to watch by name (e.g. `myprefix-*`, `*` for all). Combined with `--managed-meta-prefix` as a union. |
 | `--managed-meta-prefix` | `MANAGED_META_PREFIX` | `gitops` | Prefix for job meta keys used by nomad-botherer. With prefix `gitops`, the key `gitops_managed = "true"` opts a job in. Empty disables meta-based selection. |
+| `--managed-meta-hcl-canonical` | `MANAGED_META_HCL_CANONICAL` | `false` | When false (default), the live Nomad job's meta is the source of truth for managed-meta-prefix selection. When true, the HCL file is sufficient to opt a job in even if the running job does not carry the key. |
 | `--max-git-staleness` | `MAX_GIT_STALENESS` | `0` (disabled) | If the git repo has not been successfully fetched within this window, force an immediate fetch. Set to `0` to disable. E.g. `--max-git-staleness=30m` |
 | `--max-nomad-staleness` | `MAX_NOMAD_STALENESS` | `0` (disabled) | If the Nomad diff check has not run within this window, force an immediate check. Set to `0` to disable. E.g. `--max-nomad-staleness=10m` |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,8 +38,9 @@ type Config struct {
 	IncludeDeadJobs bool
 
 	// Job selection
-	JobSelectorGlob   string
-	ManagedMetaPrefix string
+	JobSelectorGlob          string
+	ManagedMetaPrefix        string
+	ManagedMetaHCLCanonical  bool
 
 	// Staleness
 	MaxGitStaleness   time.Duration
@@ -83,6 +84,7 @@ func LoadFromArgs(fs *flag.FlagSet, args []string) (*Config, error) {
 	fs.BoolVar(&c.IncludeDeadJobs, "include-dead-jobs", envBoolOrDefault("INCLUDE_DEAD_JOBS", false), "Treat dead Nomad jobs like running ones (by default dead jobs are treated as missing)")
 	fs.StringVar(&c.JobSelectorGlob, "job-selector-glob", envOrDefault("JOB_SELECTOR_GLOB", ""), "Glob pattern selecting jobs by name (e.g. 'myprefix-*', '*' for all). Jobs matching either this or --managed-meta-prefix are watched. Empty means no glob selection.")
 	fs.StringVar(&c.ManagedMetaPrefix, "managed-meta-prefix", envOrDefault("MANAGED_META_PREFIX", "gitops"), "Prefix for job meta keys used by nomad-botherer (e.g. 'gitops' means 'gitops_managed = true' opts a job in). Empty disables meta-based selection.")
+	fs.BoolVar(&c.ManagedMetaHCLCanonical, "managed-meta-hcl-canonical", envBoolOrDefault("MANAGED_META_HCL_CANONICAL", false), "Use the HCL file as the source of truth for managed-meta-prefix selection. By default the live Nomad job's meta is checked; enable this to select jobs based on the meta key in HCL even if the running job does not carry it.")
 	fs.DurationVar(&c.MaxGitStaleness, "max-git-staleness", envDurationOrDefault("MAX_GIT_STALENESS", 0), "Maximum time since last successful git fetch before forcing a refresh (0 disables)")
 	fs.DurationVar(&c.MaxNomadStaleness, "max-nomad-staleness", envDurationOrDefault("MAX_NOMAD_STALENESS", 0), "Maximum time since last successful Nomad diff check before forcing a refresh (0 disables)")
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -490,3 +490,38 @@ func TestLoadFromArgs_JobSelectorGlobEnv(t *testing.T) {
 		t.Errorf("JobSelectorGlob: want myapp-*, got %q", cfg.JobSelectorGlob)
 	}
 }
+
+func TestLoadFromArgs_ManagedMetaHCLCanonicalDefault(t *testing.T) {
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ManagedMetaHCLCanonical {
+		t.Error("ManagedMetaHCLCanonical: want false (Nomad-canonical by default), got true")
+	}
+}
+
+func TestLoadFromArgs_ManagedMetaHCLCanonicalFlag(t *testing.T) {
+	cfg, err := LoadFromArgs(newFS(), []string{
+		"--repo-url", "https://example.com/r.git",
+		"--managed-meta-hcl-canonical",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.ManagedMetaHCLCanonical {
+		t.Error("ManagedMetaHCLCanonical: want true after --managed-meta-hcl-canonical flag, got false")
+	}
+}
+
+func TestLoadFromArgs_ManagedMetaHCLCanonicalEnv(t *testing.T) {
+	os.Setenv("MANAGED_META_HCL_CANONICAL", "true")
+	t.Cleanup(func() { os.Unsetenv("MANAGED_META_HCL_CANONICAL") })
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.ManagedMetaHCLCanonical {
+		t.Error("ManagedMetaHCLCanonical: want true from env var, got false")
+	}
+}

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -82,11 +82,16 @@ type NomadJobsClient interface {
 
 // Differ runs periodic diff checks and stores the latest results.
 type Differ struct {
-	jobs            NomadJobsClient
-	namespace       string
-	includeDeadJobs bool
+	jobs              NomadJobsClient
+	namespace         string
+	includeDeadJobs   bool
 	jobSelectorGlob   string
 	managedMetaPrefix string
+	// metaHCLCanonical controls whether the HCL file or the live Nomad job is
+	// the source of truth for managed-meta-prefix selection. When false (the
+	// default), the live job's meta is checked; the HCL meta is used as a
+	// fallback only when the job does not yet exist in Nomad.
+	metaHCLCanonical bool
 
 	mu              sync.RWMutex
 	diffs           []JobDiff
@@ -110,7 +115,7 @@ type Differ struct {
 }
 
 // newDifferBase constructs a Differ with metrics registered into reg.
-func newDifferBase(jobs NomadJobsClient, namespace string, includeDeadJobs bool, jobSelectorGlob, managedMetaPrefix string, reg prometheus.Registerer) *Differ {
+func newDifferBase(jobs NomadJobsClient, namespace string, includeDeadJobs bool, jobSelectorGlob, managedMetaPrefix string, metaHCLCanonical bool, reg prometheus.Registerer) *Differ {
 	f := promauto.With(reg)
 	d := &Differ{
 		jobs:              jobs,
@@ -118,7 +123,8 @@ func newDifferBase(jobs NomadJobsClient, namespace string, includeDeadJobs bool,
 		includeDeadJobs:   includeDeadJobs,
 		jobSelectorGlob:   jobSelectorGlob,
 		managedMetaPrefix: managedMetaPrefix,
-		driftFirstSeen:  make(map[string]time.Time),
+		metaHCLCanonical:  metaHCLCanonical,
+		driftFirstSeen:    make(map[string]time.Time),
 		hclParseErrors: f.NewCounter(prometheus.CounterOpts{
 			Name: "nomad_botherer_hcl_parse_errors_total",
 			Help: "Total number of HCL files that failed to parse as Nomad job definitions.",
@@ -193,18 +199,18 @@ func NewDiffer(cfg *config.Config) (*Differ, error) {
 		return nil, fmt.Errorf("creating nomad client: %w", err)
 	}
 
-	return newDifferBase(client.Jobs(), cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaPrefix, prometheus.DefaultRegisterer), nil
+	return newDifferBase(client.Jobs(), cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaPrefix, cfg.ManagedMetaHCLCanonical, prometheus.DefaultRegisterer), nil
 }
 
 // NewWithClient creates a Differ with a custom jobs client, intended for tests.
 func NewWithClient(cfg *config.Config, jobs NomadJobsClient) *Differ {
-	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaPrefix, prometheus.NewRegistry())
+	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaPrefix, cfg.ManagedMetaHCLCanonical, prometheus.NewRegistry())
 }
 
 // NewWithClientAndRegistry creates a Differ with a custom jobs client and Prometheus
 // registry. Use this in tests that need to inspect metric values.
 func NewWithClientAndRegistry(cfg *config.Config, jobs NomadJobsClient, reg prometheus.Registerer) *Differ {
-	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaPrefix, reg)
+	return newDifferBase(jobs, cfg.NomadNamespace, cfg.IncludeDeadJobs, cfg.JobSelectorGlob, cfg.ManagedMetaPrefix, cfg.ManagedMetaHCLCanonical, reg)
 }
 
 // jobSelectionReason reports whether a job should be watched and, if so, why.
@@ -292,12 +298,17 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 	slog.Info("Running diff check", "commit", commit, "hcl_files", len(hclFiles))
 	d.diffChecks.Inc()
 
-	// Parse all HCL files via the Nomad API.
-	hclJobs := make(map[string]*nomadapi.Job) // jobID → parsed job
-	hclJobFile := make(map[string]string)      // jobID → source HCL file path
-	// selReasons accumulates the selection reason for each matched job across
-	// both the HCL and Nomad phases, deduplicating by job ID.
-	selReasons := make(map[string]SelectionReason)
+	// Parse all HCL files via the Nomad API into preliminary candidates.
+	// Candidates are jobs where the glob matches OR the managed meta key is
+	// present in the HCL. Final selection (using the live job's meta when
+	// metaHCLCanonical is false) is deferred to the combined selection+plan loop.
+	type hclEntry struct {
+		job     *nomadapi.Job
+		file    string
+		globSel bool // matched by job-selector-glob
+		metaHCL bool // managed meta key present in parsed HCL
+	}
+	hclEntries := make(map[string]hclEntry)
 
 	for filename, content := range hclFiles {
 		if !jobBlockRe.MatchString(content) {
@@ -317,37 +328,80 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 			continue
 		}
 		jobID := *job.ID
-		selected, reason := d.jobSelectionReason(jobID, job.Meta)
-		if !selected {
+
+		globSel := false
+		if d.jobSelectorGlob != "" {
+			globSel, _ = path.Match(d.jobSelectorGlob, jobID)
+		}
+		metaHCL := d.managedMetaPrefix != "" && job.Meta[d.managedMetaPrefix+"_managed"] == "true"
+
+		if !globSel && !metaHCL {
 			slog.Debug("Skipping job not matching selection criteria", "job", jobID, "file", filename)
 			d.jobsSkippedBySel.WithLabelValues("hcl").Inc()
 			continue
 		}
-		selReasons[jobID] = mergeSelectionReason(selReasons[jobID], reason)
-		hclJobs[jobID] = job
-		hclJobFile[jobID] = filename
+		hclEntries[jobID] = hclEntry{job: job, file: filename, globSel: globSel, metaHCL: metaHCL}
 		slog.Debug("Parsed HCL file", "file", filename, "job_id", jobID)
 	}
 
+	// hclJobs records all HCL jobs that passed final selection.
+	// Used by the Nomad-list phase below to detect missing_from_hcl.
+	hclJobs := make(map[string]*nomadapi.Job, len(hclEntries))
+	hclJobFile := make(map[string]string, len(hclEntries))
+	// selReasons accumulates the selection reason across both phases.
+	selReasons := make(map[string]SelectionReason)
+
 	var diffs []JobDiff
 
-	// For each job defined in HCL, check Nomad.
-	for jobID, job := range hclJobs {
-		filename := hclJobFile[jobID]
+	// For each HCL candidate: determine final selection then diff against Nomad.
+	for jobID, entry := range hclEntries {
+		nomadJob, _, infoErr := d.jobs.Info(jobID, q)
+		notFound := infoErr != nil && isNotFound(infoErr)
 
-		nomadJob, _, err := d.jobs.Info(jobID, q)
-		if err != nil {
-			if isNotFound(err) {
-				diffs = append(diffs, JobDiff{
-					JobID:    jobID,
-					HCLFile:  filename,
-					DiffType: DiffTypeMissingFromNomad,
-					Detail:   "job is defined in HCL but not registered in Nomad",
-				})
-				continue
-			}
+		// Determine final selection. When metaHCLCanonical is false (the
+		// default), the live job's meta is authoritative. For jobs that do not
+		// yet exist in Nomad, the HCL meta is used as a fallback since there is
+		// no live state to consult.
+		metaSelected := entry.metaHCL // HCL meta (used when HCL-canonical or job is missing)
+		if !d.metaHCLCanonical && !notFound && infoErr == nil {
+			// Nomad-canonical and job exists: check live meta instead.
+			metaSelected = d.managedMetaPrefix != "" && nomadJob != nil && nomadJob.Meta[d.managedMetaPrefix+"_managed"] == "true"
+		}
+
+		var finalSel bool
+		var reason SelectionReason
+		switch {
+		case entry.globSel && metaSelected:
+			finalSel, reason = true, SelectionReasonBoth
+		case entry.globSel:
+			finalSel, reason = true, SelectionReasonGlob
+		case metaSelected:
+			finalSel, reason = true, SelectionReasonMeta
+		}
+
+		if !finalSel {
+			slog.Debug("Skipping HCL job: managed meta key absent from live Nomad job", "job", jobID)
+			d.jobsSkippedBySel.WithLabelValues("hcl").Inc()
+			continue
+		}
+
+		selReasons[jobID] = mergeSelectionReason(selReasons[jobID], reason)
+		hclJobs[jobID] = entry.job
+		hclJobFile[jobID] = entry.file
+
+		// Handle Info() error outcomes.
+		if notFound {
+			diffs = append(diffs, JobDiff{
+				JobID:    jobID,
+				HCLFile:  entry.file,
+				DiffType: DiffTypeMissingFromNomad,
+				Detail:   "job is defined in HCL but not registered in Nomad",
+			})
+			continue
+		}
+		if infoErr != nil {
 			d.nomadAPIErrors.WithLabelValues("info").Inc()
-			slog.Warn("Failed to query job from Nomad", "job", jobID, "err", err)
+			slog.Warn("Failed to query job from Nomad", "job", jobID, "err", infoErr)
 			continue
 		}
 
@@ -357,7 +411,7 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 			slog.Debug("Job is dead in Nomad, treating as missing", "job", jobID)
 			diffs = append(diffs, JobDiff{
 				JobID:    jobID,
-				HCLFile:  filename,
+				HCLFile:  entry.file,
 				DiffType: DiffTypeMissingFromNomad,
 				Detail:   "job is defined in HCL but is in 'dead' state in Nomad",
 			})
@@ -367,6 +421,7 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 		// Job exists and is live — run a plan to detect config drift.
 		// Nomad's deregister call sets Stop=true on the job record. Copy it
 		// onto the HCL job so the plan does not report a Stop field diff.
+		job := entry.job
 		if nomadJob.Stop != nil && *nomadJob.Stop {
 			stop := true
 			job.Stop = &stop
@@ -388,7 +443,7 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 			}
 			diffs = append(diffs, JobDiff{
 				JobID:    jobID,
-				HCLFile:  filename,
+				HCLFile:  entry.file,
 				DiffType: DiffTypeModified,
 				Detail:   fmt.Sprintf("Nomad plan shows diff type %q", plan.Diff.Type),
 				PlanDiff: plan.Diff,

--- a/internal/nomad/differ_test.go
+++ b/internal/nomad/differ_test.go
@@ -1119,7 +1119,8 @@ func TestDiffer_SelectedJobs_BothReason(t *testing.T) {
 }
 
 // TestDiffer_SelectedJobs_NoDuplicates verifies that a job appearing in both the
-// HCL phase and the Nomad list phase is returned only once.
+// HCL phase and the Nomad list phase is returned only once. The live Nomad job
+// carries the meta key so it passes Nomad-canonical selection.
 func TestDiffer_SelectedJobs_NoDuplicates(t *testing.T) {
 	mock := defaultMock()
 	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
@@ -1127,7 +1128,7 @@ func TestDiffer_SelectedJobs_NoDuplicates(t *testing.T) {
 	}
 	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
 		s := "running"
-		return &nomadapi.Job{ID: strPtr("shared-job"), Status: &s}, nil, nil
+		return &nomadapi.Job{ID: strPtr("shared-job"), Status: &s, Meta: map[string]string{"gitops_managed": "true"}}, nil, nil
 	}
 	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
 		return []*nomadapi.JobListStub{
@@ -1145,5 +1146,116 @@ func TestDiffer_SelectedJobs_NoDuplicates(t *testing.T) {
 	jobs, _, _ := d.SelectedJobs()
 	if len(jobs) != 1 {
 		t.Errorf("want 1 unique selected job, got %d: %+v", len(jobs), jobs)
+	}
+}
+
+// TestDiffer_NomadCanonical_MetaInHCLNotNomad verifies the default behaviour:
+// a job whose HCL carries the managed meta key but whose live Nomad instance
+// does NOT is not selected (Nomad is the source of truth).
+func TestDiffer_NomadCanonical_MetaInHCLNotNomad(t *testing.T) {
+	mock := defaultMock()
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		return &nomadapi.Job{ID: strPtr("not-yet-managed"), Meta: map[string]string{"gitops_managed": "true"}}, nil
+	}
+	// Live job exists but has no meta key.
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		s := "running"
+		return &nomadapi.Job{ID: strPtr("not-yet-managed"), Status: &s, Meta: nil}, nil, nil
+	}
+	d := newTestDifferWithSelection(mock, "", "gitops")
+
+	if err := d.Check(map[string]string{"not-yet-managed.hcl": `job "not-yet-managed" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 0 {
+		t.Errorf("want 0 diffs: job meta key not present in live Nomad job, got %+v", diffs)
+	}
+	jobs, _, _ := d.SelectedJobs()
+	if len(jobs) != 0 {
+		t.Errorf("want 0 selected jobs, got %+v", jobs)
+	}
+}
+
+// TestDiffer_NomadCanonical_MetaInNomadNotHCL verifies that a live Nomad job
+// carrying the managed key is selected even if the HCL file does not declare
+// the key (Nomad is the source of truth, and missing-from-hcl is detected via
+// the Nomad list phase).
+func TestDiffer_NomadCanonical_MetaInNomadNotHCL(t *testing.T) {
+	mock := defaultMock()
+	// HCL job has no meta key.
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		return &nomadapi.Job{ID: strPtr("managed-job"), Meta: nil}, nil
+	}
+	// Live Nomad list shows the job with the meta key.
+	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
+		return []*nomadapi.JobListStub{
+			{ID: "managed-job", Status: "running", Meta: map[string]string{"gitops_managed": "true"}},
+		}, nil, nil
+	}
+	d := newTestDifferWithSelection(mock, "", "gitops")
+
+	// Pass the HCL file — but the HCL job has no meta, so it is not a candidate.
+	if err := d.Check(map[string]string{"managed-job.hcl": `job "managed-job" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	// The Nomad list phase selects the job; it has no HCL (from the differ's
+	// perspective, since the HCL candidate was dropped), so missing_from_hcl.
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 1 || diffs[0].DiffType != nomad.DiffTypeMissingFromHCL {
+		t.Errorf("want 1 missing_from_hcl diff, got %+v", diffs)
+	}
+}
+
+// TestDiffer_NomadCanonical_MissingFromNomad_HCLFallback verifies that an HCL
+// job with the managed meta key that does not yet exist in Nomad is still
+// selected (HCL is used as fallback when there is no live job to consult).
+func TestDiffer_NomadCanonical_MissingFromNomad_HCLFallback(t *testing.T) {
+	mock := defaultMock()
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		return &nomadapi.Job{ID: strPtr("new-job"), Meta: map[string]string{"gitops_managed": "true"}}, nil
+	}
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return nil, nil, fmt.Errorf("404: not found")
+	}
+	d := newTestDifferWithSelection(mock, "", "gitops")
+
+	if err := d.Check(map[string]string{"new-job.hcl": `job "new-job" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 1 || diffs[0].DiffType != nomad.DiffTypeMissingFromNomad {
+		t.Errorf("want 1 missing_from_nomad diff (HCL fallback for new job), got %+v", diffs)
+	}
+}
+
+// TestDiffer_HCLCanonical_MetaInHCLNotNomad verifies that with
+// ManagedMetaHCLCanonical=true the HCL meta key is sufficient for selection
+// even when the live Nomad job does not carry it.
+func TestDiffer_HCLCanonical_MetaInHCLNotNomad(t *testing.T) {
+	mock := defaultMock()
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		return &nomadapi.Job{ID: strPtr("hcl-managed"), Meta: map[string]string{"gitops_managed": "true"}}, nil
+	}
+	// Live job exists but has no meta key.
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		s := "running"
+		return &nomadapi.Job{ID: strPtr("hcl-managed"), Status: &s, Meta: nil}, nil, nil
+	}
+	mock.planFn = func(job *nomadapi.Job, diff bool, q *nomadapi.WriteOptions) (*nomadapi.JobPlanResponse, *nomadapi.WriteMeta, error) {
+		return &nomadapi.JobPlanResponse{}, nil, nil
+	}
+	cfg := &config.Config{
+		ManagedMetaPrefix:       "gitops",
+		ManagedMetaHCLCanonical: true,
+	}
+	d := nomad.NewWithClient(cfg, mock)
+
+	if err := d.Check(map[string]string{"hcl-managed.hcl": `job "hcl-managed" {}`}, "abc"); err != nil {
+		t.Fatal(err)
+	}
+	jobs, _, _ := d.SelectedJobs()
+	if len(jobs) != 1 || jobs[0].JobID != "hcl-managed" {
+		t.Errorf("want 1 selected job (hcl-canonical), got %+v", jobs)
 	}
 }


### PR DESCRIPTION
## What

Changes the source of truth for `--managed-meta-prefix` selection from the HCL file to the live Nomad job.

**Before**: if an HCL file declared `gitops_managed = "true"` but the running Nomad job did not carry that key, the job was still selected and diffed.

**After**: the running job's meta is checked. If the live Nomad job does not have `gitops_managed = "true"`, it is not selected, even if the HCL says it should be.

The HCL meta is used as a fallback only when the job does not yet exist in Nomad, so new jobs declared in HCL still surface as `missing_from_nomad`.

## Why

A job should opt itself in to management by carrying the key in its live registered state. Relying on the HCL file means nomad-botherer can silently start watching a job because a stale or mis-keyed HCL appeared in the repo, rather than because the operator deliberately registered the job with the opt-in key.

## Escape hatch

`--managed-meta-hcl-canonical` (`MANAGED_META_HCL_CANONICAL=true`) restores the previous behaviour.

## Implementation

The two HCL loops in `Check()` — parse (with HCL-meta selection), then plan — are merged into a single pass: parse → preliminary filter (`glob || metaInHCL`) → `Info()` → final selection using live Nomad meta → plan. This avoids a redundant `Info()` call and makes both modes share a single code path.

The selection logic:

```
metaSelected = metaInHCL                    // HCL-canonical or job not in Nomad
metaSelected = liveNomad["gitops_managed"]  // Nomad-canonical (default) and job exists
```

Glob selection is unaffected — a glob match always selects regardless of mode.

## Tests

- `TestDiffer_NomadCanonical_MetaInHCLNotNomad` — meta in HCL, not in live job → not selected
- `TestDiffer_NomadCanonical_MetaInNomadNotHCL` — meta in live job, HCL has none → selected via Nomad list phase as missing_from_hcl
- `TestDiffer_NomadCanonical_MissingFromNomad_HCLFallback` — new job, not in Nomad → HCL fallback, selected, missing_from_nomad diff
- `TestDiffer_HCLCanonical_MetaInHCLNotNomad` — opt-in flag set → old behaviour preserved
- Config tests for flag and env var defaults