### PR TITLE
Docs: nomad-botherer and Diun don't talk to each other; reject git-branch checkpoint store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,14 @@ without volume claims. The checkpointing proposal recommends Nomad Variables
 `CheckpointStore` interface so the backend is swappable. Do not introduce
 SQLite, PostgreSQL, Redis, or any other external store.
 
+**Never write to Git.** nomad-botherer reads Git and reads/writes Nomad —
+nothing else. No commits, no pushes, no GitHub API writes, no state branch;
+the tool holds no Git write credentials. Repo changes (including image tag
+bumps surfaced by external tooling like Diun) arrive by PR from humans or
+from automation that is not this tool. The most nomad-botherer offers is a
+read-only diff (the image-patch endpoint in the Diun proposal) for someone
+else to turn into a PR.
+
 **Decoupled detection and application.** The diff check loop and the apply loop
 are separate. A slow or failing apply must not delay the next diff check. The
 async queue model (Alternative B in the job updates proposal) is the right
@@ -102,9 +110,8 @@ The detection side has optimisations that are easy to accidentally break:
   prior cycle, per-job plan calls are skipped entirely. Keep this optimisation
   when extending `Check()`.
 - **In-memory clone**: `gitwatch.Watcher` uses `memory.NewStorage()` —
-  no disk writes, no persistent files. Any new git interaction should stay
-  in-memory or go through a clearly separate path (e.g. a checkpoint writer on
-  a state branch).
+  no disk writes, no persistent files. Any new git interaction stays
+  in-memory and read-only (see "Never write to Git" above).
 - **Webhook coalescing**: `Watcher.triggerCh` is a buffered channel of size 1.
   Multiple rapid triggers collapse to one fetch. Don't change this to unbuffered.
 

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -114,8 +114,10 @@ tag regexes, semver sorting, and notify-on-new vs notify-on-update. It
 deliberately *only notifies*: it never writes to a cluster or a repo, has no
 query API (push-only, each event delivered once), and keeps its own seen-state
 in an embedded store. This makes it composable with a GitOps operator rather
-than competing with one, and it is the planned integration for
-nomad-botherer's update-availability surface.
+than competing with one. nomad-botherer's planned integration is one-way:
+generate Diun's watch list from the managed jobs in Git, and offer a patch
+endpoint for whoever acts on the notifications — consuming them and writing
+the bump to Git stays outside the tool.
 
 ### Renovate (renovatebot/renovate)
 
@@ -143,8 +145,8 @@ A Kubernetes operator that updates workloads *in-cluster* when new images
 appear, with optional approval workflows. The cluster drifts ahead of Git
 by design; Git stops being the source of truth. This is precisely the
 failure mode nomad-botherer avoids by never applying anything that is not
-in Git: image updates are surfaced and a diff is offered, but the change
-must land in the repo before it lands in Nomad.
+in Git: Diun notices the update, nomad-botherer offers a ready-made diff,
+but the change must land in the repo before it lands in Nomad.
 
 ---
 

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -114,8 +114,9 @@ tag regexes, semver sorting, and notify-on-new vs notify-on-update. It
 deliberately *only notifies*: it never writes to a cluster or a repo, has no
 query API (push-only, each event delivered once), and keeps its own seen-state
 in an embedded store. This makes it composable with a GitOps operator rather
-than competing with one. nomad-botherer's planned integration is one-way:
-generate Diun's watch list from the managed jobs in Git, and offer a patch
+than competing with one. The planned setup points Diun's Nomad provider at
+the cluster, watching all jobs; nomad-botherer and Diun do not talk to each
+other at all. nomad-botherer's only contribution is a read-only patch
 endpoint for whoever acts on the notifications — consuming them and writing
 the bump to Git stays outside the tool.
 
@@ -203,10 +204,11 @@ touched, even if it is running in Nomad without a corresponding HCL file. This
 prevents accidental deregistration of manually-managed jobs.
 
 **No external database for state.** nomad-ops requires SQLite on persistent
-storage. The design proposals describe three alternatives that avoid this: Nomad
-Variables (Raft-backed KV built into Nomad 1.4+), a dedicated Git state branch,
-or deriving restart state from per-job metadata. The goal is that nomad-botherer
-can be rescheduled to any node without volume claims.
+storage. The design proposals use Nomad Variables (Raft-backed KV built into
+Nomad 1.4+) for checkpoint state instead, paired with a meta opt-in scope
+selector; a dedicated Git state branch was considered and rejected, because
+nomad-botherer never writes to Git. The goal is that nomad-botherer can be
+rescheduled to any node without volume claims.
 
 **Async apply queue, not synchronous blocking.** An in-process queue decouples
 detection from application. A slow or failing apply does not delay the next diff

--- a/docs/proposals/change-checkpointing.md
+++ b/docs/proposals/change-checkpointing.md
@@ -48,14 +48,11 @@ standalone database.
   comes from CAS and re-planning, and deregister safety comes from
   rechecking live state immediately before the call, not from remembered
   intent. See "Restart safety and recovery" in
-  [gitops-job-updates.md](gitops-job-updates.md).
-
-One known exception sits outside this rule by nature: Diun image-update
-notifications are delivered once and are not recomputable from Git or Nomad,
-so losing them loses real information (until the next upstream event). They
-use the same Nomad Variables store, and their loss still degrades only
-visibility, not GitOps correctness. See
-[diun-integration.md](diun-integration.md).
+  [gitops-job-updates.md](gitops-job-updates.md). This rule is
+  exception-free: anything that would require nomad-botherer to hold
+  non-recomputable state belongs outside the tool (the
+  [Diun integration proposal](diun-integration.md) keeps once-only
+  notification delivery outside the boundary for exactly this reason).
 
 ---
 
@@ -72,11 +69,6 @@ nomad-botherer writes one Variable per in-flight rollout at a well-known path:
 ```
 nomad/jobs/gitops/checkpoints/<git_commit>
 ```
-
-(The [Diun integration proposal](diun-integration.md) stores received
-image-update notifications under a sibling prefix,
-`nomad/jobs/gitops/image-updates/`, so a single ACL policy on
-`nomad/jobs/gitops/*` covers all nomad-botherer operational state.)
 
 The value is a JSON-serialised snapshot of the `JobUpdate`
 slice for that commit. The Variable is created when the first update for a

--- a/docs/proposals/change-checkpointing.md
+++ b/docs/proposals/change-checkpointing.md
@@ -25,8 +25,8 @@ not. A fresh diff cycle will detect the remaining drift and queue new updates,
 but whether those new updates correspond to the same intent as the interrupted
 rollout is ambiguous.
 
-This proposal describes three ways to checkpoint update state without a
-standalone database.
+This proposal describes how to checkpoint update state without a standalone
+database, and records one considered-and-rejected alternative.
 
 ---
 
