### PR TITLE
Fix regression test build

### DIFF
--- a/tests/regression/infra_test.go
+++ b/tests/regression/infra_test.go
@@ -486,6 +486,9 @@ type mockDiffSource struct {
 func (m *mockDiffSource) Diffs() ([]nomad.JobDiff, time.Time, string) {
 	return m.diffs, time.Now(), "deadbeef"
 }
+func (m *mockDiffSource) SelectedJobs() ([]nomad.SelectedJob, time.Time, string) {
+	return nil, time.Now(), "deadbeef"
+}
 func (m *mockDiffSource) Ready() bool { return m.ready }
 
 type mockGitSource struct {

--- a/tests/regression/security_test.go
+++ b/tests/regression/security_test.go
@@ -194,7 +194,7 @@ func TestSecurity_Webhook_HTMLEscaping(t *testing.T) {
 		WebhookPath:       "/webhook",
 		ManagedMetaPrefix: "gitops",
 	}
-	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, "test", prometheus.NewRegistry())
+	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
 
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
Two build errors under `-tags=regression` introduced when the JSON API landed:

1. `mockDiffSource` in `tests/regression/infra_test.go` was missing the `SelectedJobs()` method that the `server.DiffSource` interface now requires.
2. `newWebhookTestServer` in `security_test.go` still passed a bare `"test"` string to `server.NewWithRegistry`, which now takes `server.BuildInfo`.

Both fixes are purely mechanical — no logic changes.