### PR TITLE
Docs: proposals for per-job update policies and Diun image-update integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,9 @@ nomad-botherer applies the Git state to Nomad. The design proposals in
 existing tooling (nomad-gitops-operator, nomad-ops, Levant, Waypoint) and
 explains what problems they have that nomad-botherer is trying to avoid.
 
-Before implementing the apply side, read both proposal docs. The decisions in
-them were made deliberately and the reasoning matters.
+Before implementing the apply side, read the proposal docs (job updates,
+checkpointing, update policies, Diun integration). The decisions in them were
+made deliberately and the reasoning matters.
 
 ### Core design principles for the apply side
 

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -96,6 +96,58 @@ focuses on internal developer platforms and has no Nomad deployment story.
 
 ---
 
+## Adjacent prior art: image update automation
+
+GitOps pins image tags; something else has to notice that upstream moved.
+The tools in this space differ mainly in *where the bump is written*, which
+is the design-relevant axis (see
+[`docs/proposals/diun-integration.md`](proposals/diun-integration.md)):
+
+### Diun (crazy-max/diun)
+
+Watches container registries for new tags and changed digests, and sends
+notifications (webhook among ~20 channels). Providers define the watch list:
+Docker, Swarm, Kubernetes, **Nomad** (watches running Docker-driver tasks,
+opt-in via `diun.enable` meta — the same Operator Pattern shape as scalad),
+File (a YAML list on local disk), and Dockerfile. Per-image options cover
+tag regexes, semver sorting, and notify-on-new vs notify-on-update. It
+deliberately *only notifies*: it never writes to a cluster or a repo, has no
+query API (push-only, each event delivered once), and keeps its own seen-state
+in an embedded store. This makes it composable with a GitOps operator rather
+than competing with one, and it is the planned integration for
+nomad-botherer's update-availability surface.
+
+### Renovate (renovatebot/renovate)
+
+Opens PRs against the repo when dependencies — including Docker image
+references — have newer versions. Writes to *Git*, which keeps the GitOps
+invariant intact. The catch for this project: Nomad HCL is not a natively
+supported manager, so image references in job files need custom regex
+managers. Renovate can coexist with nomad-botherer (Renovate bumps Git,
+nomad-botherer applies), and the planned patch-helper endpoint deliberately
+leaves room for it or similar tooling to own the PR side.
+
+### argocd-image-updater (Argo project)
+
+The Kubernetes precedent for bolting image tracking onto a GitOps operator.
+Watches registries for images used by Argo CD applications and supports two
+write-back methods: commit the bump to Git (preserves the GitOps model) or
+mutate the application's parameters directly in-cluster (faster, but the
+live state now disagrees with Git). The existence of both modes — and the
+documented advice to prefer the Git write-back — is a useful confirmation
+that "surface the update, let Git change first" is the defensible default.
+
+### Keel (keel-sh/keel)
+
+A Kubernetes operator that updates workloads *in-cluster* when new images
+appear, with optional approval workflows. The cluster drifts ahead of Git
+by design; Git stops being the source of truth. This is precisely the
+failure mode nomad-botherer avoids by never applying anything that is not
+in Git: image updates are surfaced and a diff is offered, but the change
+must land in the repo before it lands in Nomad.
+
+---
+
 ## What nomad-botherer does differently today
 
 nomad-botherer currently only detects drift; it does not apply changes. The

--- a/docs/proposals/change-checkpointing.md
+++ b/docs/proposals/change-checkpointing.md
@@ -1,7 +1,8 @@
 # Proposal: checkpointing ongoing job updates
 
 **Status**: draft  
-**Date**: 2026-05-13
+**Date**: 2026-05-13  
+**Updated**: 2026-06-11
 
 ## Background
 
@@ -38,6 +39,23 @@ standalone database.
 - Not require an external database (PostgreSQL, Redis, etcd, etc.).
 - Ideally, not require additional infrastructure beyond what the service already
   talks to (Nomad, Git).
+- **Be an optimisation, never a correctness dependency.** All durable truth
+  lives in Git (desired state) and Nomad (actual state, `JobModifyIndex`);
+  if the checkpoint store is empty, stale, or unreachable, nomad-botherer
+  must fall back to recomputing intent from one diff cycle and remain
+  correct — degraded only in visibility and audit, never in behaviour. In
+  particular, no apply decision may *require* checkpoint data: idempotency
+  comes from CAS and re-planning, and deregister safety comes from
+  rechecking live state immediately before the call, not from remembered
+  intent. See "Restart safety and recovery" in
+  [gitops-job-updates.md](gitops-job-updates.md).
+
+One known exception sits outside this rule by nature: Diun image-update
+notifications are delivered once and are not recomputable from Git or Nomad,
+so losing them loses real information (until the next upstream event). They
+use the same Nomad Variables store, and their loss still degrades only
+visibility, not GitOps correctness. See
+[diun-integration.md](diun-integration.md).
 
 ---
 
@@ -54,6 +72,11 @@ nomad-botherer writes one Variable per in-flight rollout at a well-known path:
 ```
 nomad/jobs/gitops/checkpoints/<git_commit>
 ```