@@ -136,82 +136,23 @@ operational state inside the system being managed.
 
 ---
 
-## Alternative 2: Git branch as the checkpoint store
+## Alternative 2 (rejected): Git branch as the checkpoint store
 
-**How it works**
+Earlier drafts described a second option in detail: a dedicated
+`gitops-state` branch in the watched repository, holding one JSON checkpoint
+file per rollout, committed and pushed on every status transition, with push
+rejection as the concurrency control. Its attraction was the audit trail —
+every state transition an immutable commit, inspectable with stock Git
+tooling.
 
-nomad-botherer maintains a dedicated branch in the same repository it watches,
-e.g., `gitops-state`, which it treats as a write-only append log. The branch
-holds one file per active rollout:
-
-```
-checkpoints/<git_commit>.json
-```
-
-Each file contains the `JobUpdate` slice for that commit, serialised as JSON.
-The file is committed and pushed when updates are enqueued, and updated with
-terminal statuses when each update completes. The branch is never merged into
-the main branch; it is purely operational state.
-
-On startup, nomad-botherer shallow-fetches the `gitops-state` branch (a small
-fetch since it only contains checkpoint files, not job HCL), reads all
-non-terminal checkpoint files, and rehydrates the queue.
-
-**Concurrency control**
-
-Git itself provides concurrency control via push rejection. If two instances try
-to push a checkpoint update simultaneously, one will receive a non-fast-forward
-rejection and must pull, merge, and retry. For checkpoint files (one file per
-commit, independent between commits), merge conflicts are essentially impossible;
-the only conflict would be two instances updating the same file, which is
-prevented by the single-writer design (only the instance that detected the
-commit owns its checkpoint).
-
-**Implementation sketch**
-
-The existing `gitwatch.Watcher` uses `go-git` and `memory.NewStorage()`. The
-checkpoint writer needs a separate, persistable storage (not in-memory) so that
-pushes can be made. This likely means a second `go-git` clone with disk-backed
-storage, or a thin wrapper around `git` CLI calls for the state branch.
-
-```go
-type GitCheckpointStore struct {
-    repoURL    string
-    branch     string  // "gitops-state"
-    workDir    string  // disk path for the state clone
-    auth       transport.AuthMethod
-}
-```
-
-**Pros**
-
-- Git is already a dependency; no new credentials or network endpoints needed
-  (assuming write access to the repo is already granted via token or SSH key).
-- The checkpoint history is a full Git log: every state transition is an
-  immutable commit, with timestamp and message. This is a better audit trail
-  than the in-memory or Nomad Variables approaches.
-- Standard Git tooling (`git log`, `git diff`, `git show`) lets operators
-  inspect and manipulate checkpoint state without custom tooling.
-- No external API version constraints (works with any Git host).
-
-**Cons**
-
-- Requires write access to the repository. Read-only tokens (common for
-  pull-based GitOps setups) are not sufficient.
-- Adds Git push latency to the hot path of every status update. A rollout of
-  30 jobs produces 30+ commits to the state branch.
-- Branch history grows unboundedly unless a periodic cleanup job prunes old
-  checkpoint commits (e.g., `git push --force` with a truncated history, or
-  a separate cleanup cron).
-- Mixing operational state and source code in one repository is operationally
-  awkward. Teams that have separate read/write access policies for source vs
-  operational state cannot use this without repo restructuring.
-- The state branch must be protected from human pushes that could corrupt
-  checkpoint data; this requires branch protection rules on the Git host.
-
-**Verdict**: good for teams that already have write access and want a full audit
-trail, but the per-update commit overhead and the read-write access requirement
-make it awkward as a default.
+It is rejected on principle: **nomad-botherer never writes to Git.** The
+tool reads Git and reads/writes Nomad; repo changes of any kind arrive by PR
+from humans or external automation, and the tool holds no Git write
+credentials. Beyond the principle, the practical costs were real too — a
+write-capable token where pull-based GitOps otherwise needs read-only, push
+latency on every status update, unbounded state-branch history, and a
+disk-backed second clone alongside the in-memory one. The full write-up is
+in this file's Git history if the reasoning ever needs revisiting.
 
 ---
 
@@ -382,23 +323,23 @@ selector; it is not a checkpoint mechanism.
 
 ## Comparison
 
-The three alternatives address the same problem (where to persist checkpoint
-state) but sit on different infrastructure axes. Alternative 3 is also an answer
-to a slightly different question (which jobs should be managed at all), so it
-layers on top of either of the other two rather than replacing them.
+The two live alternatives answer different questions — Alternative 1 is
+where to persist checkpoint state, Alternative 3 is which jobs should be
+managed at all — so Alternative 3 layers on top of Alternative 1 rather
+than replacing it.
 
-| Property | Alt 1: Nomad Variables | Alt 2: Git state branch | Alt 3: meta opt-in |
-|---|---|---|---|
-| What it stores | Pending/completed updates | Pending/completed updates | Scope selector only |
-| Infrastructure | Nomad 1.4+ | Git write access | Any Nomad |
-| Durability | Raft-backed | Full Git history | N/A (opt-in flag, not state) |
-| Audit trail | Moderate | Best | N/A |
-| Startup cost | List Variables + rehydrate | Clone state branch + read files | Already paid by diff cycle |
-| Concurrent instances | CAS on Variable ModifyIndex | Push rejection + retry | N/A |
-| Diff loop risk | None | None | None (flag is in HCL, not written by tool) |
-| Deregister tracking | Variable deleted on success | Checkpoint file removed | No record |
-| Nomad version required | 1.4+ | Any | Any |
-| Prevents touching manual jobs | No | No | Yes |
+| Property | Alt 1: Nomad Variables | Alt 3: meta opt-in |
+|---|---|---|
+| What it stores | Pending/completed updates | Scope selector only |
+| Infrastructure | Nomad 1.4+ | Any Nomad |
+| Durability | Raft-backed | N/A (opt-in flag, not state) |
+| Audit trail | Moderate | N/A |
+| Startup cost | List Variables + rehydrate | Already paid by diff cycle |
+| Concurrent instances | CAS on Variable ModifyIndex | N/A |
+| Diff loop risk | None | None (flag is in HCL, not written by tool) |
+| Deregister tracking | Variable deleted on success | No record |
+| Nomad version required | 1.4+ | Any |
+| Prevents touching manual jobs | No | Yes |
 
 ---
 
@@ -415,12 +356,11 @@ Implement the hybrid of Alternative 3 + Alternative 1:
    config flag (`--checkpoint-store`, default: `nomad-variables`). This provides
    durable, CAS-protected restart state without an external database.
 
