### PR TITLE
Update lastCheck metric on skip cycles to prevent spurious stale alerts

### DIFF
--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -488,6 +488,7 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 	if listMeta != nil && listMeta.LastIndex == prevIndex && commit == prevCommit {
 		slog.Debug("Skipping diff: Nomad index and commit unchanged", "index", listMeta.LastIndex, "commit", commit)
 		d.diffChecksSkipped.Inc()
+		d.lastCheck.Set(float64(time.Now().Unix()))
 		return nil
 	}
 

--- a/internal/nomad/differ_test.go
+++ b/internal/nomad/differ_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/prometheus/client_golang/prometheus"
@@ -550,6 +551,18 @@ func TestDiffer_SkipOnUnchangedIndexAndCommit(t *testing.T) {
 		t.Fatalf("expected 1 Info call after first check, got %d", infoCalls)
 	}
 
+	// Capture the timestamp written by the first (full) check.
+	tsAfterFirst := gatherLastCheckTimestamp(t, reg)
+	if tsAfterFirst == 0 {
+		t.Fatal("expected last_check_timestamp_seconds to be set after first check")
+	}
+
+	// Wait until the wall clock has advanced past tsAfterFirst so that a fresh
+	// time.Now().Unix() will produce a strictly larger value. This is at most
+	// one second and avoids flakiness from both checks landing in the same second.
+	deadline := time.Unix(int64(tsAfterFirst)+1, 0)
+	time.Sleep(time.Until(deadline))
+
 	// Second call: same commit, same Nomad index — must skip per-job work.
 	if err := d.Check(map[string]string{"a.hcl": `job "test-job" {}`}, "abc123"); err != nil {
 		t.Fatal(err)
@@ -558,23 +571,28 @@ func TestDiffer_SkipOnUnchangedIndexAndCommit(t *testing.T) {
 		t.Errorf("expected Info not called on skip, got %d total calls", infoCalls)
 	}
 
-	// The last-check timestamp must be updated even on a skip so that the
-	// NomadBothererCheckStale alert does not fire on quiet but healthy cycles.
+	// The skip path must have advanced the timestamp, proving it updated the
+	// metric rather than relying on the earlier commitResults() call.
+	tsAfterSkip := gatherLastCheckTimestamp(t, reg)
+	if tsAfterSkip <= tsAfterFirst {
+		t.Errorf("last_check_timestamp_seconds not updated by skip: before=%v after=%v", tsAfterFirst, tsAfterSkip)
+	}
+}
+
+func gatherLastCheckTimestamp(t *testing.T, reg prometheus.Gatherer) float64 {
+	t.Helper()
 	mfs, err := reg.Gather()
 	if err != nil {
 		t.Fatalf("gather: %v", err)
 	}
-	var lastCheckTs float64
 	for _, mf := range mfs {
 		if mf.GetName() == "nomad_botherer_last_check_timestamp_seconds" {
 			for _, m := range mf.GetMetric() {
-				lastCheckTs = m.GetGauge().GetValue()
+				return m.GetGauge().GetValue()
 			}
 		}
 	}
-	if lastCheckTs == 0 {
-		t.Error("expected nomad_botherer_last_check_timestamp_seconds to be set after a skip cycle")
-	}
+	return 0
 }
 
 // TestDiffer_NoSkipOnChangedCommit verifies that a new git commit forces a

--- a/internal/nomad/differ_test.go
+++ b/internal/nomad/differ_test.go
@@ -528,7 +528,8 @@ func gatherJobDriftSince(t *testing.T, reg prometheus.Gatherer, job, diffType st
 
 // TestDiffer_SkipOnUnchangedIndexAndCommit verifies that Check skips all
 // per-job API calls when both the Nomad Raft index and the git commit are
-// identical to the previous check.
+// identical to the previous check, and still updates the last-check timestamp
+// so the NomadBothererCheckStale alert does not fire on quiet but healthy cycles.
 func TestDiffer_SkipOnUnchangedIndexAndCommit(t *testing.T) {
 	mock := defaultMock()
 	infoCalls := 0
@@ -539,7 +540,8 @@ func TestDiffer_SkipOnUnchangedIndexAndCommit(t *testing.T) {
 	mock.listFn = func(q *nomadapi.QueryOptions) ([]*nomadapi.JobListStub, *nomadapi.QueryMeta, error) {
 		return nil, &nomadapi.QueryMeta{LastIndex: 42}, nil
 	}
-	d := newTestDiffer(mock)
+	reg := prometheus.NewRegistry()
+	d := newTestDifferWithRegistry(mock, reg)
 
 	if err := d.Check(map[string]string{"a.hcl": `job "test-job" {}`}, "abc123"); err != nil {
 		t.Fatal(err)
@@ -554,6 +556,24 @@ func TestDiffer_SkipOnUnchangedIndexAndCommit(t *testing.T) {
 	}
 	if infoCalls != 1 {
 		t.Errorf("expected Info not called on skip, got %d total calls", infoCalls)
+	}
+
+	// The last-check timestamp must be updated even on a skip so that the
+	// NomadBothererCheckStale alert does not fire on quiet but healthy cycles.
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var lastCheckTs float64
+	for _, mf := range mfs {
+		if mf.GetName() == "nomad_botherer_last_check_timestamp_seconds" {
+			for _, m := range mf.GetMetric() {
+				lastCheckTs = m.GetGauge().GetValue()
+			}
+		}
+	}
+	if lastCheckTs == 0 {
+		t.Error("expected nomad_botherer_last_check_timestamp_seconds to be set after a skip cycle")
 	}
 }
 


### PR DESCRIPTION
When the Raft index and git commit are both unchanged, Check() skips the
expensive per-job loop. Previously it did not update
nomad_botherer_last_check_timestamp_seconds, so the NomadBothererCheckStale
alert would fire after enough quiet cycles even when the loop was healthy.

Now the metric is updated on the skip path too, since "we looked and nothing
changed" counts as a successful check from the alerting perspective.

https://claude.ai/code/session_016HFxBA1Sbe6EDjCRVjz23V