### PR TITLE
Docs cleanup, coverage improvements, API e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.4.0 — 2026-06-02
+
+### Breaking changes
+
+- **gRPC API and `nbctl` CLI removed.** The gRPC server, proto definitions,
+  generated bindings, and the `nbctl` CLI are gone. The `--grpc-listen-addr`
+  and `--grpc-api-key` flags are removed.
+
+### New features
+
+- **JSON API** (`/api/v1/`): a plain HTTP/JSON API replaces the gRPC server.
+  Enable it by setting `--api-key` / `API_KEY`. All endpoints require
+  `Authorization: Bearer <key>`. Available endpoints:
+  - `GET /api/v1/diffs` — current job diffs
+  - `GET /api/v1/selected-jobs` — jobs selected for monitoring and why
+  - `GET /api/v1/status` — git watcher status
+  - `GET /api/v1/version` — build version / commit / date
+  - `POST /api/v1/refresh` — trigger immediate git pull
+  - `GET /api/openapi.json` — OpenAPI 3.0 spec (public, no auth required)
+
 ## v0.3.0 — 2026-06-02
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ Three kinds of drift are tracked:
 - [Quick start](#quick-start)
 - [Configuration](#configuration)
 - [Webhooks](#webhooks)
-- [gRPC API](#grpc-api)
+- [JSON API](#json-api)
   - [Authentication](#authentication)
-  - [Available RPCs](#available-rpcs)
-  - [nbctl — operator CLI](#nbctl--operator-cli)
-  - [grpcurl examples](#grpcurl-examples)
+  - [Endpoints](#endpoints)
+  - [curl examples](#curl-examples)
 - [Monitoring](#monitoring)
   - [`/healthz`](#healthz)
   - [`/metrics`](#metrics)
@@ -65,9 +64,9 @@ is a ready-to-use job definition with every configuration option commented.
 
 1. Copy `examples/nomad-botherer.hcl` into your job repo (or download it).
 
-2. Set the two required values in the `env {}` block:
+2. Set the required values in the `env {}` block:
    - `GIT_REPO_URL` — the URL of your HCL repo
-   - `GRPC_API_KEY` — a long random string (used to authenticate `nbctl` and `grpcurl`)
+   - `API_KEY` — a long random string (used to authenticate requests to the `/api/` endpoints)
 
 3. For a private repo, also set `GIT_TOKEN` (HTTPS) or mount an SSH key and
    set `GIT_SSH_KEY`. The example file has commented instructions for both,
@@ -96,8 +95,7 @@ is a ready-to-use job definition with every configuration option commented.
 ```bash
 ./nomad-botherer \
   --repo-url https://github.com/myorg/nomad-jobs.git \
-  --nomad-addr http://nomad.example.com:4646 \
-  --grpc-api-key your-api-key
+  --nomad-addr http://nomad.example.com:4646
 ```
 
 For a private HTTPS repo add `--git-token ghp_...`; for SSH add
@@ -155,8 +153,8 @@ The design proposals for job application and change checkpointing are in
 5. All jobs **currently running in Nomad** (non-dead) that match the selection criteria but have no corresponding HCL file → `missing_from_hcl`
 
    Dead jobs are excluded from both checks by default because a stopped job is expected state — it was intentionally halted. Pass `--include-dead-jobs` to treat dead jobs like running ones.
-6. Results are stored in memory and exposed via `/healthz` (JSON), `/metrics` (Prometheus), and the gRPC API.
-7. The repo is re-checked on every `--poll-interval` (git fetch), on every `--diff-interval` (Nomad-side drift), and immediately on a webhook push event or a `TriggerRefresh` gRPC call. When `--max-git-staleness` or `--max-nomad-staleness` is set, a dedicated background goroutine for each forces a refresh if the respective source has not been updated within the configured window — useful when webhooks are unreliable or paused. The two timers are independent and can be set or disabled individually.
+6. Results are stored in memory and exposed via `/healthz` (JSON), `/metrics` (Prometheus), and the authenticated JSON API (`/api/v1/`).
+7. The repo is re-checked on every `--poll-interval` (git fetch), on every `--diff-interval` (Nomad-side drift), and immediately on a webhook push event or a `POST /api/v1/refresh` call. When `--max-git-staleness` or `--max-nomad-staleness` is set, a dedicated background goroutine for each forces a refresh if the respective source has not been updated within the configured window — useful when webhooks are unreliable or paused. The two timers are independent and can be set or disabled individually.
 
 ---
 
@@ -239,7 +237,6 @@ git clone https://github.com/gerrowadat/nomad-botherer.git
 cd nomad-botherer
 make build
 ./nomad-botherer --help
-./nbctl --help
 ```
 
 ### Docker
@@ -304,8 +301,7 @@ Every flag has a corresponding environment variable. Environment variables are r
 | `--listen-addr` | `LISTEN_ADDR` | `:8080` | HTTP listen address |
 | `--webhook-secret` | `WEBHOOK_SECRET` | | GitHub webhook HMAC secret |
 | `--webhook-path` | `WEBHOOK_PATH` | `/webhook` | Webhook endpoint path |
-| `--grpc-listen-addr` | `GRPC_LISTEN_ADDR` | *(empty — disabled)* | gRPC listen address. Set to a non-empty value (e.g. `:9090`) to enable the gRPC server. Requires `--grpc-api-key`. |
-| `--grpc-api-key` | `GRPC_API_KEY` | | Pre-shared API key for gRPC authentication. Required when `--grpc-listen-addr` is set. |
+| `--api-key` | `API_KEY` | *(empty — disabled)* | Pre-shared key for `/api/` endpoints (Bearer token). Empty disables the JSON API. |
 | `--diff-interval` | `DIFF_INTERVAL` | `1m` | Periodic Nomad-side drift check interval |
 | `--include-dead-jobs` | `INCLUDE_DEAD_JOBS` | `false` | Treat dead Nomad jobs like running ones (by default dead jobs count as missing) |
 | `--job-selector-glob` | `JOB_SELECTOR_GLOB` | *(empty — no glob)* | Glob pattern selecting jobs to watch by name (e.g. `myprefix-*`, `*` for all). Combined with `--managed-meta-prefix` as a union. |
@@ -338,127 +334,56 @@ If `--webhook-secret` is empty, signature verification is skipped. In production
 
 ---
 
-## gRPC API
+## JSON API
 
-The gRPC server is disabled by default. Enable it by setting `--grpc-listen-addr`
-to a listen address (e.g. `:9090`) and providing an API key via `--grpc-api-key`.
-Setting an address without an API key is a startup error.
-
-The service is defined in [`proto/nomad_botherer.proto`](proto/nomad_botherer.proto).
-Go bindings are pre-generated in `internal/grpcapi/` — no code generation is required
-to build the binary.
+The JSON API is served on the same HTTP port as the web console (`--listen-addr`, default `:8080`). It is disabled by default; set `--api-key` / `API_KEY` to enable it.
 
 ### Authentication
 
-All RPCs require a pre-shared API key in the `authorization` gRPC metadata header:
+All `/api/v1/` endpoints require a pre-shared key as a Bearer token:
 
 ```
-authorization: Bearer <your-api-key>
+Authorization: Bearer <your-api-key>
 ```
 
-There is no TLS termination built in. In production, put the gRPC port behind a
-TLS-terminating proxy (e.g. nginx, Envoy, or a load balancer), or restrict access
-at the network level. The API key protects against unauthenticated reads on an
-already-reachable port; it is not a substitute for transport security.
+There is no TLS built in. In production, front the server with a TLS-terminating proxy (nginx, Envoy, a load balancer). The API key protects against unauthenticated reads on an already-reachable port; it is not a substitute for transport security.
 
-### Available RPCs
+The OpenAPI 3.0 specification is served at `GET /api/openapi.json` without authentication.
 
-| RPC | Request | Response | Description |
-|-----|---------|----------|-------------|
-| `GetDiffs` | `GetDiffsRequest` | `GetDiffsResponse` | Returns all currently-detected job diffs, plus the last check time and git commit. Returns `codes.Unavailable` until startup is complete. |
-| `GetStatus` | `GetStatusRequest` | `GetStatusResponse` | Returns git watcher status: last commit hash and last successful fetch time. Returns `codes.Unavailable` until the initial clone completes. |
-| `TriggerRefresh` | `TriggerRefreshRequest` | `TriggerRefreshResponse` | Triggers an immediate git pull and diff check (same effect as a webhook push event) |
-| `GetVersion` | `GetVersionRequest` | `GetVersionResponse` | Returns the server's version string, git commit hash, and build date (as set by `-ldflags` at build time; defaults to `dev` / `unknown`) |
+### Endpoints
 
-### nbctl — operator CLI
+| Method | Path | Returns | Notes |
+|--------|------|---------|-------|
+| GET | `/api/v1/diffs` | Current job diffs + last check time + last commit | 503 until startup completes |
+| GET | `/api/v1/selected-jobs` | Jobs matched by selection criteria + reason each matched | 503 until startup completes |
+| GET | `/api/v1/status` | Git watcher status (last commit, last fetch time) | 503 until git clone completes |
+| GET | `/api/v1/version` | Build version, commit hash, build date | Always available |
+| POST | `/api/v1/refresh` | `{"message":"refresh triggered"}` | Triggers immediate git pull |
+| GET | `/api/openapi.json` | OpenAPI 3.0 spec (JSON) | No authentication required |
 
-`nbctl` is the purpose-built CLI for the gRPC API. It can be installed independently without cloning the repo:
+### curl examples
 
 ```bash
-go install github.com/gerrowadat/nomad-botherer/cmd/nbctl@latest
+BASE=http://localhost:8080
+KEY=your-api-key
+
+# Current diffs
+curl -s -H "Authorization: Bearer $KEY" $BASE/api/v1/diffs | jq .
+
+# Jobs being watched and why
+curl -s -H "Authorization: Bearer $KEY" $BASE/api/v1/selected-jobs | jq .
+
+# Git watcher status
+curl -s -H "Authorization: Bearer $KEY" $BASE/api/v1/status | jq .
+
+# Build version
+curl -s -H "Authorization: Bearer $KEY" $BASE/api/v1/version | jq .
+
+# Trigger an immediate refresh
+curl -s -X POST -H "Authorization: Bearer $KEY" $BASE/api/v1/refresh | jq .
 ```
 
-Or built locally alongside the server:
-
-```bash
-make build-ctl   # produces ./nbctl
-make build       # produces both ./nomad-botherer and ./nbctl
-```
-
-#### Configuration
-
-| Flag | Env var | Default | Description |
-|------|---------|---------|-------------|
-| `--server` / `-s` | `NBCTL_SERVER` | `localhost:9090` | gRPC server address |
-| `--api-key` / `-k` | `NBCTL_API_KEY` | | API key (required) |
-| `--timeout` | | `10s` | Per-request timeout |
-| `--output` / `-o` | | `text` | Output format: `text` or `json` |
-| `--tls` | | `false` | Use TLS for the gRPC connection |
-
-The API key is most conveniently set via the environment so it does not appear in shell history:
-
-```bash
-export NBCTL_API_KEY=your-api-key
-export NBCTL_SERVER=nomad-botherer.internal:9090
-```
-
-#### Commands
-
-**Show current job diffs:**
-
-```bash
-nbctl diffs
-```
-
-```
-2 diff(s) detected
-last check:  2026-05-08T12:00:00Z
-last commit: abc1234def5678
-
-[modified] api-server (jobs/api-server.hcl)
-  Nomad plan shows diff type "Edited"
-
-[missing_from_hcl] legacy-worker
-```
-
-**Show git watcher status:**
-
-```bash
-nbctl status
-```
-
-```
-last commit:  abc1234def5678
-last updated: 2026-05-08T11:59:50Z
-```
-
-**Trigger an immediate refresh:**
-
-```bash
-nbctl refresh
-```
-
-```
-refresh triggered
-```
-
-**Show the server's build version:**
-
-```bash
-nbctl version
-```
-
-```
-version:    v1.2.3
-commit:     abc1234def5678
-build date: 2026-05-08T10:00:00Z
-```
-
-**JSON output** (all commands support `--output json` / `-o json`):
-
-```bash
-nbctl diffs -o json
-```
+Example `/api/v1/diffs` response when drift is detected:
 
 ```json
 {
@@ -468,125 +393,16 @@ nbctl diffs -o json
       "hcl_file": "jobs/api-server.hcl",
       "diff_type": "modified",
       "detail": "Nomad plan shows diff type \"Edited\""
+    },
+    {
+      "job_id": "legacy-worker",
+      "diff_type": "missing_from_hcl",
+      "detail": "job is running in Nomad (status: running) but has no HCL definition in the repo"
     }
   ],
   "last_check_time": "2026-05-08T12:00:00Z",
   "last_commit": "abc1234def5678"
 }
-```
-
-**Connecting to a remote server with TLS:**
-
-```bash
-nbctl --server nomad-botherer.internal:9090 --tls diffs
-```
-
-**`nbctl --version`** prints the CLI's own build version (set at link time via `-ldflags`; independent of the server version returned by `nbctl version`).
-
-### grpcurl examples
-
-The examples below use [`grpcurl`](https://github.com/fullstackio/grpcurl), which can be installed with:
-
-```bash
-go install github.com/fullstackio/grpcurl/cmd/grpcurl@latest
-# or: brew install grpcurl
-```
-
-**List available RPCs** (requires the `.proto` file or a reflection-enabled server):
-
-```bash
-grpcurl -plaintext \
-  -proto proto/nomad_botherer.proto \
-  localhost:9090 list nomad_botherer.v1.NomadBotherer
-```
-
-**Get current diffs:**
-
-```bash
-grpcurl -plaintext \
-  -proto proto/nomad_botherer.proto \
-  -H 'authorization: Bearer your-api-key' \
-  localhost:9090 nomad_botherer.v1.NomadBotherer/GetDiffs
-```
-
-Example output when drift is detected:
-
-```json
-{
-  "diffs": [
-    {
-      "jobId": "api-server",
-      "hclFile": "jobs/api-server.hcl",
-      "diffType": "modified",
-      "detail": "Nomad plan shows diff type \"Edited\""
-    },
-    {
-      "jobId": "legacy-worker",
-      "diffType": "missing_from_hcl"
-    }
-  ],
-  "lastCheckTime": "2026-05-08T12:00:00Z",
-  "lastCommit": "abc1234def5678"
-}
-```
-
-**Get git watcher status:**
-
-```bash
-grpcurl -plaintext \
-  -proto proto/nomad_botherer.proto \
-  -H 'authorization: Bearer your-api-key' \
-  localhost:9090 nomad_botherer.v1.NomadBotherer/GetStatus
-```
-
-```json
-{
-  "lastCommit": "abc1234def5678",
-  "lastUpdateTime": "2026-05-08T11:59:50Z"
-}
-```
-
-**Trigger an immediate refresh:**
-
-```bash
-grpcurl -plaintext \
-  -proto proto/nomad_botherer.proto \
-  -H 'authorization: Bearer your-api-key' \
-  localhost:9090 nomad_botherer.v1.NomadBotherer/TriggerRefresh
-```
-
-```json
-{
-  "message": "refresh triggered"
-}
-```
-
-**Get server version:**
-
-```bash
-grpcurl -plaintext \
-  -proto proto/nomad_botherer.proto \
-  -H 'authorization: Bearer your-api-key' \
-  localhost:9090 nomad_botherer.v1.NomadBotherer/GetVersion
-```
-
-```json
-{
-  "version": "v1.2.3",
-  "commit": "abc1234def5678",
-  "buildDate": "2026-05-08T10:00:00Z"
-}
-```
-
-Binaries built without `-ldflags` return `"version": "dev"`, `"commit": "unknown"`, `"buildDate": "unknown"`.
-
-**Calling from a different host** (e.g. from a workstation against a remote deployment):
-
-```bash
-grpcurl -plaintext \
-  -proto proto/nomad_botherer.proto \
-  -H 'authorization: Bearer your-api-key' \
-  nomad-botherer.internal:9090 nomad_botherer.v1.NomadBotherer/GetDiffs
 ```
 
 ---
@@ -622,7 +438,7 @@ Returns **HTTP 200** once the server has built its initial state (completed the 
 
 `"status"` is `"ok"` when there are no diffs, `"diffs_detected"` when drift is detected, and `"starting"` (with HTTP 503) before the first diff check completes.
 
-The `/diffs` endpoint and all gRPC RPCs that return state also return HTTP 503 / `codes.Unavailable` during startup.
+The `/diffs` endpoint and all `/api/v1/` endpoints that return state also return HTTP 503 during startup.
 
 ### `/metrics`
 
@@ -679,15 +495,6 @@ These counters are only non-zero when `--max-git-staleness` or `--max-nomad-stal
 |--------|------|--------|-------------------|
 | `nomad_botherer_git_staleness_refreshes_total` | Counter | — | Git fetches triggered because `time() - nomad_botherer_git_last_update_timestamp_seconds` exceeded `--max-git-staleness`. A rising count means the normal polling or webhook path is not keeping the repo current. |
 | `nomad_botherer_nomad_staleness_checks_total` | Counter | — | Nomad diff checks triggered because `time() - nomad_botherer_last_check_timestamp_seconds` exceeded `--max-nomad-staleness`. A rising count means the normal diff loop is falling behind. |
-
-#### gRPC
-
-These metrics describe requests to the gRPC server. They are only present when `--grpc-listen-addr` is configured.
-
-| Metric | Type | Labels | What it tells you |
-|--------|------|--------|-------------------|
-| `nomad_botherer_grpc_requests_total` | Counter | `method`, `code` | Authenticated gRPC requests completed, by full method name and gRPC status code. |
-| `nomad_botherer_grpc_auth_errors_total` | Counter | `method` | Requests rejected due to a missing or invalid API key, by method. |
 
 #### Service info
 
@@ -746,7 +553,7 @@ docker run -d \
   ghcr.io/gerrowadat/nomad-botherer:latest
 ```
 
-To enable the gRPC API, add `-e GRPC_LISTEN_ADDR=:9090 -e GRPC_API_KEY=your-api-key -p 9090:9090`.
+To enable the JSON API, add `-e API_KEY=your-api-key`.
 
 Supported platforms: `linux/amd64`, `linux/arm64` (Raspberry Pi 4+).
 
@@ -776,8 +583,8 @@ make test-cover   # run tests and generate coverage.html
 The regression suite lives in `tests/regression/` and is excluded from normal
 `go test ./...` runs by the `//go:build regression` build tag. It starts a real
 Nomad cluster (via Docker or a pre-existing address) and exercises the full
-request path: drift detection, job selection, Prometheus metrics, HTTP and gRPC
-endpoints, webhook HMAC verification, and the compiled binary's startup
+request path: drift detection, job selection, Prometheus metrics, HTTP and JSON
+API endpoints, webhook HMAC verification, and the compiled binary's startup
 lifecycle.
 
 Run it before cutting a release to verify that the build behaves correctly
@@ -853,8 +660,8 @@ calls. They are reliable against the isolated Docker-managed cluster.
 | `drift_test.go` | All three DiffTypes (`modified`, `missing_from_nomad`, `missing_from_hcl`); dead-job handling (stop-only and purge modes); Raft-index skip optimisation; commit-change bypass; multi-job checks; `ForceCheck` staleness counter |
 | `selection_test.go` | Exact glob; wildcard glob; no-match glob; meta-key presence/absence; union selection (both criteria); no criteria configured |
 | `metrics_test.go` | All expected metric names registered at construction; gauge values match observed drift; skip counter; first-seen timestamps (set, stable, cleared); parse-error and non-job-skip counters |
-| `security_test.go` | Webhook HMAC-SHA256 (valid, invalid, missing, wrong algorithm, large body, concurrent flood, no-secret mode); gRPC auth (missing, wrong, correct key; 100-concurrent load); path-traversal job IDs; very large HCL files; HTML XSS escaping in the index page |
-| `e2e_test.go` | Binary lifecycle (503→200 on startup); drift detected over HTTP and `/diffs`; webhook triggers refresh without waiting for next poll interval; gRPC `GetDiffs`, `GetStatus`, `TriggerRefresh`; `/metrics` endpoint content |
+| `security_test.go` | Webhook HMAC-SHA256 (valid, invalid, missing, wrong algorithm, large body, concurrent flood, no-secret mode); JSON API auth (missing, wrong, correct key; 100-concurrent load); path-traversal job IDs; very large HCL files; HTML XSS escaping in the index page |
+| `e2e_test.go` | Binary lifecycle (503→200 on startup); drift detected over HTTP and `/diffs`; webhook triggers refresh without waiting for next poll interval; JSON API (`/api/v1/diffs`, `/api/v1/status`, `/api/v1/selected-jobs`, `/api/v1/version`, `POST /api/v1/refresh`, `/api/openapi.json`); `/metrics` endpoint content |
 
 #### Nomad version compatibility
 
@@ -886,10 +693,8 @@ make build
 ### Build and test
 
 ```bash
-make build        # compile both nomad-botherer and nbctl
-make build-server # compile just the server
-make build-ctl    # compile just nbctl
-make install      # go install both binaries to $GOPATH/bin
+make build        # compile nomad-botherer
+make install      # go install to $GOPATH/bin
 make test         # go test -race ./...
 make test-cover   # run tests and generate coverage.html
 make test-regression                              # regression suite against Nomad 1.9.3 (Docker)

--- a/docs/proposals/change-checkpointing.md
+++ b/docs/proposals/change-checkpointing.md
@@ -55,7 +55,7 @@ nomad-botherer writes one Variable per in-flight rollout at a well-known path:
 nomad/jobs/gitops/checkpoints/<git_commit>
 ```
 
-The value is a serialised (JSON or protobuf binary) snapshot of the `JobUpdate`
+The value is a JSON-serialised snapshot of the `JobUpdate`
 slice for that commit. The Variable is created when the first update for a
 commit is enqueued and updated atomically as each update transitions through
 `PENDING → IN_PROGRESS → SUCCEEDED/FAILED`. When all updates for a commit reach

--- a/docs/proposals/gitops-job-updates.md
+++ b/docs/proposals/gitops-job-updates.md
@@ -12,7 +12,7 @@ reconciles Nomad job state toward what is declared in Git.
 
 The core questions are:
 
-1. How should a job update be represented internally (and in the gRPC API)?
+1. How should a job update be represented internally (and exposed via the JSON API)?
 2. How should we use Nomad cluster state — particularly the Raft index and job
    version fields — to make updates safe and idempotent?
 3. Which of three possible architectures should we adopt?
@@ -35,90 +35,64 @@ is an intended transition.
 
 ---
 
-## Protobuf representation
+## Go struct representation
 
-The existing `JobDiff` message in `proto/nomad_botherer.proto` captures the
-observation side. A new `JobUpdate` message captures the action side. Below is
-the proposed addition to the proto file.
+The existing `JobDiff` struct in `internal/nomad/differ.go` captures the
+observation side. A new `JobUpdate` struct captures the action side:
 
-```protobuf
+```go
 // JobUpdate represents a single intended change to a Nomad job, derived from
 // a detected diff between Git and the cluster. One diff produces one update.
-message JobUpdate {
-  // Unique identifier for this update, assigned by nomad-botherer.
-  // Format: <job_id>/<git_commit_short> — stable across restarts.
-  string update_id = 1;
+type JobUpdate struct {
+    // Unique identifier for this update, assigned by nomad-botherer.
+    // Format: <job_id>/<git_commit_short> — stable across restarts.
+    UpdateID string `json:"update_id"`
 
-  string job_id = 2;
+    JobID string `json:"job_id"`
 
-  // Path to the HCL file that is the source of truth for this job.
-  // Empty when operation is DEREGISTER (no HCL file for the job).
-  string hcl_file = 3;
+    // Path to the HCL file that is the source of truth for this job.
+    // Empty when operation is DEREGISTER (no HCL file for the job).
+    HCLFile string `json:"hcl_file,omitempty"`
 
-  // Git commit hash that triggered this update.
-  string git_commit = 4;
+    // Git commit hash that triggered this update.
+    GitCommit string `json:"git_commit"`
 
-  // Operation to perform on the Nomad cluster.
-  JobUpdateOperation operation = 5;
+    Operation JobUpdateOperation `json:"operation"`
+    Status    JobUpdateStatus    `json:"status"`
 
-  // Current status of this update.
-  JobUpdateStatus status = 6;
+    // Nomad's JobModifyIndex at the time the drift was detected.
+    // Used as a CAS (check-and-set) token when calling Jobs.Register().
+    // Zero means the job did not exist in Nomad at detection time.
+    NomadJobModifyIndex uint64 `json:"nomad_job_modify_index"`
 
-  // Nomad's JobModifyIndex at the time the drift was detected.
-  // Used as a CAS (check-and-set) token when calling Jobs.Register().
-  // Zero means the job did not exist in Nomad at detection time.
-  uint64 nomad_job_modify_index = 7;
+    // Nomad's cluster Raft index at detection time; recorded for auditability.
+    NomadRaftIndex uint64 `json:"nomad_raft_index"`
 
-  // Nomad's cluster Raft index (QueryMeta.LastIndex from Jobs.List())
-  // at the time the diff check ran. Recorded for auditability.
-  uint64 nomad_raft_index = 8;
-
-  // RFC3339 timestamp when the diff was detected and this update was created.
-  string detected_at = 9;
-
-  // RFC3339 timestamp when the update was applied (or failed). Empty until then.
-  string applied_at = 10;
-
-  // Human-readable error message if status is FAILED. Empty otherwise.
-  string error = 11;
+    DetectedAt string `json:"detected_at"`           // RFC3339
+    AppliedAt  string `json:"applied_at,omitempty"`  // RFC3339; empty until applied
+    Error      string `json:"error,omitempty"`
 }
 
-enum JobUpdateOperation {
-  JOB_UPDATE_OPERATION_UNSPECIFIED = 0;
-  REGISTER   = 1;  // Jobs.Register() — covers both first-time and modify
-  DEREGISTER = 2;  // Jobs.Deregister()
-}
+type JobUpdateOperation string
 
-enum JobUpdateStatus {
-  JOB_UPDATE_STATUS_UNSPECIFIED = 0;
-  PENDING     = 1;  // Created, not yet attempted
-  IN_PROGRESS = 2;  // Apply call in flight
-  SUCCEEDED   = 3;  // Nomad accepted the change
-  FAILED      = 4;  // Nomad rejected or returned an error
-  SUPERSEDED  = 5;  // A newer update for the same job was created before this one applied
-}
+const (
+    JobUpdateOperationRegister   JobUpdateOperation = "REGISTER"
+    JobUpdateOperationDeregister JobUpdateOperation = "DEREGISTER"
+)
+
+type JobUpdateStatus string
+
+const (
+    JobUpdateStatusPending    JobUpdateStatus = "PENDING"
+    JobUpdateStatusInProgress JobUpdateStatus = "IN_PROGRESS"
+    JobUpdateStatusSucceeded  JobUpdateStatus = "SUCCEEDED"
+    JobUpdateStatusFailed     JobUpdateStatus = "FAILED"
+    JobUpdateStatusSuperseded JobUpdateStatus = "SUPERSEDED"
+)
 ```
 
-A new gRPC method gives operators visibility into the update queue:
-
-```protobuf
-service NomadBotherer {
-  // ... existing methods ...
-
-  // ListUpdates returns the current set of pending and recently completed
-  // job updates.
-  rpc ListUpdates(ListUpdatesRequest) returns (ListUpdatesResponse);
-}
-
-message ListUpdatesRequest {
-  // If true, include SUCCEEDED and FAILED updates, not just PENDING/IN_PROGRESS.
-  bool include_completed = 1;
-}
-
-message ListUpdatesResponse {
-  repeated JobUpdate updates = 1;
-}
-```
+A `GET /api/v1/updates` endpoint gives operators visibility into the update queue,
+returning the same JSON-serialised `[]JobUpdate` slice.
 
 ---
 
@@ -239,8 +213,7 @@ check is triggered.
 
 - Diff checks and applies are decoupled. A slow or failing apply does not affect
   detection latency.
-- Per-update status is first-class: `ListUpdates` gRPC method has meaningful
-  data.
+- Per-update status is first-class: `GET /api/v1/updates` has meaningful data.
 - Natural place to add apply rate limiting (one update per N seconds per job)
   or dry-run mode (process queue but skip the actual `Jobs.Register()` call).
 - The `SUPERSEDED` status handles pushes that arrive faster than applies finish.
@@ -318,9 +291,9 @@ value, is the most compatible with the existing Differ/Watcher architecture,
 and provides the hooks needed to add Alternative C's approval layer later without
 restructuring the core.
 
-The protobuf additions above should land in the same change as the queue
-implementation. The `ListUpdates` gRPC method makes the queue observable without
-requiring log scraping.
+The `JobUpdate` struct additions above should land in the same change as the queue
+implementation. The `GET /api/v1/updates` endpoint makes the queue observable
+without requiring log scraping.
 
 ---
 

--- a/examples/nomad-botherer.hcl
+++ b/examples/nomad-botherer.hcl
@@ -6,8 +6,8 @@
 #
 #   nomad job run nomad-botherer.hcl
 #
-# The only required settings are GIT_REPO_URL and (when gRPC is enabled)
-# GRPC_API_KEY. Everything else has a sensible default.
+# The only required setting is GIT_REPO_URL. Everything else has a sensible
+# default. Set API_KEY to enable the authenticated JSON API (/api/v1/).
 
 job "nomad-botherer" {
   # Run in the same namespace as the jobs you want to watch. nomad-botherer
@@ -40,12 +40,8 @@ job "nomad-botherer" {
     }
 
     network {
-      # HTTP port: /healthz, /metrics, /diffs, /webhook, and the status page.
+      # HTTP port: /healthz, /metrics, /diffs, /webhook, /api/v1/, and the status page.
       port "http" { to = 8080 }
-
-      # gRPC port: used by nbctl and grpcurl. Remove this port and set
-      # GRPC_LISTEN_ADDR = "" below if you do not need the gRPC API.
-      port "grpc" { to = 9090 }
     }
 
     task "nomad-botherer" {
@@ -53,7 +49,7 @@ job "nomad-botherer" {
 
       config {
         image = "ghcr.io/gerrowadat/nomad-botherer:latest"
-        ports = ["http", "grpc"]
+        ports = ["http"]
       }
 
       env {
@@ -125,18 +121,14 @@ job "nomad-botherer" {
         # URL path for the webhook endpoint. Defaults to /webhook.
         # WEBHOOK_PATH = "/webhook"
 
-        # ── gRPC server ─────────────────────────────────────────────────────
+        # ── JSON API ────────────────────────────────────────────────────────
         #
-        # The gRPC server is used by nbctl and grpcurl. To disable it, set
-        # GRPC_LISTEN_ADDR to an empty string and remove the "grpc" port above.
-
-        GRPC_LISTEN_ADDR = ":9090"
-
-        # Pre-shared API key for gRPC authentication. Required when
-        # GRPC_LISTEN_ADDR is non-empty. Clients pass this as:
-        #   -H 'authorization: Bearer <key>'
-        # Choose a long random value and store it in a Nomad Variable.
-        GRPC_API_KEY = "change-me"
+        # The /api/v1/ endpoints are disabled by default. Set API_KEY to a
+        # long random string to enable them. All /api/v1/ requests must include:
+        #   Authorization: Bearer <key>
+        # The OpenAPI spec is served publicly at /api/openapi.json.
+        # Store the key in a Nomad Variable rather than hardcoding it here.
+        # API_KEY = "change-me"
 
         # ── Job selection ───────────────────────────────────────────────────
         #
@@ -190,19 +182,19 @@ job "nomad-botherer" {
 
       # ── Reading secrets from Nomad Variables ──────────────────────────────
       #
-      # Uncomment and adapt this block to pull GIT_TOKEN and GRPC_API_KEY from
+      # Uncomment and adapt this block to pull GIT_TOKEN and API_KEY from
       # a Nomad Variable rather than hardcoding them in env {}.
       #
       # First, create the variable:
       #   nomad var put nomad/jobs/nomad-botherer \
       #     GIT_TOKEN=ghp_... \
-      #     GRPC_API_KEY=your-long-random-key
+      #     API_KEY=your-long-random-key
       #
       # template {
       #   data        = <<-EOT
       #     {{ with nomadVar "nomad/jobs/nomad-botherer" }}
       #     GIT_TOKEN={{ .GIT_TOKEN }}
-      #     GRPC_API_KEY={{ .GRPC_API_KEY }}
+      #     API_KEY={{ .API_KEY }}
       #     {{ end }}
       #   EOT
       #   destination = "secrets/env"

--- a/internal/nomad/differ_test.go
+++ b/internal/nomad/differ_test.go
@@ -1259,3 +1259,137 @@ func TestDiffer_HCLCanonical_MetaInHCLNotNomad(t *testing.T) {
 		t.Errorf("want 1 selected job (hcl-canonical), got %+v", jobs)
 	}
 }
+
+// ── mergeSelectionReason ──────────────────────────────────────────────────────
+
+func TestMergeSelectionReason_EmptyExisting(t *testing.T) {
+	got := nomad.MergeSelectionReason("", nomad.SelectionReasonGlob)
+	if got != nomad.SelectionReasonGlob {
+		t.Errorf("want glob, got %v", got)
+	}
+}
+
+func TestMergeSelectionReason_SameReason(t *testing.T) {
+	got := nomad.MergeSelectionReason(nomad.SelectionReasonMeta, nomad.SelectionReasonMeta)
+	if got != nomad.SelectionReasonMeta {
+		t.Errorf("want meta, got %v", got)
+	}
+}
+
+func TestMergeSelectionReason_DifferentReasons(t *testing.T) {
+	got := nomad.MergeSelectionReason(nomad.SelectionReasonGlob, nomad.SelectionReasonMeta)
+	if got != nomad.SelectionReasonBoth {
+		t.Errorf("want both, got %v", got)
+	}
+}
+
+// ── hasContentDiff ────────────────────────────────────────────────────────────
+
+func TestHasContentDiff_Nil(t *testing.T) {
+	if nomad.HasContentDiff(nil) {
+		t.Error("nil diff should not be a content diff")
+	}
+}
+
+func TestHasContentDiff_TypeNone(t *testing.T) {
+	d := &nomadapi.JobDiff{Type: "None"}
+	if nomad.HasContentDiff(d) {
+		t.Error("Type=None should not be a content diff")
+	}
+}
+
+func TestHasContentDiff_TopLevelField(t *testing.T) {
+	d := &nomadapi.JobDiff{
+		Type:   "Edited",
+		Fields: []*nomadapi.FieldDiff{{Name: "Priority", Type: "Edited"}},
+	}
+	if !nomad.HasContentDiff(d) {
+		t.Error("top-level field diff should be a content diff")
+	}
+}
+
+func TestHasContentDiff_TopLevelObject(t *testing.T) {
+	d := &nomadapi.JobDiff{
+		Type:    "Edited",
+		Objects: []*nomadapi.ObjectDiff{{Type: "Edited"}},
+	}
+	if !nomad.HasContentDiff(d) {
+		t.Error("top-level object diff should be a content diff")
+	}
+}
+
+func TestHasContentDiff_TaskGroupAdded(t *testing.T) {
+	d := &nomadapi.JobDiff{
+		Type: "Edited",
+		TaskGroups: []*nomadapi.TaskGroupDiff{
+			{Type: "Added"},
+		},
+	}
+	if !nomad.HasContentDiff(d) {
+		t.Error("Added task group should be a content diff")
+	}
+}
+
+func TestHasContentDiff_TaskGroupFieldOnly(t *testing.T) {
+	d := &nomadapi.JobDiff{
+		Type: "Edited",
+		TaskGroups: []*nomadapi.TaskGroupDiff{
+			{
+				Type:   "Edited",
+				Fields: []*nomadapi.FieldDiff{{Name: "Count", Type: "Edited"}},
+			},
+		},
+	}
+	if !nomad.HasContentDiff(d) {
+		t.Error("task group field diff should be a content diff")
+	}
+}
+
+func TestHasContentDiff_TaskGroupObjectOnly(t *testing.T) {
+	d := &nomadapi.JobDiff{
+		Type: "Edited",
+		TaskGroups: []*nomadapi.TaskGroupDiff{
+			{
+				Type:    "Edited",
+				Objects: []*nomadapi.ObjectDiff{{Type: "Edited"}},
+			},
+		},
+	}
+	if !nomad.HasContentDiff(d) {
+		t.Error("task group object diff should be a content diff")
+	}
+}
+
+func TestHasContentDiff_TaskEdited(t *testing.T) {
+	d := &nomadapi.JobDiff{
+		Type: "Edited",
+		TaskGroups: []*nomadapi.TaskGroupDiff{
+			{
+				Type: "Edited",
+				Tasks: []*nomadapi.TaskDiff{
+					{Type: "Edited", Fields: []*nomadapi.FieldDiff{{Name: "Driver"}}},
+				},
+			},
+		},
+	}
+	if !nomad.HasContentDiff(d) {
+		t.Error("edited task should be a content diff")
+	}
+}
+
+func TestHasContentDiff_AllTaskGroupsNone(t *testing.T) {
+	d := &nomadapi.JobDiff{
+		Type: "Edited",
+		TaskGroups: []*nomadapi.TaskGroupDiff{
+			{
+				Type: "None",
+				Tasks: []*nomadapi.TaskDiff{
+					{Type: "None"},
+				},
+			},
+		},
+	}
+	if nomad.HasContentDiff(d) {
+		t.Error("all-None task groups should not be a content diff")
+	}
+}

--- a/internal/nomad/export_test.go
+++ b/internal/nomad/export_test.go
@@ -1,0 +1,14 @@
+// export_test.go exposes unexported functions for testing from the nomad_test package.
+package nomad
+
+import nomadapi "github.com/hashicorp/nomad/api"
+
+// MergeSelectionReason wraps mergeSelectionReason for external test access.
+func MergeSelectionReason(existing, incoming SelectionReason) SelectionReason {
+	return mergeSelectionReason(existing, incoming)
+}
+
+// HasContentDiff wraps hasContentDiff for external test access.
+func HasContentDiff(d *nomadapi.JobDiff) bool {
+	return hasContentDiff(d)
+}

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -1,0 +1,7 @@
+// export_test.go exposes unexported functions for testing from the server_test package.
+package server
+
+import "time"
+
+// FmtTime wraps fmtTime for external test access.
+func FmtTime(t time.Time) string { return fmtTime(t) }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -959,19 +959,63 @@ func TestAPI_Spec_Public(t *testing.T) {
 	}
 }
 
-func TestAPI_NotReady_Returns503(t *testing.T) {
+func notReadySrv(t *testing.T) *server.Server {
+	t.Helper()
 	const key = "testkey"
 	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main", APIKey: key}
-	// Not-ready diff source (zero lastCheck)
-	diffSrc := &mockDiffSource{}
+	diffSrc := &mockDiffSource{} // zero lastCheck → not ready
 	gitSrc := &mockGitSource{lastCommit: "x", lastUpdate: time.Now()}
-	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
+	return server.NewWithRegistry(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
+}
 
+func TestAPI_NotReady_Diffs_Returns503(t *testing.T) {
+	srv := notReadySrv(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/diffs", nil)
-	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Authorization", "Bearer testkey")
 	rec := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rec, req)
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Errorf("want 503 when not ready, got %d", rec.Code)
+	}
+}
+
+func TestAPI_NotReady_SelectedJobs_Returns503(t *testing.T) {
+	srv := notReadySrv(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/selected-jobs", nil)
+	req.Header.Set("Authorization", "Bearer testkey")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("want 503 for selected-jobs when not ready, got %d", rec.Code)
+	}
+}
+
+func TestAPI_NotReady_Status_Returns503(t *testing.T) {
+	const key = "testkey"
+	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main", APIKey: key}
+	diffSrc := &mockDiffSource{lastCheck: time.Now()} // diffs ready
+	gitSrc := &mockGitSource{}                         // git NOT ready (zero lastUpdate)
+	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("want 503 for status when git not ready, got %d", rec.Code)
+	}
+}
+
+func TestFmtTime_ZeroReturnsEmpty(t *testing.T) {
+	if got := server.FmtTime(time.Time{}); got != "" {
+		t.Errorf("zero time: want empty string, got %q", got)
+	}
+}
+
+func TestFmtTime_NonZeroReturnsRFC3339(t *testing.T) {
+	ts := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	got := server.FmtTime(ts)
+	if got != "2026-01-15T12:00:00Z" {
+		t.Errorf("want RFC3339 UTC, got %q", got)
 	}
 }

--- a/tests/regression/e2e_test.go
+++ b/tests/regression/e2e_test.go
@@ -307,6 +307,101 @@ func TestE2E_APIRefresh(t *testing.T) {
 	t.Error("POST /api/v1/refresh did not cause the git commit to advance within 20s")
 }
 
+// TestE2E_APISelectedJobs verifies GET /api/v1/selected-jobs returns the list
+// of watched jobs when at least one job is selected by glob.
+func TestE2E_APISelectedJobs(t *testing.T) {
+	repoURL, workDir, branch := createGitRepo(t)
+	apiKey := "selj-key-" + randomSuffix()
+
+	jobID := uniqueJobID("e2e-selj")
+	commitToGit(t, workDir, map[string]string{
+		jobID + ".hcl": testJobHCL(jobID),
+	})
+	registerJobHCL(t, testJobHCL(jobID))
+	waitForJobStatus(t, jobID, "running", 30*time.Second)
+
+	baseURL := startBothererWithAPI(t, apiKey,
+		"--repo-url="+repoURL,
+		"--branch="+branch,
+		"--job-selector-glob="+jobID,
+	)
+
+	var result struct {
+		Jobs []struct {
+			JobID  string `json:"job_id"`
+			Reason string `json:"selection_reason"`
+		} `json:"jobs"`
+	}
+	apiGet(t, baseURL+"/api/v1/selected-jobs", apiKey, &result)
+
+	found := false
+	for _, j := range result.Jobs {
+		if j.JobID == jobID {
+			found = true
+			if j.Reason != "glob" {
+				t.Errorf("job %q: want reason=glob, got %q", jobID, j.Reason)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("job %q not found in /api/v1/selected-jobs: %+v", jobID, result.Jobs)
+	}
+}
+
+// TestE2E_APIVersion verifies GET /api/v1/version returns build metadata.
+func TestE2E_APIVersion(t *testing.T) {
+	repoURL, workDir, branch := createGitRepo(t)
+	apiKey := "ver-key-" + randomSuffix()
+	commitToGit(t, workDir, map[string]string{"placeholder.hcl": "# no jobs"})
+
+	baseURL := startBothererWithAPI(t, apiKey,
+		"--repo-url="+repoURL,
+		"--branch="+branch,
+		"--job-selector-glob=does-not-exist",
+	)
+
+	var result struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+	}
+	apiGet(t, baseURL+"/api/v1/version", apiKey, &result)
+
+	if result.Version == "" {
+		t.Error("version should not be empty")
+	}
+	if result.Commit == "" {
+		t.Error("commit should not be empty")
+	}
+}
+
+// TestE2E_APISpec verifies GET /api/openapi.json is public and returns a valid
+// OpenAPI document.
+func TestE2E_APISpec(t *testing.T) {
+	repoURL, workDir, branch := createGitRepo(t)
+	apiKey := "spec-key-" + randomSuffix()
+	commitToGit(t, workDir, map[string]string{"placeholder.hcl": "# no jobs"})
+
+	baseURL := startBothererWithAPI(t, apiKey,
+		"--repo-url="+repoURL,
+		"--branch="+branch,
+		"--job-selector-glob=does-not-exist",
+	)
+
+	// No Authorization header — spec is public.
+	resp, err := http.Get(baseURL + "/api/openapi.json")
+	if err != nil {
+		t.Fatalf("GET /api/openapi.json: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), `"openapi"`) {
+		t.Error("spec response should contain openapi field")
+	}
+}
+
 // ── API helpers ───────────────────────────────────────────────────────────────
 
 // apiGet makes an authenticated GET request and decodes the JSON response into v.

--- a/tests/regression/infra_test.go
+++ b/tests/regression/infra_test.go
@@ -476,7 +476,7 @@ func gatherCounter(t *testing.T, reg *prometheus.Registry, name string) float64 
 	return total
 }
 
-// ── Mock sources (for server/gRPC unit-style security tests) ─────────────────
+// ── Mock sources (for server unit-style security tests) ──────────────────────
 
 type mockDiffSource struct {
 	ready bool


### PR DESCRIPTION
## What

Three things in one branch as they're all low-risk and naturally go together.

### 1. Remove all remaining gRPC / nbctl references

Every mention of gRPC, grpcurl, nbctl, protobuf, or GRPC_* env vars has been scrubbed from active documentation and code:

- **README**: the 250-line gRPC API + nbctl + grpcurl section is replaced by a 50-line JSON API section covering the same ground. All other stale references (Getting started, How it works, Installation, Configuration table, Monitoring metrics, Docker, Testing, Development) updated.
- **examples/nomad-botherer.hcl**: gRPC port removed, `GRPC_LISTEN_ADDR`/`GRPC_API_KEY` replaced with an `API_KEY` comment.
- **CHANGELOG**: v0.4.0 entry added.
- **docs/proposals/gitops-job-updates.md**: protobuf message definitions replaced with equivalent Go struct definitions; `ListUpdates` gRPC method reference updated to `GET /api/v1/updates`.
- **docs/proposals/change-checkpointing.md**: "JSON or protobuf binary" → "JSON".
- **tests/regression/infra_test.go**: stale "server/gRPC unit-style" comment fixed.

### 2. Coverage improvements

Before: nomad 88.1%, server 90.9%, total 84.5%  
After: nomad 94.8%, server 93.0%, total 87.4%

- `internal/nomad/export_test.go`: export wrappers so the external `nomad_test` package can reach `mergeSelectionReason` and `hasContentDiff`.
- `differ_test.go`: full branch coverage for `mergeSelectionReason` (empty existing, same reason, different reasons) and `hasContentDiff` (nil, Type=None, top-level fields, top-level objects, task group added/deleted, task group fields, task group objects, edited task, all-None task groups).
- `internal/server/export_test.go`: export wrapper for `fmtTime`.
- `server_test.go`: `fmtTime` zero and non-zero tests; separate 503 not-ready tests for `/api/v1/diffs`, `/api/v1/selected-jobs`, and `/api/v1/status`.

### 3. Missing e2e API tests

The previous PR added e2e tests for `diffs`, `status`, and `refresh`. Three endpoints had no e2e coverage:

- `TestE2E_APISelectedJobs` — starts a binary with a real Nomad job selected by glob, verifies `/api/v1/selected-jobs` returns it with `selection_reason: "glob"`.
- `TestE2E_APIVersion` — verifies `/api/v1/version` returns non-empty `version` and `commit`.
- `TestE2E_APISpec` — verifies `/api/openapi.json` is public (no auth header) and returns a valid OpenAPI document.