-3. Offer Alternative 2 (Git state branch) as `--checkpoint-store=git-branch` for
-   teams that need a full audit trail and already have repo write access.
-
-The `CheckpointStore` interface above is the right abstraction boundary. Each
-alternative is an implementation of that interface; the update queue does not
-need to know which backend is active. The opt-in flag is orthogonal to this
+The `CheckpointStore` interface above is still the right abstraction
+boundary: the update queue does not need to know which backend is active,
+and a future backend (or a no-op store for memory-only operation) slots in
+without restructuring. Any such backend must respect the never-write-to-Git
+rule. The opt-in flag is orthogonal to this
 interface and should be a config-level default (`--gitops-opt-in-key`, default:
 `gitops_managed`) so teams can rename it if they have a key naming convention.
 When customising the prefix, keeping `gitops` as a root (e.g. `gitops_myteam`)

--- a/docs/proposals/diun-integration.md
+++ b/docs/proposals/diun-integration.md
@@ -3,6 +3,15 @@
 **Status**: draft  
 **Date**: 2026-06-11
 
+> **Revision note**: an earlier draft of this proposal had nomad-botherer
+> receiving Diun's webhooks, persisting "available update" records in Nomad
+> Variables, and serving them from an API. That has been removed. A Diun
+> notification is not actionable by nomad-botherer — nothing may change in
+> Nomad until Git changes, and nomad-botherer already watches Git — so
+> consuming notifications added state (the only state in the design not
+> recomputable from Git and Nomad) without adding behaviour. Closing the
+> notification-to-Git loop now lives explicitly outside the tool.
+
 ## Background
 
 GitOps pins image tags in HCL. That is the point — the cluster runs what Git
@@ -17,27 +26,40 @@ registries for new or changed tags and sends notifications. Per the
 no-reimplementation rule, nomad-botherer should not grow its own registry
 polling; it should integrate with Diun.
 
-Two hard constraints frame the design:
+The constraints that frame the design:
 
 1. **Git is the source of truth for what to track.** The set of images worth
    watching is exactly the set referenced by managed jobs in the repo. That
    set should drive Diun, not be maintained by hand in a second place.
-2. **nomad-botherer never mutates GitHub.** Available updates are surfaced,
-   and a helper produces a ready-to-use diff, but committing and PR-ing the
-   bump is the human's (or external automation's) job.
+2. **nomad-botherer never writes to Git.** Not directly, not via the GitHub
+   API, not on a side branch for this feature. Bumping a tag in a job file
+   is a Git change like any other: it arrives by PR, authored by a human or
+   by automation that is not this tool.
+3. **nomad-botherer acts only on Git and Nomad state.** Everything it knows
+   must be recomputable from those two (see "Restart safety and recovery" in
+   [gitops-job-updates.md](gitops-job-updates.md)). Diun notifications are
+   delivered exactly once and are not recomputable, so nomad-botherer does
+   not consume them.
 
-The result is a full circle:
+## Division of labour
 
 ```
-Git HCL (source of truth: images + tag constraints)
-  → nomad-botherer derives the image watch list
-  → Diun checks registries on its own schedule
-  → Diun webhook → nomad-botherer records an available update
-  → surfaced via API + metrics; patch helper emits a diff
-  → human turns the diff into a PR; merge updates Git
-  → normal GitOps apply path registers the change (policy-gated)
-  → HCL now references the new tag → available-update record pruned
+nomad-botherer   Git HCL → derive the image watch list → expose it for Diun
+Diun             check registries on its own schedule
+                 → notify (Slack/Matrix/email/webhook/… — Diun's job)
+outside          turn a notification into a Git PR: a human, or a small
+                 separate "bumper" job — either may use nomad-botherer's
+                 patch endpoint to get a ready-made diff
+Git              PR review + merge: the only write path
+nomad-botherer   ordinary GitOps apply of the merged commit (policy-gated,
+                 see update-policies.md)
 ```
+
+The circle still closes — Git's images stay current, and for jobs with
+`gitops_update_policy = "image-only"` the merged bump is applied
+automatically — but the segment that writes to Git is outside the tool, and
+nomad-botherer's two roles in the circle are both stateless functions of
+the repo at HEAD.
 
 ---
 
@@ -55,37 +77,17 @@ Facts that constrain the design, from Diun's documentation:
 - **Per-image options** are the same vocabulary everywhere: `watch_repo`,
   `include_tags` / `exclude_tags` (regexps), `max_tags`, `sort_tags`
   (including `semver`), `notify_on` (`new`/`update`), `platform`, and a
-  free-form `metadata` map that is echoed back in notifications.
-- **Notifications are push-only.** Diun has no HTTP query API; you cannot ask
-  it "what updates are available?". Its webhook notifier sends a JSON
-  payload per event with configurable endpoint, method, and headers.
-- **Diun owns its own seen-state** (an embedded key-value store). Each
-  new tag or changed digest is notified **once**. A consumer that loses a
-  notification does not get it again.
-
-The webhook payload (fields as documented):
-
-```json
-{
-  "diun_version": "...",
-  "hostname": "diun-host",
-  "status": "new",
-  "provider": "file",
-  "image": "ghcr.io/example/api-server:1.44.0",
-  "hub_link": "https://github.com/example/api-server/pkgs/container/api-server",
-  "mime_type": "application/vnd.docker.distribution.manifest.v2+json",
-  "digest": "sha256:…",
-  "created": "2026-06-11T10:26:58Z",
-  "platform": "linux/amd64",
-  "metadata": { "…": "echoed from the provider entry" }
-}
-```
-
-`status` is `new` (a tag not seen before — how new releases of a
-`watch_repo` image arrive) or `update` (a watched tag's digest changed — how
-a mutable tag like `:1.43` or `:latest` being re-pushed arrives). Both are
-interesting to a GitOps setup: the first is "there is something newer", the
-second is "what you have pinned no longer means what it meant".
+  free-form `metadata` map that is echoed back in notifications — useful
+  for whatever consumes them.
+- **Notifications are push-only and once-only.** Diun has no HTTP query API;
+  you cannot ask it "what updates are available?". It supports ~20
+  notification channels (including a generic webhook), and each new tag or
+  changed digest is notified **once** — Diun keeps its own seen-state in an
+  embedded store. A consumer that loses a notification does not get it
+  again. This is the property that makes notification consumption a poor
+  fit for a tool whose state must be recomputable.
+- It **never writes** to a cluster or a repo, which is exactly why it
+  composes with a GitOps operator instead of competing with one.
 
 ---
 
@@ -94,21 +96,20 @@ second is "what you have pinned no longer means what it meant".
 Diun wants a list it owns and polls; it does not answer ad-hoc queries. The
 question is where that list comes from.
 