+
+(The [Diun integration proposal](diun-integration.md) stores received
+image-update notifications under a sibling prefix,
+`nomad/jobs/gitops/image-updates/`, so a single ACL policy on
+`nomad/jobs/gitops/*` covers all nomad-botherer operational state.)
 
 The value is a JSON-serialised snapshot of the `JobUpdate`
 slice for that commit. The Variable is created when the first update for a

--- a/docs/proposals/diun-integration.md
+++ b/docs/proposals/diun-integration.md
@@ -1,0 +1,384 @@
+# Proposal: image update tracking with Diun
+
+**Status**: draft  
+**Date**: 2026-06-11
+
+## Background
+
+GitOps pins image tags in HCL. That is the point — the cluster runs what Git
+says — but it means nobody is watching the other direction: upstream
+publishes `api-server:1.44.0` and Git happily pins `1.43.0` forever. The
+missing piece is *update availability*: knowing that a newer image exists for
+something Git manages, and making it easy to act on.
+
+[Diun](https://github.com/crazy-max/diun) (Docker Image Update Notifier,
+crazy-max/diun) is the established tool for this: it watches container
+registries for new or changed tags and sends notifications. Per the
+no-reimplementation rule, nomad-botherer should not grow its own registry
+polling; it should integrate with Diun.
+
+Two hard constraints frame the design:
+
+1. **Git is the source of truth for what to track.** The set of images worth
+   watching is exactly the set referenced by managed jobs in the repo. That
+   set should drive Diun, not be maintained by hand in a second place.
+2. **nomad-botherer never mutates GitHub.** Available updates are surfaced,
+   and a helper produces a ready-to-use diff, but committing and PR-ing the
+   bump is the human's (or external automation's) job.
+
+The result is a full circle:
+
+```
+Git HCL (source of truth: images + tag constraints)
+  → nomad-botherer derives the image watch list
+  → Diun checks registries on its own schedule
+  → Diun webhook → nomad-botherer records an available update
+  → surfaced via API + metrics; patch helper emits a diff
+  → human turns the diff into a PR; merge updates Git
+  → normal GitOps apply path registers the change (policy-gated)
+  → HCL now references the new tag → available-update record pruned
+```
+
+---
+
+## What Diun provides (and does not)
+
+Facts that constrain the design, from Diun's documentation:
+
+- **Providers** define what Diun watches: Docker, Swarm, Kubernetes,
+  **Nomad**, File, and Dockerfile. The Nomad provider connects to a cluster
+  and watches images from running Docker-driver tasks, with opt-in via
+  `diun.enable = "true"` in job/group/task meta (or service tags), plus a
+  `watchByDefault` mode. The File provider reads a YAML list of image
+  entries from the **local filesystem only** (a file or a directory; no
+  HTTP fetch).
+- **Per-image options** are the same vocabulary everywhere: `watch_repo`,
+  `include_tags` / `exclude_tags` (regexps), `max_tags`, `sort_tags`
+  (including `semver`), `notify_on` (`new`/`update`), `platform`, and a
+  free-form `metadata` map that is echoed back in notifications.
+- **Notifications are push-only.** Diun has no HTTP query API; you cannot ask
+  it "what updates are available?". Its webhook notifier sends a JSON
+  payload per event with configurable endpoint, method, and headers.
+- **Diun owns its own seen-state** (an embedded key-value store). Each
+  new tag or changed digest is notified **once**. A consumer that loses a
+  notification does not get it again.
+
+The webhook payload (fields as documented):
+
+```json
+{
+  "diun_version": "...",
+  "hostname": "diun-host",
+  "status": "new",
+  "provider": "file",
+  "image": "ghcr.io/example/api-server:1.44.0",
+  "hub_link": "https://github.com/example/api-server/pkgs/container/api-server",
+  "mime_type": "application/vnd.docker.distribution.manifest.v2+json",
+  "digest": "sha256:…",
+  "created": "2026-06-11T10:26:58Z",
+  "platform": "linux/amd64",
+  "metadata": { "…": "echoed from the provider entry" }
+}
+```
+
+`status` is `new` (a tag not seen before — how new releases of a
+`watch_repo` image arrive) or `update` (a watched tag's digest changed — how
+a mutable tag like `:1.43` or `:latest` being re-pushed arrives). Both are
+interesting to a GitOps setup: the first is "there is something newer", the
+second is "what you have pinned no longer means what it meant".
+
+---
+
+## Who owns the watch list
+
+Diun wants a list it owns and polls; it does not answer ad-hoc queries. The
+question is where that list comes from.
+
+### Alternative A: Diun's Nomad provider, nomad-botherer passive
+
+Point Diun's Nomad provider at the cluster. Jobs opt in by carrying
+`diun.enable = "true"` in their meta — which, for managed jobs, lives in the
+HCL in Git, so the opt-in is still version-controlled. nomad-botherer's only
+involvement is receiving webhooks.
+
+**Pros**
+
+- Zero list-maintenance code in nomad-botherer. Diun's Nomad provider
+  already exists and is maintained.
+- The `diun.*` meta keys in HCL are human-written and round-trip through
+  registration untouched — no meta-drift.
+- Diun's default Nomad metadata (job ID, namespace, task group) comes back
+  in the webhook, making it trivial to match a notification to a job.
+
+**Cons**
+
+- **The watch list is the *running cluster*, not Git.** During drift windows
+  the tracked tag is whatever is running, not what Git declares; a job
+  committed to Git but not yet registered is not watched at all; a job
+  stopped for maintenance silently drops out of tracking.
+- Diun needs its own Nomad token with job-read access, a second credential
+  to manage.
+- Only Docker-driver tasks of *running* jobs are seen.
+
+### Alternative B: nomad-botherer generates the File provider list
+
+nomad-botherer already parses every managed job's HCL each cycle. From the
+parsed jobs it derives the image watch list: every Docker task image in a
+job with `"diun.enable" = "true"` in meta, with the job's other `diun.*`
+meta keys mapped onto the corresponding File provider entry options
+(`include_tags`, `sort_tags`, `watch_repo`, …). Each entry's `metadata` map
+carries the owning job IDs and HCL file paths, so the webhook payload comes
+back pre-correlated.
+
+The list is exposed two ways, both stateless and regenerated from HEAD:
+
+- `GET /api/v1/diun/images.yml` — the rendered File provider YAML, always
+  available. Useful for inspection and for any external mechanism that
+  delivers it to Diun.
+- `--diun-image-list-path` / `DIUN_IMAGE_LIST_PATH` (optional): a filesystem
+  path the list is (atomically: write temp + rename) rewritten to whenever
+  HEAD changes. Intended for co-scheduling Diun and nomad-botherer in the
+  same Nomad task group with a shared `alloc/` directory; Diun's File
+  provider points at the shared path. This is a deliberate, narrow exception
+  to the no-disk-writes posture: the file is derived state, owned by this
+  feature, regenerable from Git at any time, and written outside the in-memory
+  git clone (which stays `memory.NewStorage()`).
+
+**Pros**
+
+- **Git is the source of truth**, exactly as required. Images are tracked
+  from the moment they are committed, before first registration, and
+  independently of cluster state.
+- The same `diun.*` meta vocabulary as Alternative A — switching between
+  alternatives needs no HCL changes.
+- The `metadata` round-trip makes webhook matching exact rather than
+  inferred.
+- Diun needs no Nomad credentials.
+
+**Cons**
+
+- The File provider reads local files only, so list delivery requires either
+  co-scheduling with a shared alloc dir or an external fetch-to-disk step.
+- More code in nomad-botherer: list rendering, the endpoint, the file
+  writer, and their tests.
+
+### Alternative C: query Diun directly — rejected
+
+Diun has a gRPC API used by its own CLI (`diun image list`), bound to
+localhost by default. It is an internal interface, not a stable integration
+surface, and polling it would still leave Diun's watch list to be maintained
+somewhere. Webhooks are the supported integration point; this alternative is
+noted only because "nomad-botherer asks Diun" sounds plausible until the
+shape of Diun's API is examined.
+
+### Verdict
+
+Alternative B, with Alternative A as a zero-code fallback that the webhook
+intake should be compatible with from day one (the intake matches
+notifications by image repository regardless of provider, so a deployment
+can start on A and move to B without changes on the receiving side).
+
+---
+
+## Webhook intake
+
+The existing webhook server gains a second endpoint:
+
+| Flag | Env var | Default |
+|---|---|---|
+| `--diun-webhook-path` | `DIUN_WEBHOOK_PATH` | `/webhook/diun` |
+| `--diun-webhook-token` | `DIUN_WEBHOOK_TOKEN` | (empty — endpoint disabled) |
+
+Diun's webhook notifier supports custom headers; the Diun config sets
+`Authorization: Bearer <token>` (or an `X-Diun-Token` header) to the same
+value, and nomad-botherer rejects non-matching requests. Unlike the GitHub
+webhook there is no HMAC signature scheme; a shared bearer token is what the
+mechanism supports. An empty token leaves the endpoint unregistered rather
+than unauthenticated.
+
+On receipt, nomad-botherer:
+
+1. Parses the payload; rejects anything without an `image`.
+2. Splits the image reference into repository and tag, and matches the
+   repository against images referenced by managed jobs' HCL at current
+   HEAD (plus the `metadata` job hints when present). A repository may match
+   several jobs; the update fans out to all of them.
+3. Records an `AvailableImageUpdate` per (job, repository):
+
+```go
+type AvailableImageUpdate struct {
+    JobID      string `json:"job_id"`
+    HCLFile    string `json:"hcl_file"`
+    Repository string `json:"repository"`          // e.g. ghcr.io/example/api-server
+    CurrentRef string `json:"current_ref"`         // image reference pinned in HCL
+    NewTag     string `json:"new_tag"`
+    Digest     string `json:"digest"`
+    Status     string `json:"status"`              // diun's "new" or "update"
+    Created    string `json:"created"`             // image creation time, from diun
+    ReceivedAt string `json:"received_at"`         // RFC3339
+}
+```
+
+4. Surfaces the set at `GET /api/v1/image-updates`.
+
+A notification whose repository matches no managed job is counted (metric
+below) and dropped — likely a stale watch list or an Alternative A
+deployment with `watchByDefault` on.
+
+---
+
+## Restart safety
+
+This is the one place in the design where in-memory state is *not*
+recoverable from Git and Nomad alone: Diun notifies each event once, so if
+nomad-botherer restarts after receiving a webhook but the human has not yet
+acted on it, the knowledge is gone and Diun will not resend it.
+
+Per the [checkpointing proposal](change-checkpointing.md), the store for
+small operational state is Nomad Variables. Each received update is written
+to:
+
+```
+nomad/jobs/gitops/image-updates/<sanitised repository>
+```
+
+(Variable paths allow a restricted character set; the repository string is
+sanitised by replacing disallowed characters, with the original kept in the
+JSON value.) The value is the JSON set of outstanding `AvailableImageUpdate`
+records for that repository — small, far under the 64 KiB Variable limit,
+CAS-protected against concurrent writers. On startup, nomad-botherer lists
+the prefix and rehydrates.
+
+**Pruning** closes the circle and needs no tag-ordering heuristics: an
+`AvailableImageUpdate` is dropped when the HCL at current HEAD pins exactly
+the notified tag for that job (the human merged the bump — it is no longer
+"available", it is current), or when the job no longer references the
+repository at all. Records the human chose to skip (e.g. `1.44.0` arrived,
+then `1.45.0`, and only the latter was merged) are pruned by a retention
+flag rather than guesswork:
+
+| Flag | Env var | Default |
+|---|---|---|
+| `--image-update-retention` | `IMAGE_UPDATE_RETENTION` | `720h` |
+
+If Variables are unavailable (pre-1.4 cluster, ACL restrictions), the
+feature degrades to memory-only with a logged warning: updates are still
+received and surfaced, and a restart loses unactioned ones until the next
+Diun-side event. That degradation is acceptable; correctness of the GitOps
+core never depends on this data.
+
+---
+
+## The patch helper
+
+Surfacing an available update is only useful if acting on it is cheap. The
+helper endpoint emits a diff that can be fed straight into a PR:
+
+```
+GET /api/v1/image-updates/{job_id}/patch
+```
+
+returns `text/x-patch`, a unified diff against the HCL file at current HEAD
+with each outstanding image update for that job applied:
+
+```diff
+--- a/jobs/api-server.hcl
++++ b/jobs/api-server.hcl
+@@ -23,7 +23,7 @@
+       driver = "docker"
+       config {
+-        image = "ghcr.io/example/api-server:1.43.0"
++        image = "ghcr.io/example/api-server:1.44.0"
+       }
+```
+
+Query parameters narrow the selection when a job has several outstanding
+updates: `?repository=…` and `?tag=…` (default: all outstanding updates for
+the job, each at its most recently notified tag).
+
+Implementation notes:
+
+- The patch is produced by **exact string substitution** of the old image
+  reference in the raw file content from the in-memory clone — not by
+  re-rendering parsed HCL, which would destroy formatting and comments. The
+  unified diff is generated with an established diff library, not
+  hand-rolled.
+- If the image reference in the file is not a plain literal (built from HCL
+  variables or interpolation), substitution cannot work; the endpoint
+  returns `422` with a body explaining which file and why. This limitation
+  is documented rather than worked around.
+- The workflow is deliberately one step short of automation:
+
+  ```
+  curl -s botherer:8080/api/v1/image-updates/api-server/patch \
+    | git apply
+  git checkout -b bump-api-server && git commit -am "Bump api-server to 1.44.0"
+  ```
+
+  or the same patch fed to the GitHub contents API by an external script.
+  nomad-botherer itself never holds GitHub write credentials. If a later
+  proposal wants PR automation, it builds on this endpoint from outside.
+
+Once the PR merges, the change is ordinary Git drift and flows through the
+apply path under the job's [update policy](update-policies.md) — for jobs
+set to `image-only`, this circle is precisely the automation they opted
+into.
+
+---
+
+## Observability
+
+Following the metrics convention (`promauto.With(reg)`, `nomad_botherer_`
+prefix):
+
+- `nomad_botherer_diun_webhooks_received_total{status}` — counter; `status`
+  is Diun's `new`/`update`.
+- `nomad_botherer_diun_webhooks_unmatched_total` — counter; notifications
+  matching no managed job.
+- `nomad_botherer_diun_webhook_errors_total` — counter; auth failures and
+  malformed payloads.
+- `nomad_botherer_image_updates_available` — gauge; current outstanding
+  `AvailableImageUpdate` count.
+- `nomad_botherer_diun_image_list_entries` — gauge; entries in the generated
+  watch list.
+- `nomad_botherer_image_update_patches_served_total` — counter.
+
+---
+
+## Deployment sketch (Alternative B, co-scheduled)
+
+One Nomad job, one group, two tasks sharing the allocation directory:
+
+- `nomad-botherer` with `--diun-image-list-path=${NOMAD_ALLOC_DIR}/data/diun/images.yml`
+  and `--diun-webhook-token` set.
+- `diun` with the File provider pointed at that path, its embedded state db
+  on ephemeral task disk — losing it merely re-notifies everything once,
+  which nomad-botherer deduplicates by (repository, tag) — and the webhook
+  notifier pointed at `http://127.0.0.1:<listen>/webhook/diun` with the
+  matching bearer header.
+
+No volumes, no external services; the whole pair is reschedulable to any
+node, preserving the no-volume-claims principle.
+
+---
+
+## Open questions
+
+- **Digest-only changes.** A `status: update` on a pinned tag (same tag, new
+  digest) cannot be expressed as an HCL diff — the file already says the
+  right thing. Surface it as a distinct class ("pinned tag was re-pushed
+  upstream") with no patch offered? Probably yes; it is a supply-chain
+  signal, not a version bump.
+- **Tag constraint defaults.** Should jobs without `diun.include_tags` get a
+  generated default (e.g. `sort_tags: semver` + `watch_repo: true`), or the
+  Diun defaults? Generated defaults are friendlier but more magic.
+- **Shared images.** Two jobs pinning different tags of the same repository
+  produce one watch-list entry but two `AvailableImageUpdate` records with
+  different `current_ref`s. The list renderer needs to merge constraints
+  (union of include_tags?) — or emit one entry per distinct (repository,
+  constraints) pair. The latter is simpler; verify Diun deduplicates
+  registry calls itself.
+- **Webhook payload versioning.** Diun's payload is documented but not
+  versioned. The parser should ignore unknown fields and tolerate missing
+  optional ones; a contract test against a captured real payload would catch
+  upstream changes.

--- a/docs/proposals/gitops-job-updates.md
+++ b/docs/proposals/gitops-job-updates.md
@@ -1,7 +1,13 @@
 # Proposal: GitOps job updates
 
 **Status**: draft  
-**Date**: 2026-05-13
+**Date**: 2026-05-13  
+**Updated**: 2026-06-11
+
+Related proposals: [change-checkpointing.md](change-checkpointing.md)
+(persisting queue state), [update-policies.md](update-policies.md) (per-job
+control over what gets applied), [diun-integration.md](diun-integration.md)
+(tracking upstream image updates).
 
 ## Background
 
@@ -32,6 +38,17 @@ A GitOps update is triggered when `Check()` detects any of the following:
 The update carries enough context to execute the action and to record what
 happened. It is distinct from a `JobDiff`: a diff is an observation, an update
 is an intended transition.
+
+Not every diff becomes an update. Two filters sit between detection and
+enqueueing:
+
+- **Opt-in scope**: only jobs with `gitops_managed = "true"` are considered
+  at all (see [change-checkpointing.md](change-checkpointing.md),
+  Alternative 3).
+- **Per-job update policy**: the job's `gitops_update_policy` meta key
+  (`full` / `image-only` / `none`) decides whether this *kind* of change may
+  be applied automatically. A policy-blocked diff stays an observation and
+  never becomes a `JobUpdate`. See [update-policies.md](update-policies.md).
 
 ---
 
@@ -137,6 +154,99 @@ Each job in Nomad has a `Version` field that increments on every registered
 change. We do not use this for the apply decision, but it is worth recording in
 the update so that a future rollback operator (not in scope here) can target a
 specific version with `Jobs.Revert()`.
+
+---
+
+## Restart safety and recovery
+
+nomad-botherer must be able to die at any instant — mid-apply, mid-rollout,
+between detection and apply — and recover without an operator noticing
+anything beyond a metrics gap. The design rule that makes this possible:
+
+**All durable truth lives in Git (desired state) and Nomad (actual state plus
+`JobModifyIndex`). Anything nomad-botherer holds is a cache, derivable from
+those two by running one diff cycle.**
+
+Recovery is therefore not a special path. Startup is: clone (in-memory),
+`Check()`, enqueue whatever is still drifted. There is no replay log to
+process, no journal to fsck, and no state whose loss changes behaviour —
+only state whose loss costs one cycle of latency.
+
+What makes interruption at each point safe:
+
+- **Crash after detect, before apply**: the pending update is lost; the next
+  cycle re-detects the same drift and recreates it. The `UpdateID`
+  (`<job_id>/<git_commit_short>`) is deliberately derived from stable inputs
+  so the recreated update is recognisably the same intent.
+- **Crash after `Jobs.Register()` was sent, before recording the outcome**:
+  the next cycle's plan shows no diff (the register landed) and produces no
+  update — a natural no-op. If the register did not land, the drift is still
+  there and is retried. CAS via `EnforceIndex` ensures a retry cannot
+  stomp anything that changed in between.
+- **Crash mid-`DEREGISTER`**: deregister is the one non-idempotent risk — a
+  blind retry could delete a job that was legitimately re-registered in the
+  gap. The guard is *recheck, don't remember*: immediately before calling
+  deregister, re-confirm against live state (the job exists, its live meta
+  still has `gitops_managed = "true"`, and no HCL file for it exists at
+  current HEAD). A stored intent is never sufficient on its own, so a stale
+  replayed intent is harmless by construction.
+
+The [checkpointing proposal](change-checkpointing.md) layers durability on
+top of this for visibility and audit — an operator mid-rollout can see what
+was applied — but it is an optimisation, never a correctness dependency. If
+the checkpoint store is empty, wrong, or unreachable, the system falls back
+to recomputation and remains correct.
+
+---
+
+## Where the apply runs
+
+Orthogonal to the queue architecture below is the question of *what process*
+executes an apply. Two options were considered.
+
+### In-process (recommended)
+
+The reconciler goroutine calls `Jobs.Plan()` and `Jobs.Register()` directly.
+An apply is a handful of API calls completing in seconds; the restart
+analysis above already makes interruption safe, so process death mid-apply
+costs nothing but a cycle.
+
+### Dispatched Nomad job as apply executor
+
+The alternative: nomad-botherer registers a parameterized batch job
+(`nomad-botherer-apply`) once, and performs each apply by dispatching it
+with meta parameters — job ID, git commit, HCL path, captured
+`JobModifyIndex`. The dispatched task fetches the HCL at that exact commit,
+runs the plan + CAS register itself, and exits. Nomad supervises the
+executor, so the apply survives nomad-botherer's death entirely, and
+in-flight applies are discoverable on startup by listing the dispatch
+children — cluster state doubling as the in-flight-work record, which is an
+attractive extension of the "state lives in Nomad" idea. Each apply also
+gets a Nomad-native audit record and resource isolation for free.
+
+The costs are substantial, though:
+
+- The executor task needs its own Git credentials and a Nomad token with
+  submit-job rights — a secrets-distribution problem nomad-botherer
+  otherwise doesn't have.
+- Dispatch payloads are capped at 16 KiB, so the payload must be a pointer
+  (commit + path), which forces the executor to clone the repo per apply —
+  exactly the re-clone-per-cycle cost this project criticises in prior art,
+  now per-update.
+- Failure handling spans two processes: the executor can fail in ways
+  nomad-botherer must then discover by polling the dispatch job's status,
+  reintroducing the visibility machinery the in-process queue gives us
+  directly.
+- Latency per apply goes from seconds to scheduler-roundtrip-plus-image-pull.
+- The executor job itself must be registered and upgraded by something —
+  a bootstrap wrinkle for the tool that exists to register jobs.
+
+**Verdict**: not justified while applies are short-lived API calls that are
+already safe to interrupt. Revisit if the apply path grows long-running
+phases — e.g. watching a deployment's health to decide on auto-revert —
+where surviving the operator's restart mid-watch has real value. The
+`Applier` interface boundary should be kept clean enough that a dispatching
+implementation can be slotted in without restructuring.
 
 ---
 
@@ -299,12 +409,19 @@ without requiring log scraping.
 
 ## Open questions
 
-- **Deregister behaviour**: should `missing_from_hcl` trigger a deregister
-  unconditionally, or should it require an explicit `gitops: deregister` flag in
-  the job meta to prevent accidental deletions when a file is renamed?
+- **Deregister behaviour** (resolved direction): deregister requires an
+  explicit enable flag, `gitops_managed = "true"` on the *live* job, an
+  effective update policy of `full`, and a recheck of live state immediately
+  before the call (see "Restart safety and recovery"). Purge is never the
+  default. What remains open is whether a grace period (drift must persist
+  for N cycles before deregister fires) is also wanted, to absorb file
+  renames that briefly look like deletions.
 - **Apply ordering**: if multiple jobs change in one commit, should they be
   applied in dependency order? Nomad does not expose a dependency graph, so this
   would require an explicit ordering field in HCL or job meta.
 - **Rollback**: if a registered job's health checks fail after apply, should
   nomad-botherer trigger `Jobs.Revert()`? This needs a separate health-check
-  polling loop and is out of scope for an initial implementation.
+  polling loop and is out of scope for an initial implementation. If it is
+  ever built, it is the strongest argument for the dispatched-executor model
+  in "Where the apply runs", since the watch outlives any single
+  nomad-botherer process.

--- a/docs/proposals/update-policies.md
+++ b/docs/proposals/update-policies.md
@@ -1,0 +1,216 @@
+# Proposal: per-job update policies
+
+**Status**: draft  
+**Date**: 2026-06-11
+
+## Background
+
+The [GitOps job updates proposal](gitops-job-updates.md) describes how
+nomad-botherer will apply detected drift to the cluster. That proposal treats
+apply as all-or-nothing: a job is either managed (`gitops_managed = "true"`)
+and fully reconciled, or not managed and never touched.
+
+In practice, jobs want different degrees of automation. A stateless web
+frontend can absorb any change Git throws at it. A database job might want
+image version bumps applied automatically but anything touching volumes,
+resources, or constraints held for a human. A particularly delicate job might
+want drift *reported* but never applied.
+
+This proposal adds a per-job policy key to the existing meta opt-in mechanism,
+so that the degree of automation is declared in the job's HCL alongside the
+opt-in flag — version-controlled, reviewable, and human-written (no
+meta-drift; see [change-checkpointing.md](change-checkpointing.md)).
+
+---
+
+## The policy key
+
+```hcl
+job "api-server" {
+  meta {
+    gitops_managed       = "true"
+    gitops_update_policy = "image-only"
+  }
+}
+```
+
+`gitops_update_policy` takes one of three values:
+
+| Value | Meaning |
+|---|---|
+| `full` | Any detected drift between the HCL and the cluster is applied (plan → CAS register, per the apply flow). |
+| `image-only` | Drift is applied only when the *entire* plan diff is confined to Docker image references. Any other change — even one bundled in the same commit as an image bump — leaves the whole update unapplied and surfaced as a diff. |
+| `none` | Drift is detected and surfaced (diffs API, metrics) but never applied. Detection-only, per job. |
+
+A job with `gitops_managed = "true"` and no policy key gets the default
+policy, which is a config flag:
+
+| Flag | Env var | Default |
+|---|---|---|
+| `--default-update-policy` | `DEFAULT_UPDATE_POLICY` | `full` |
+
+The default is `full` because `gitops_managed = "true"` already expresses
+the intent to be managed; the policy key *restricts* that. Deployments that
+want to enrol jobs gradually can set `--default-update-policy=none` and
+promote jobs one at a time by adding explicit policy keys.
+
+The conservative gate lives at the deployment level, not the job level: a
+global apply mode flag (see the job updates proposal) defaults to off, so no
+policy value causes a write until the operator turns applying on.
+
+---
+
+## Semantics by drift type
+
+| Drift type | `full` | `image-only` | `none` |
+|---|---|---|---|
+| `modified` (image fields only) | apply | apply | surface only |
+| `modified` (anything else) | apply | surface only | surface only |
+| `missing_from_nomad` | register | surface only | surface only |
+| `missing_from_hcl` | see below | never | never |
+
+Notes:
+
+- **Initial registration is `full`-only.** Registering a job for the first
+  time is by definition not an image-only change; an `image-only` job that is
+  missing from the cluster is surfaced as `missing_from_nomad` and left for a
+  human to register. This keeps `image-only` true to its name: the only write
+  it ever performs is a re-register where the plan shows image changes alone.
+- **Deregistration is not enabled by any policy value.** Per the existing
+  design intent, deregister requires the global enable flag *and*
+  `gitops_managed = "true"` on the live job. When that lands, it should
+  additionally require policy `full` (effective, after defaulting) — but the
+  policy key never turns deregistration on by itself.
+- For `missing_from_nomad` and `missing_from_hcl`, there is no live/parsed
+  job pair to compare, so "image-only" has no meaningful diff to classify;
+  hence the table above.
+
+The policy is read from the *HCL side* (the parsed job in Git) when both
+sides exist, because Git is the source of truth for intent. For
+`missing_from_hcl` there is no HCL; the live job's meta is all we have, which
+is consistent with the deregister guard already reading the live meta.
+
+---
+
+## Classifying a diff as image-only
+
+`Jobs.Plan()` returns a `JobPlanResponse` whose `Diff` field is a structured
+tree: job-level `Fields` and `Objects`, then `TaskGroups[]`, then `Tasks[]`,
+each with their own `Fields` and `Objects`. The Docker image lives at
+task level as the `image` field inside the `Config` object.
+
+A plan diff is image-only when every leaf marked changed (`Type` of `Added`,
+`Deleted`, or `Edited`) is:
+
+- a `Fields` entry named `image` inside a task's `Config` object, or
+- an annotation-only artefact of that change (Nomad marks the enclosing
+  task/group/job as `Edited` when any child changes; those container nodes
+  are not leaves).
+
+Everything else — env vars, resources, count, constraints, templates, meta
+itself — disqualifies the diff.
+
+Two existing principles interact with this classification and apply to *all*
+policies, not just `image-only`:
+
+- **Autoscaler ownership of `Count`.** Per the design intent (and nomad-ops
+  prior art), when a job has a scaling policy, changes to `Count`/`Scaling`
+  fields are excluded from drift consideration before policy is evaluated.
+  A diff that is "image change + autoscaler-owned count change" is still
+  image-only.
+- **Plan-before-apply.** The classification is done on the same plan response
+  that gates the register call, so there is no second round trip and no
+  window where the classified diff differs from the applied one. The
+  `JobModifyIndex` captured for CAS covers the classification too: if the
+  cluster moves after the plan, the register is rejected regardless of
+  policy.
+
+The classifier should be a pure function over `*api.JobDiff`
+(`classifyDiff(diff) DiffClass`) with table-driven tests covering: image-only,
+image+env, image+count-with-scaling-policy, image+count-without-scaling-policy,
+added task, removed group. It is the natural extension point if more
+categories are wanted later (see open questions).
+
+---
+
+## Meta key syntax
+
+HCL2 block attribute names cannot contain dots, so the block form works for
+nomad-botherer's own keys:
+
+```hcl
+meta {
+  gitops_managed       = "true"
+  gitops_update_policy = "image-only"
+}
+```
+
+The [Diun integration proposal](diun-integration.md) reuses Diun's dotted
+`diun.*` meta vocabulary, and dotted keys require the object-expression form.
+HCL does not allow mixing the two forms in one block, so a job using both
+families of keys writes:
+
+```hcl
+meta = {
+  "gitops_managed"       = "true"
+  "gitops_update_policy" = "image-only"
+  "diun.enable"          = "true"
+  "diun.include_tags"    = "^1\\."
+}
+```
+
+This is cosmetic but worth documenting in the README when implemented,
+because the error HCL produces when you mix forms is unhelpful.
+
+---
+
+## Relationship to image update tracking
+
+This proposal governs the *downstream* direction: Git has changed, how much
+of that change may be applied to Nomad automatically.
+
+The [Diun integration proposal](diun-integration.md) governs the *upstream*
+direction: a newer image exists in a registry, but Git still pins the old
+tag. That is not drift — Git and Nomad agree — so no policy value causes it
+to be applied. It is surfaced as an available update, and a human (or
+external automation) updates Git, at which point the change flows back
+through this proposal's policy gate like any other commit.
+
+The two are deliberately orthogonal: `gitops_update_policy` never causes a
+write that is not in Git, and Diun tracking never causes a write at all.
+
+---
+
+## Observability
+
+Per the metrics convention:
+
+- `nomad_botherer_updates_blocked_by_policy_total{job_id, policy}` — counter,
+  incremented when a detected diff would have produced a `JobUpdate` but the
+  effective policy filtered it out. This is the signal an operator watches to
+  find jobs accumulating unapplied drift.
+- The existing per-job drift gauges already cover the "surfaced but not
+  applied" state; blocked updates remain visible as diffs.
+
+Policy filtering happens at update *creation* time, not at apply time: a
+policy-blocked diff never becomes a `JobUpdate`, so no new `JobUpdateStatus`
+value is needed and the updates API only ever shows actionable intent.
+
+---
+
+## Open questions
+
+- **More categories.** Is `image-only` the only restricted policy worth
+  having, or do `env-only` / `resources-only` earn their keep? Proposal:
+  ship `full`/`image-only`/`none` and let the diff classifier's design make
+  additions cheap, rather than speculating now.
+- **Per-task or per-group policy.** A job with a delicate stateful task and a
+  disposable sidecar might want different policies per task. Nomad meta
+  exists at job, group, and task level, so the mechanism allows it — but
+  Nomad applies job registrations atomically, so a partial apply is not
+  actually possible. Job-level only, unless a real need appears.
+- **Policy on the live job disagreeing with HCL.** If the live job says
+  `full` and the HCL says `none`, the HCL wins (Git is intent). But the
+  *transition* commit that changes the policy is itself drift that the old
+  policy may block applying. Probably fine — a human registered the policy
+  change manually or the default policy applies — but worth a test case.


### PR DESCRIPTION
Docs-only. Prepares the design ground for the mutation/apply work.

## New proposals

**docs/proposals/update-policies.md** — adds a `gitops_update_policy` meta key
(`full` / `image-only` / `none`) next to the existing `gitops_managed` opt-in,
so each job declares how much automated application it wants. Defines the
semantics per drift type (initial registration is full-only; no policy value
enables deregistration), how a plan diff is classified as image-only from the
`Jobs.Plan()` diff tree, and how this interacts with the autoscaler
count-exclusion rule. Includes the HCL quoted-key gotcha when mixing
`gitops_*` and dotted `diun.*` meta keys.

**docs/proposals/diun-integration.md** — the full-circle image update design.
Git HCL is the source of truth for what to watch: nomad-botherer renders a
Diun file-provider YAML from managed jobs (served at an endpoint, optionally
written to a shared alloc dir when co-scheduled with Diun), Diun checks
registries and webhooks back, nomad-botherer records available updates and
serves a unified-diff patch endpoint you can pipe to `git apply` or a PR
script. nomad-botherer never gets GitHub write access. Because Diun notifies
each event exactly once, received updates are persisted in Nomad Variables
(under the same `nomad/jobs/gitops/` prefix as checkpoints) so a restart does
not lose them; loss degrades visibility only, never GitOps correctness.
Diun's native Nomad provider is documented as the zero-code alternative and
the webhook intake stays compatible with it. Verified against Diun's docs:
file provider is local-filesystem only, webhook payload fields, no query API.

## Updated

**gitops-job-updates.md** — new "Restart safety and recovery" section making
the recovery model explicit: all durable truth lives in Git + Nomad, recovery
is one diff cycle, interrupted registers are safe via CAS/re-plan, and
deregister safety comes from rechecking live state immediately before the
call rather than from remembered intent. New "Where the apply runs" section
weighs in-process apply against dispatching a parameterized Nomad batch job
per apply; in-process is recommended, with the executor model noted as worth
revisiting only if applies grow long-running phases (e.g. health-watch
auto-revert). Diffs are now explicitly policy-gated before becoming updates.

**change-checkpointing.md** — adds the requirement that the checkpoint store
is an optimisation, never a correctness dependency, with the Diun
notification store called out as the one piece of state not recomputable
from Git/Nomad.

**prior-art.md** — adds an image-update-automation survey (Diun, Renovate,
argocd-image-updater, Keel), organised around where each tool writes the
bump, since that is the axis that matters for keeping Git the source of truth.

**CLAUDE.md** — the "read both proposal docs" pointer now lists all four.

## What to review

Mostly the decisions: default policy `full` for opted-in jobs (restriction is
per-job, the conservative gate is the global apply mode), image-only jobs not
auto-registering when missing from Nomad, Nomad Variables for received Diun
notifications, and recommending against the dispatched-job apply executor for
now. Open questions are listed at the end of each proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)