### PR TITLE
Record v0.4.0 regression results in the Nomad compatibility matrix

### DIFF
--- a/docs/nomad-versions.md
+++ b/docs/nomad-versions.md
@@ -22,6 +22,7 @@ After a successful run, add a row to the table below and update `tests/regressio
 
 | nomad-botherer | Nomad 1.9.x | Nomad 1.10.x | Nomad 1.11.x | Nomad 2.0.x | Notes |
 |----------------|:-----------:|:------------:|:------------:|:-----------:|-------|
+| v0.4.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    |       |
 | v0.1.2         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    |       |
 
 ### Column key

--- a/tests/regression/compat.go
+++ b/tests/regression/compat.go
@@ -52,6 +52,30 @@ type VersionRecord struct {
 var TestedVersions = []VersionRecord{
 	{
 		NomadVersion:    "2.0.2",
+		BothererRelease: "v0.4.0",
+		TestedAt:        time.Date(2026, 6, 11, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.11.3",
+		BothererRelease: "v0.4.0",
+		TestedAt:        time.Date(2026, 6, 11, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.10.5",
+		BothererRelease: "v0.4.0",
+		TestedAt:        time.Date(2026, 6, 11, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.9.6",
+		BothererRelease: "v0.4.0",
+		TestedAt:        time.Date(2026, 6, 11, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "2.0.2",
 		BothererRelease: "v0.1.2",
 		TestedAt:        time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC),
 		Passed:          true,


### PR DESCRIPTION
Adds a v0.4.0 row to docs/nomad-versions.md and the matching VersionRecord entries in tests/regression/compat.go.

The full regression suite passes against Nomad 1.9.6, 1.10.5, 1.11.3, and 2.0.2, run 2026-06-11 via `make test-regression-versions` on a host with a live Nomad agent (using the suite port-collision fix from #53; the product code under test is identical to the v0.4.0 tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)