-### Alternative A: Diun's Nomad provider, nomad-botherer passive
+### Alternative A: Diun's Nomad provider, nomad-botherer uninvolved
 
 Point Diun's Nomad provider at the cluster. Jobs opt in by carrying
 `diun.enable = "true"` in their meta — which, for managed jobs, lives in the
-HCL in Git, so the opt-in is still version-controlled. nomad-botherer's only
-involvement is receiving webhooks.
+HCL in Git, so the opt-in is still version-controlled. nomad-botherer has no
+role at all.
 
 **Pros**
 
-- Zero list-maintenance code in nomad-botherer. Diun's Nomad provider
-  already exists and is maintained.
+- Zero code. Diun's Nomad provider already exists and is maintained.
 - The `diun.*` meta keys in HCL are human-written and round-trip through
   registration untouched — no meta-drift.
-- Diun's default Nomad metadata (job ID, namespace, task group) comes back
-  in the webhook, making it trivial to match a notification to a job.
+- Diun's default Nomad metadata (job ID, namespace, task group) is included
+  in notifications, giving the consumer job context for free.
 
 **Cons**
 
@@ -127,8 +128,8 @@ parsed jobs it derives the image watch list: every Docker task image in a
 job with `"diun.enable" = "true"` in meta, with the job's other `diun.*`
 meta keys mapped onto the corresponding File provider entry options
 (`include_tags`, `sort_tags`, `watch_repo`, …). Each entry's `metadata` map
-carries the owning job IDs and HCL file paths, so the webhook payload comes
-back pre-correlated.
+carries the owning job IDs and HCL file paths, so notifications arrive at
+their consumer pre-correlated with the repo.
 
 The list is exposed two ways, both stateless and regenerated from HEAD:
 
@@ -151,8 +152,6 @@ The list is exposed two ways, both stateless and regenerated from HEAD:
   independently of cluster state.
 - The same `diun.*` meta vocabulary as Alternative A — switching between
   alternatives needs no HCL changes.
-- The `metadata` round-trip makes webhook matching exact rather than
-  inferred.
 - Diun needs no Nomad credentials.
 
 **Cons**
@@ -167,119 +166,34 @@ The list is exposed two ways, both stateless and regenerated from HEAD:
 Diun has a gRPC API used by its own CLI (`diun image list`), bound to
 localhost by default. It is an internal interface, not a stable integration
 surface, and polling it would still leave Diun's watch list to be maintained
-somewhere. Webhooks are the supported integration point; this alternative is
-noted only because "nomad-botherer asks Diun" sounds plausible until the
-shape of Diun's API is examined.
+somewhere. This alternative is noted only because "nomad-botherer asks Diun"
+sounds plausible until the shape of Diun's API is examined.
 
 ### Verdict
 
-Alternative B, with Alternative A as a zero-code fallback that the webhook
-intake should be compatible with from day one (the intake matches
-notifications by image repository regardless of provider, so a deployment
-can start on A and move to B without changes on the receiving side).
-
----
-
-## Webhook intake
-
-The existing webhook server gains a second endpoint:
-
-| Flag | Env var | Default |
-|---|---|---|
-| `--diun-webhook-path` | `DIUN_WEBHOOK_PATH` | `/webhook/diun` |
-| `--diun-webhook-token` | `DIUN_WEBHOOK_TOKEN` | (empty — endpoint disabled) |
-
-Diun's webhook notifier supports custom headers; the Diun config sets
-`Authorization: Bearer <token>` (or an `X-Diun-Token` header) to the same
-value, and nomad-botherer rejects non-matching requests. Unlike the GitHub
-webhook there is no HMAC signature scheme; a shared bearer token is what the
-mechanism supports. An empty token leaves the endpoint unregistered rather
-than unauthenticated.
-
-On receipt, nomad-botherer:
-
-1. Parses the payload; rejects anything without an `image`.
-2. Splits the image reference into repository and tag, and matches the
-   repository against images referenced by managed jobs' HCL at current
-   HEAD (plus the `metadata` job hints when present). A repository may match
-   several jobs; the update fans out to all of them.
-3. Records an `AvailableImageUpdate` per (job, repository):
-
-```go
-type AvailableImageUpdate struct {
-    JobID      string `json:"job_id"`
-    HCLFile    string `json:"hcl_file"`
-    Repository string `json:"repository"`          // e.g. ghcr.io/example/api-server
-    CurrentRef string `json:"current_ref"`         // image reference pinned in HCL
-    NewTag     string `json:"new_tag"`
-    Digest     string `json:"digest"`
-    Status     string `json:"status"`              // diun's "new" or "update"
-    Created    string `json:"created"`             // image creation time, from diun
-    ReceivedAt string `json:"received_at"`         // RFC3339
-}
-```
-
-4. Surfaces the set at `GET /api/v1/image-updates`.
-
-A notification whose repository matches no managed job is counted (metric
-below) and dropped — likely a stale watch list or an Alternative A
-deployment with `watchByDefault` on.
-
----
-
-## Restart safety
-
-This is the one place in the design where in-memory state is *not*
-recoverable from Git and Nomad alone: Diun notifies each event once, so if
-nomad-botherer restarts after receiving a webhook but the human has not yet
-acted on it, the knowledge is gone and Diun will not resend it.
-
-Per the [checkpointing proposal](change-checkpointing.md), the store for
-small operational state is Nomad Variables. Each received update is written
-to:
-
-```
-nomad/jobs/gitops/image-updates/<sanitised repository>
-```
-
-(Variable paths allow a restricted character set; the repository string is
-sanitised by replacing disallowed characters, with the original kept in the
-JSON value.) The value is the JSON set of outstanding `AvailableImageUpdate`
-records for that repository — small, far under the 64 KiB Variable limit,
-CAS-protected against concurrent writers. On startup, nomad-botherer lists
-the prefix and rehydrates.
-
-**Pruning** closes the circle and needs no tag-ordering heuristics: an
-`AvailableImageUpdate` is dropped when the HCL at current HEAD pins exactly
-the notified tag for that job (the human merged the bump — it is no longer
-"available", it is current), or when the job no longer references the
-repository at all. Records the human chose to skip (e.g. `1.44.0` arrived,
-then `1.45.0`, and only the latter was merged) are pruned by a retention
-flag rather than guesswork:
-
-| Flag | Env var | Default |
-|---|---|---|
-| `--image-update-retention` | `IMAGE_UPDATE_RETENTION` | `720h` |
-
-If Variables are unavailable (pre-1.4 cluster, ACL restrictions), the
-feature degrades to memory-only with a logged warning: updates are still
-received and surfaced, and a restart loses unactioned ones until the next
-Diun-side event. That degradation is acceptable; correctness of the GitOps
-core never depends on this data.
+Alternative B. Alternative A remains a valid zero-code deployment for setups
+that don't care about the drift-window and not-yet-registered caveats; since
+nomad-botherer is uninvolved in notification consumption either way, nothing
+in this tool needs to know which alternative a deployment chose.
 
 ---
 
 ## The patch helper
 
-Surfacing an available update is only useful if acting on it is cheap. The
-helper endpoint emits a diff that can be fed straight into a PR:
+nomad-botherer holds one thing the notification consumer wants and cannot
+cheaply get: the parsed repo at HEAD, including which managed HCL files
+reference a given image repository and the exact literal to substitute. The
+patch helper exposes that as a stateless endpoint — the caller brings the
+facts from the notification, nomad-botherer renders the diff:
 
 ```
-GET /api/v1/image-updates/{job_id}/patch
+GET /api/v1/image-patch?repository=ghcr.io/example/api-server&tag=1.44.0
 ```
 
-returns `text/x-patch`, a unified diff against the HCL file at current HEAD
-with each outstanding image update for that job applied:
+returns `text/x-patch`: a unified diff against the repo at current HEAD that
+bumps every managed job's reference to that repository up to the given tag
+(possibly spanning multiple files, when several jobs pin the same image).
+An optional `&job=<job_id>` narrows it to one job's file.
 
 ```diff
 --- a/jobs/api-server.hcl
@@ -292,10 +206,6 @@ with each outstanding image update for that job applied:
        }
 ```
 
-Query parameters narrow the selection when a job has several outstanding
-updates: `?repository=…` and `?tag=…` (default: all outstanding updates for
-the job, each at its most recently notified tag).
-
 Implementation notes:
 
 - The patch is produced by **exact string substitution** of the old image
@@ -303,26 +213,48 @@ Implementation notes:
   re-rendering parsed HCL, which would destroy formatting and comments. The
   unified diff is generated with an established diff library, not
   hand-rolled.
-- If the image reference in the file is not a plain literal (built from HCL
-  variables or interpolation), substitution cannot work; the endpoint
-  returns `422` with a body explaining which file and why. This limitation
-  is documented rather than worked around.
-- The workflow is deliberately one step short of automation:
+- The endpoint is a pure function of (HEAD, repository, tag). No notification
+  state, nothing to persist, nothing to lose on restart.
+- `404` when no managed job references the repository; `422` when a
+  referencing file builds the image string from HCL variables or
+  interpolation, with a body naming the file — substitution cannot work
+  there, and the limitation is documented rather than worked around.
+- The tag is taken on faith. Validating that it exists in the registry would
+  mean nomad-botherer talking to registries, which is Diun's job; the caller
+  got the tag *from* Diun.
 
-  ```
-  curl -s botherer:8080/api/v1/image-updates/api-server/patch \
-    | git apply
-  git checkout -b bump-api-server && git commit -am "Bump api-server to 1.44.0"
-  ```
+The endpoint deliberately stops one step short of a PR. nomad-botherer never
+holds GitHub write credentials.
 
-  or the same patch fed to the GitHub contents API by an external script.
-  nomad-botherer itself never holds GitHub write credentials. If a later
-  proposal wants PR automation, it builds on this endpoint from outside.
+---
 
-Once the PR merges, the change is ordinary Git drift and flows through the
-apply path under the job's [update policy](update-policies.md) — for jobs
-set to `image-only`, this circle is precisely the automation they opted
-into.
+## Closing the loop, outside nomad-botherer
+
+How a Diun notification becomes a Git PR is out of scope for this tool, by
+design. Two shapes, for illustration:
+
+**Manually.** Diun notifies a Slack/Matrix/email channel. A human sees
+"api-server 1.44.0 available" and runs:
+
+```
+curl -s "http://botherer:8080/api/v1/image-patch?repository=ghcr.io/example/api-server&tag=1.44.0" \
+  | git apply
+git checkout -b bump-api-server
+git commit -am "Bump api-server to 1.44.0" && git push
+```
+
+**A separate bumper job.** A small service (or scheduled Nomad job — *not*
+nomad-botherer, not this repo) receives Diun's generic webhook, calls the
+patch endpoint with the notified repository and tag, and opens a PR via the
+GitHub API. It owns the GitHub token, its own auth on the webhook, and its
+own policy about which notifications deserve automatic PRs. If it dies and
+loses a notification, that is between it and Diun — nomad-botherer's
+correctness and state are untouched. Tools like Renovate occupy the same
+seat (see [prior-art.md](../prior-art.md)).
+
+Either way, the merged PR is ordinary Git drift and flows through the apply
+path under the job's [update policy](update-policies.md) — for jobs set to
+`image-only`, this circle is precisely the automation they opted into.
 
 ---
 
@@ -331,17 +263,13 @@ into.
 Following the metrics convention (`promauto.With(reg)`, `nomad_botherer_`
 prefix):
 
-- `nomad_botherer_diun_webhooks_received_total{status}` — counter; `status`
-  is Diun's `new`/`update`.
-- `nomad_botherer_diun_webhooks_unmatched_total` — counter; notifications
-  matching no managed job.
-- `nomad_botherer_diun_webhook_errors_total` — counter; auth failures and
-  malformed payloads.
-- `nomad_botherer_image_updates_available` — gauge; current outstanding
-  `AvailableImageUpdate` count.
 - `nomad_botherer_diun_image_list_entries` — gauge; entries in the generated
   watch list.
-- `nomad_botherer_image_update_patches_served_total` — counter.
+- `nomad_botherer_diun_image_list_writes_total` / `…_write_errors_total` —
+  counters; rewrites of the `--diun-image-list-path` file.
+- `nomad_botherer_image_patches_served_total` — counter.
+- `nomad_botherer_image_patch_errors_total{reason}` — counter; `reason` of
+  `unknown_repository` or `non_literal_reference`.
 
 ---
 
@@ -349,13 +277,14 @@ prefix):
 
 One Nomad job, one group, two tasks sharing the allocation directory:
 
-- `nomad-botherer` with `--diun-image-list-path=${NOMAD_ALLOC_DIR}/data/diun/images.yml`
-  and `--diun-webhook-token` set.
+- `nomad-botherer` with
+  `--diun-image-list-path=${NOMAD_ALLOC_DIR}/data/diun/images.yml`.
 - `diun` with the File provider pointed at that path, its embedded state db
   on ephemeral task disk — losing it merely re-notifies everything once,
-  which nomad-botherer deduplicates by (repository, tag) — and the webhook
-  notifier pointed at `http://127.0.0.1:<listen>/webhook/diun` with the
-  matching bearer header.
+  which is the notification consumer's noise to absorb, not
+  nomad-botherer's — and notifiers configured for wherever the loop is
+  closed (a chat channel for the manual workflow, the bumper job's endpoint
+  for the automated one).
 
 No volumes, no external services; the whole pair is reschedulable to any
 node, preserving the no-volume-claims principle.
@@ -364,21 +293,20 @@ node, preserving the no-volume-claims principle.
 
 ## Open questions
 
-- **Digest-only changes.** A `status: update` on a pinned tag (same tag, new
-  digest) cannot be expressed as an HCL diff — the file already says the
-  right thing. Surface it as a distinct class ("pinned tag was re-pushed
-  upstream") with no patch offered? Probably yes; it is a supply-chain
-  signal, not a version bump.
 - **Tag constraint defaults.** Should jobs without `diun.include_tags` get a
   generated default (e.g. `sort_tags: semver` + `watch_repo: true`), or the
   Diun defaults? Generated defaults are friendlier but more magic.
-- **Shared images.** Two jobs pinning different tags of the same repository
-  produce one watch-list entry but two `AvailableImageUpdate` records with
-  different `current_ref`s. The list renderer needs to merge constraints
-  (union of include_tags?) — or emit one entry per distinct (repository,
-  constraints) pair. The latter is simpler; verify Diun deduplicates
-  registry calls itself.
-- **Webhook payload versioning.** Diun's payload is documented but not
-  versioned. The parser should ignore unknown fields and tolerate missing
-  optional ones; a contract test against a captured real payload would catch
-  upstream changes.
+- **Shared images with conflicting constraints.** Two jobs watching the same
+  repository with different `diun.*` options need either merged constraints
+  in one File entry or one entry per distinct (repository, constraints)
+  pair. The latter is simpler; verify Diun deduplicates registry calls
+  itself.
+- **Digest-only re-pushes.** Diun's `status: update` (same tag, new digest)
+  has no HCL expression — the file already names the right tag — so the
+  patch endpoint can do nothing with it. It is still a signal worth routing
+  somewhere (a mutable pinned tag changed under you), but that routing is
+  the notification consumer's concern.
+- **List staleness on the shared-file path.** If nomad-botherer is down, the
+  last-written list file persists and Diun keeps watching a stale set. That
+  is benign (it is at worst yesterday's truth) but worth a line in the
+  README when implemented.

--- a/docs/proposals/diun-integration.md
+++ b/docs/proposals/diun-integration.md
@@ -3,14 +3,16 @@
 **Status**: draft  
 **Date**: 2026-06-11
 
-> **Revision note**: an earlier draft of this proposal had nomad-botherer
-> receiving Diun's webhooks, persisting "available update" records in Nomad
-> Variables, and serving them from an API. That has been removed. A Diun
-> notification is not actionable by nomad-botherer — nothing may change in
-> Nomad until Git changes, and nomad-botherer already watches Git — so
-> consuming notifications added state (the only state in the design not
-> recomputable from Git and Nomad) without adding behaviour. Closing the
-> notification-to-Git loop now lives explicitly outside the tool.
+> **Revision note**: this proposal has shrunk twice, deliberately. An early
+> draft had nomad-botherer receiving Diun's webhooks and persisting
+> "available update" records; that went away because a notification is not
+> actionable by nomad-botherer (nothing changes in Nomad until Git changes)
+> and would have been the only state in the design not recomputable from Git
+> and Nomad. A second draft had nomad-botherer generating Diun's watch list
+> from the HCL in Git; that went away because Diun's own Nomad provider
+> covers the need with zero integration code. The result: **nomad-botherer
+> and Diun do not talk to each other at all.** The only thing this proposal
+> adds to nomad-botherer is a stateless patch endpoint.
 
 ## Background
 
@@ -23,19 +25,16 @@ something Git manages, and making it easy to act on.
 [Diun](https://github.com/crazy-max/diun) (Docker Image Update Notifier,
 crazy-max/diun) is the established tool for this: it watches container
 registries for new or changed tags and sends notifications. Per the
-no-reimplementation rule, nomad-botherer should not grow its own registry
-polling; it should integrate with Diun.
+no-reimplementation rule, nomad-botherer must not grow its own registry
+polling.
 
 The constraints that frame the design:
 
-1. **Git is the source of truth for what to track.** The set of images worth
-   watching is exactly the set referenced by managed jobs in the repo. That
-   set should drive Diun, not be maintained by hand in a second place.
-2. **nomad-botherer never writes to Git.** Not directly, not via the GitHub
-   API, not on a side branch for this feature. Bumping a tag in a job file
-   is a Git change like any other: it arrives by PR, authored by a human or
-   by automation that is not this tool.
-3. **nomad-botherer acts only on Git and Nomad state.** Everything it knows
+1. **nomad-botherer never writes to Git.** Not directly, not via the GitHub
+   API, not on a side branch. Bumping a tag in a job file is a Git change
+   like any other: it arrives by PR, authored by a human or by automation
+   that is not this tool.
+2. **nomad-botherer acts only on Git and Nomad state.** Everything it knows
    must be recomputable from those two (see "Restart safety and recovery" in
    [gitops-job-updates.md](gitops-job-updates.md)). Diun notifications are
    delivered exactly once and are not recomputable, so nomad-botherer does
@@ -44,8 +43,8 @@ The constraints that frame the design:
 ## Division of labour
 
 ```
-nomad-botherer   Git HCL → derive the image watch list → expose it for Diun
-Diun             check registries on its own schedule
+Diun             watch the cluster's images (Nomad provider, all jobs)
+                 → check registries on its own schedule
                  → notify (Slack/Matrix/email/webhook/… — Diun's job)
 outside          turn a notification into a Git PR: a human, or a small
                  separate "bumper" job — either may use nomad-botherer's
@@ -55,126 +54,54 @@ nomad-botherer   ordinary GitOps apply of the merged commit (policy-gated,
                  see update-policies.md)
 ```
 
-The circle still closes — Git's images stay current, and for jobs with
+The circle closes — Git's images stay current, and for jobs with
 `gitops_update_policy = "image-only"` the merged bump is applied
-automatically — but the segment that writes to Git is outside the tool, and
-nomad-botherer's two roles in the circle are both stateless functions of
-the repo at HEAD.
+automatically — but nomad-botherer appears in it only at the two places it
+already lives: rendering a diff from the repo at HEAD, and applying merged
+commits to Nomad.
 
 ---
 
-## What Diun provides (and does not)
+## How Diun watches: the Nomad provider
 
-Facts that constrain the design, from Diun's documentation:
+Diun's Nomad provider connects to the cluster (address/token, the same
+`NOMAD_ADDR` conventions as everything else) and watches the images of
+running Docker-driver tasks. The chosen configuration is
+`watchByDefault: true`: **all jobs are watched**, managed or not, with no
+per-job opt-in required and no involvement from nomad-botherer.
 
-- **Providers** define what Diun watches: Docker, Swarm, Kubernetes,
-  **Nomad**, File, and Dockerfile. The Nomad provider connects to a cluster
-  and watches images from running Docker-driver tasks, with opt-in via
-  `diun.enable = "true"` in job/group/task meta (or service tags), plus a
-  `watchByDefault` mode. The File provider reads a YAML list of image
-  entries from the **local filesystem only** (a file or a directory; no
-  HTTP fetch).
-- **Per-image options** are the same vocabulary everywhere: `watch_repo`,
-  `include_tags` / `exclude_tags` (regexps), `max_tags`, `sort_tags`
-  (including `semver`), `notify_on` (`new`/`update`), `platform`, and a
-  free-form `metadata` map that is echoed back in notifications — useful
-  for whatever consumes them.
-- **Notifications are push-only and once-only.** Diun has no HTTP query API;
-  you cannot ask it "what updates are available?". It supports ~20
-  notification channels (including a generic webhook), and each new tag or
-  changed digest is notified **once** — Diun keeps its own seen-state in an
-  embedded store. A consumer that loses a notification does not get it
-  again. This is the property that makes notification consumption a poor
-  fit for a tool whose state must be recomputable.
-- It **never writes** to a cluster or a repo, which is exactly why it
-  composes with a GitOps operator instead of competing with one.
+Per-job tuning still lives in Git. Diun reads its `diun.*` options from job,
+group, or task meta — `diun.include_tags`, `diun.exclude_tags`,
+`diun.sort_tags` (including `semver`), `diun.watch_repo`, `diun.max_tags`,
+`diun.notify_on`, and `diun.enable = "false"` to exclude a job — and for
+managed jobs that meta is written in the HCL and flows to the live job
+through registration. So tag-filter policy remains version-controlled and
+reviewable even though nomad-botherer never touches Diun. (Dotted meta keys
+need HCL's object-expression form; see the syntax note in
+[update-policies.md](update-policies.md).)
 
----
+Accepted tradeoffs of watching the cluster rather than the repo:
 
-## Who owns the watch list
+- The watch list is the *running cluster*. A job committed to Git but never
+  registered is not watched; a stopped job drops out of tracking; during a
+  drift window the watched tag is the running one, not the declared one.
+  For a setup where everything in Git is expected to be running, these
+  windows are short and harmless.
+- Diun needs its own Nomad token with job-read access.
+- Only Docker-driver tasks are seen.
 
-Diun wants a list it owns and polls; it does not answer ad-hoc queries. The
-question is where that list comes from.
+If those tradeoffs ever bite, the previously-drafted alternative —
+nomad-botherer rendering a Diun File-provider list from the parsed HCL at
+HEAD, so Git rather than the cluster defines the watch set — is recorded in
+this file's history (and the File provider's local-filesystem-only delivery
+constraint with it). It is not part of the current design. Likewise
+querying Diun directly was examined and rejected: Diun is push-only, with
+no HTTP query API (its gRPC interface is internal to its own CLI).
 
-### Alternative A: Diun's Nomad provider, nomad-botherer uninvolved
-
-Point Diun's Nomad provider at the cluster. Jobs opt in by carrying
-`diun.enable = "true"` in their meta — which, for managed jobs, lives in the
-HCL in Git, so the opt-in is still version-controlled. nomad-botherer has no
-role at all.
-
-**Pros**
-
-- Zero code. Diun's Nomad provider already exists and is maintained.
-- The `diun.*` meta keys in HCL are human-written and round-trip through
-  registration untouched — no meta-drift.
-- Diun's default Nomad metadata (job ID, namespace, task group) is included
-  in notifications, giving the consumer job context for free.
-
-**Cons**
-
-- **The watch list is the *running cluster*, not Git.** During drift windows
-  the tracked tag is whatever is running, not what Git declares; a job
-  committed to Git but not yet registered is not watched at all; a job
-  stopped for maintenance silently drops out of tracking.
-- Diun needs its own Nomad token with job-read access, a second credential
-  to manage.
-- Only Docker-driver tasks of *running* jobs are seen.
-
-### Alternative B: nomad-botherer generates the File provider list
-
-nomad-botherer already parses every managed job's HCL each cycle. From the
-parsed jobs it derives the image watch list: every Docker task image in a
-job with `"diun.enable" = "true"` in meta, with the job's other `diun.*`
-meta keys mapped onto the corresponding File provider entry options
-(`include_tags`, `sort_tags`, `watch_repo`, …). Each entry's `metadata` map
-carries the owning job IDs and HCL file paths, so notifications arrive at
-their consumer pre-correlated with the repo.
-
-The list is exposed two ways, both stateless and regenerated from HEAD:
-
-- `GET /api/v1/diun/images.yml` — the rendered File provider YAML, always
-  available. Useful for inspection and for any external mechanism that
-  delivers it to Diun.
-- `--diun-image-list-path` / `DIUN_IMAGE_LIST_PATH` (optional): a filesystem
-  path the list is (atomically: write temp + rename) rewritten to whenever
-  HEAD changes. Intended for co-scheduling Diun and nomad-botherer in the
-  same Nomad task group with a shared `alloc/` directory; Diun's File
-  provider points at the shared path. This is a deliberate, narrow exception
-  to the no-disk-writes posture: the file is derived state, owned by this
-  feature, regenerable from Git at any time, and written outside the in-memory
-  git clone (which stays `memory.NewStorage()`).
-
-**Pros**
-
-- **Git is the source of truth**, exactly as required. Images are tracked
-  from the moment they are committed, before first registration, and
-  independently of cluster state.
-- The same `diun.*` meta vocabulary as Alternative A — switching between
-  alternatives needs no HCL changes.
-- Diun needs no Nomad credentials.
-
-**Cons**
-
-- The File provider reads local files only, so list delivery requires either
-  co-scheduling with a shared alloc dir or an external fetch-to-disk step.
-- More code in nomad-botherer: list rendering, the endpoint, the file
-  writer, and their tests.
-
-### Alternative C: query Diun directly — rejected
-
-Diun has a gRPC API used by its own CLI (`diun image list`), bound to
-localhost by default. It is an internal interface, not a stable integration
-surface, and polling it would still leave Diun's watch list to be maintained
-somewhere. This alternative is noted only because "nomad-botherer asks Diun"
-sounds plausible until the shape of Diun's API is examined.
-
-### Verdict
-
-Alternative B. Alternative A remains a valid zero-code deployment for setups
-that don't care about the drift-window and not-yet-registered caveats; since
-nomad-botherer is uninvolved in notification consumption either way, nothing
-in this tool needs to know which alternative a deployment chose.
+One Diun behaviour worth knowing operationally: each new tag or changed
+digest is notified **once**, with seen-state kept in Diun's embedded store.
+If that store is lost (ephemeral disk, reschedule), everything is re-notified
+once — noise for the notification consumer, irrelevant to nomad-botherer.
 
 ---
 
@@ -263,50 +190,43 @@ path under the job's [update policy](update-policies.md) — for jobs set to
 Following the metrics convention (`promauto.With(reg)`, `nomad_botherer_`
 prefix):
 
-- `nomad_botherer_diun_image_list_entries` — gauge; entries in the generated
-  watch list.
-- `nomad_botherer_diun_image_list_writes_total` / `…_write_errors_total` —
-  counters; rewrites of the `--diun-image-list-path` file.
 - `nomad_botherer_image_patches_served_total` — counter.
 - `nomad_botherer_image_patch_errors_total{reason}` — counter; `reason` of
   `unknown_repository` or `non_literal_reference`.
 
+Diun has its own Prometheus metrics for the registry-watching side; nothing
+to duplicate here.
+
 ---
 
-## Deployment sketch (Alternative B, co-scheduled)
+## Deployment sketch
 
-One Nomad job, one group, two tasks sharing the allocation directory:
+Diun runs as its own Nomad job, independent of nomad-botherer:
 
-- `nomad-botherer` with
-  `--diun-image-list-path=${NOMAD_ALLOC_DIR}/data/diun/images.yml`.
-- `diun` with the File provider pointed at that path, its embedded state db
-  on ephemeral task disk — losing it merely re-notifies everything once,
-  which is the notification consumer's noise to absorb, not
-  nomad-botherer's — and notifiers configured for wherever the loop is
-  closed (a chat channel for the manual workflow, the bumper job's endpoint
-  for the automated one).
+- Nomad provider: cluster address, a read-only Nomad token,
+  `watchByDefault: true`.
+- Embedded state db on ephemeral task disk (loss is tolerable: one round of
+  re-notification).
+- Notifiers pointed wherever the loop is closed — a chat channel for the
+  manual workflow, the bumper job's endpoint for the automated one.
 
-No volumes, no external services; the whole pair is reschedulable to any
-node, preserving the no-volume-claims principle.
+nomad-botherer needs no Diun-related configuration at all; the patch
+endpoint is part of its normal HTTP server.
 
 ---
 
 ## Open questions
 
-- **Tag constraint defaults.** Should jobs without `diun.include_tags` get a
-  generated default (e.g. `sort_tags: semver` + `watch_repo: true`), or the
-  Diun defaults? Generated defaults are friendlier but more magic.
-- **Shared images with conflicting constraints.** Two jobs watching the same
-  repository with different `diun.*` options need either merged constraints
-  in one File entry or one entry per distinct (repository, constraints)
-  pair. The latter is simpler; verify Diun deduplicates registry calls
-  itself.
 - **Digest-only re-pushes.** Diun's `status: update` (same tag, new digest)
   has no HCL expression — the file already names the right tag — so the
   patch endpoint can do nothing with it. It is still a signal worth routing
   somewhere (a mutable pinned tag changed under you), but that routing is
   the notification consumer's concern.
-- **List staleness on the shared-file path.** If nomad-botherer is down, the
-  last-written list file persists and Diun keeps watching a stale set. That
-  is benign (it is at worst yesterday's truth) but worth a line in the
-  README when implemented.
+- **Tag-constraint hygiene.** With `watchByDefault: true` and no
+  `diun.include_tags`, noisy repositories (nightly tags, arch-suffixed tags)
+  may generate notification spam. That is tuned per job in HCL via `diun.*`
+  meta, which is a documentation task here, not a code one.
+- **Patch endpoint and unmanaged jobs.** Diun watches *all* jobs, but the
+  patch endpoint only knows files of managed ones. A notification for an
+  unmanaged job's image gets a `404` from the endpoint — correct, but the
+  README should say so to avoid confusion.

--- a/docs/proposals/update-policies.md
+++ b/docs/proposals/update-policies.md
@@ -172,9 +172,10 @@ of that change may be applied to Nomad automatically.
 The [Diun integration proposal](diun-integration.md) governs the *upstream*
 direction: a newer image exists in a registry, but Git still pins the old
 tag. That is not drift — Git and Nomad agree — so no policy value causes it
-to be applied. It is surfaced as an available update, and a human (or
-external automation) updates Git, at which point the change flows back
-through this proposal's policy gate like any other commit.
+to be applied, and nomad-botherer does not even consume the notification:
+Diun notifies whoever closes that loop (a human, or a separate bumper job),
+Git gets updated by PR, and the change then flows back through this
+proposal's policy gate like any other commit.
 
 The two are deliberately orthogonal: `gitops_update_policy` never causes a
 write that is not in Git, and Diun tracking never causes a write at all.


### PR DESCRIPTION
Docs-only revision of the proposals merged in #50, in two steps of shrinking
following review feedback.

## Step 1: drop the webhook intake (first commit)

A Diun notification is not actionable by nomad-botherer — nothing changes in
Nomad until Git changes, which the tool already watches — so receiving
notifications added state without adding behaviour. Worse, that state was
the one thing in the design not recomputable from Git and Nomad (Diun
delivers each event exactly once), which forced Nomad Variables persistence
and a restart-safety exception. Gone: the /webhook/diun intake,
AvailableImageUpdate, the image-updates Variables prefix, the
/api/v1/image-updates API, and the related flags and metrics.

## Step 2: drop the watch-list generation too (second commit)

Diun's Nomad provider with watchByDefault watches all jobs in the cluster
directly, so nomad-botherer does not need to render a file-provider list
from Git either. nomad-botherer and Diun now have no interaction at all.
The accepted tradeoffs (watch list is the running cluster, not the repo;
Diun needs a read-only Nomad token) are recorded in the proposal, and
per-job diun.* tuning still lives in HCL meta and reaches Diun through job
registration, so it stays version-controlled.

What survives in nomad-botherer: a single stateless endpoint,
GET /api/v1/image-patch?repository=…&tag=… — the caller brings the facts
from the notification, nomad-botherer renders a unified diff against HEAD
for a human or an external bumper job to turn into a PR.

## Also: git state branch checkpoint store rejected

change-checkpointing.md's Alternative 2 (push checkpoint JSON to a
gitops-state branch) is now explicitly rejected rather than offered as
--checkpoint-store=git-branch, on the principle that nomad-botherer never
writes to Git. The principle is added to CLAUDE.md's core design
principles, and the in-memory-clone preservation note no longer suggests a
state-branch write path. prior-art.md and update-policies.md
cross-references updated to match.

Net effect: every piece of nomad-botherer state is derivable from Git and
Nomad with no exceptions, and the tool's I/O surface is exactly read-Git,
read/write-Nomad, serve-HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
