### PR TITLE
Improve unit test coverage from 78% to 88% of statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Changed
+
+- **Test coverage raised from 78% to 88% of statements.** `internal/config`
+  and `internal/nomad` are at 100%, `internal/server` at 99%, and
+  `internal/gitwatch` went from 66% to 92% — Clone, pull, and Run are now
+  exercised against real on-disk git repositories instead of only mocks.
+  No production code changed.
+
 ### Fixed
 
 - **Regression suite runs alongside a real Nomad agent.** The Docker-managed

--- a/cmd/nomad-botherer/main_test.go
+++ b/cmd/nomad-botherer/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+func TestSetupLogging_Levels(t *testing.T) {
+	orig := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	cases := []struct {
+		in   string
+		want slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"bogus", slog.LevelInfo}, // unknown levels fall back to info
+		{"", slog.LevelInfo},
+	}
+
+	ctx := context.Background()
+	for _, tc := range cases {
+		setupLogging(tc.in)
+		logger := slog.Default()
+		if !logger.Enabled(ctx, tc.want) {
+			t.Errorf("level %q: logger should be enabled at %v", tc.in, tc.want)
+		}
+		if logger.Enabled(ctx, tc.want-1) {
+			t.Errorf("level %q: logger should be disabled below %v", tc.in, tc.want)
+		}
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -563,3 +563,31 @@ func TestLoadFromArgs_RedactSecretsEnvOff(t *testing.T) {
 		t.Error("RedactSecrets: want false from env var, got true")
 	}
 }
+
+func TestLoad_UsesCommandLineAndArgs(t *testing.T) {
+	os.Unsetenv("GIT_REPO_URL")
+	oldArgs := os.Args
+	oldCommandLine := flag.CommandLine
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		flag.CommandLine = oldCommandLine
+	})
+	flag.CommandLine = flag.NewFlagSet("nomad-botherer", flag.ContinueOnError)
+	os.Args = []string{"nomad-botherer", "--repo-url", "https://example.com/load.git"}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.RepoURL != "https://example.com/load.git" {
+		t.Errorf("unexpected RepoURL from Load: %q", cfg.RepoURL)
+	}
+}
+
+func TestLoadFromArgs_UnknownFlagRejected(t *testing.T) {
+	os.Unsetenv("GIT_REPO_URL")
+	_, err := LoadFromArgs(newFS(), []string{"--no-such-flag"})
+	if err == nil {
+		t.Error("unknown flag should produce a parse error")
+	}
+}

--- a/internal/gitwatch/watcher_clone_test.go
+++ b/internal/gitwatch/watcher_clone_test.go
@@ -1,0 +1,392 @@
+package gitwatch
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	xssh "golang.org/x/crypto/ssh"
+
+	"github.com/gerrowadat/nomad-botherer/internal/config"
+)
+
+// makeDiskRepo creates a real git repository on disk with the given files
+// committed on branch "main". The watcher can clone it via the local path,
+// exercising the same Clone/Pull code paths as a remote URL.
+func makeDiskRepo(t *testing.T, files map[string]string) (dir string, repo *git.Repository) {
+	t.Helper()
+	dir = t.TempDir()
+	repo, err := git.PlainInitWithOptions(dir, &git.PlainInitOptions{
+		InitOptions: git.InitOptions{DefaultBranch: plumbing.NewBranchReferenceName("main")},
+	})
+	if err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+	commitFiles(t, dir, repo, files, "initial commit")
+	return dir, repo
+}
+
+// commitFiles writes files into the repo worktree and commits them.
+func commitFiles(t *testing.T, dir string, repo *git.Repository, files map[string]string, msg string) {
+	t.Helper()
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		if _, err := wt.Add(name); err != nil {
+			t.Fatalf("git add %s: %v", name, err)
+		}
+	}
+	_, err = wt.Commit(msg, &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.invalid", When: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}
+
+func TestClone_LocalRepo(t *testing.T) {
+	dir, _ := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, nil)
+
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	if !w.Ready() {
+		t.Error("Ready should be true after Clone")
+	}
+	commit, updated := w.Status()
+	if commit == "" {
+		t.Error("Status should report a commit after Clone")
+	}
+	if updated.IsZero() {
+		t.Error("Status should report an update time after Clone")
+	}
+
+	files, err := w.ReadHCLFiles()
+	if err != nil {
+		t.Fatalf("ReadHCLFiles: %v", err)
+	}
+	if files["app.hcl"] != `job "app" {}` {
+		t.Errorf("unexpected files after clone: %v", files)
+	}
+}
+
+func TestClone_BadURL(t *testing.T) {
+	w := newTestWatcher(&config.Config{RepoURL: filepath.Join(t.TempDir(), "nonexistent"), Branch: "main"}, nil)
+	if err := w.Clone(context.Background()); err == nil {
+		t.Error("Clone of a nonexistent path should fail")
+	}
+	if w.Ready() {
+		t.Error("Ready should be false after failed Clone")
+	}
+}
+
+func TestClone_BadBranch(t *testing.T) {
+	dir, _ := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "no-such-branch"}, nil)
+	if err := w.Clone(context.Background()); err == nil {
+		t.Error("Clone of a nonexistent branch should fail")
+	}
+}
+
+func TestClone_AuthBuildError(t *testing.T) {
+	dir, _ := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+	w := newTestWatcher(&config.Config{
+		RepoURL:       dir,
+		Branch:        "main",
+		GitSSHKeyPath: filepath.Join(t.TempDir(), "no-such-key"),
+	}, nil)
+	if err := w.Clone(context.Background()); err == nil {
+		t.Error("Clone with an unreadable SSH key should fail")
+	}
+}
+
+func TestPull_NewCommitFiresOnChange(t *testing.T) {
+	dir, repo := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+
+	changed := make(chan string, 1)
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, func(commit string) {
+		changed <- commit
+	})
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	first := w.LastCommit()
+
+	commitFiles(t, dir, repo, map[string]string{"app.hcl": `job "app" { type = "service" }`}, "update app")
+
+	w.pull(context.Background())
+
+	select {
+	case commit := <-changed:
+		if commit == first {
+			t.Error("onChange fired with the old commit")
+		}
+		if commit != w.LastCommit() {
+			t.Errorf("onChange commit %q != LastCommit %q", commit, w.LastCommit())
+		}
+	default:
+		t.Fatal("onChange did not fire after pull of a new commit")
+	}
+
+	files, err := w.ReadHCLFiles()
+	if err != nil {
+		t.Fatalf("ReadHCLFiles: %v", err)
+	}
+	if files["app.hcl"] != `job "app" { type = "service" }` {
+		t.Errorf("pull did not update file contents: %q", files["app.hcl"])
+	}
+}
+
+func TestPull_NoChange_NoCallback(t *testing.T) {
+	dir, _ := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+
+	changed := make(chan string, 1)
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, func(commit string) {
+		changed <- commit
+	})
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+
+	w.pull(context.Background())
+
+	select {
+	case c := <-changed:
+		t.Errorf("onChange fired with %q despite no new commit", c)
+	default:
+	}
+	if _, updated := w.Status(); updated.IsZero() {
+		t.Error("lastUpdate should still be set after a no-op pull")
+	}
+}
+
+func TestPull_AuthBuildError_ReturnsEarly(t *testing.T) {
+	dir, repo := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, nil)
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	first := w.LastCommit()
+
+	commitFiles(t, dir, repo, map[string]string{"new.hcl": `job "new" {}`}, "another commit")
+
+	// Break auth config after the clone; pull must bail out before fetching.
+	w.cfg.GitSSHKeyPath = filepath.Join(t.TempDir(), "no-such-key")
+	w.pull(context.Background())
+
+	if w.LastCommit() != first {
+		t.Error("pull should not have advanced the commit when auth building fails")
+	}
+}
+
+func TestPull_RemoteGone_RecloneFails(t *testing.T) {
+	dir, _ := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, nil)
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	first := w.LastCommit()
+
+	// Delete the source repo: pull fails, and the fallback re-clone fails too.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("removing source repo: %v", err)
+	}
+	w.pull(context.Background())
+
+	if w.LastCommit() != first {
+		t.Error("commit should be unchanged after failed pull and re-clone")
+	}
+	if !w.Ready() {
+		t.Error("watcher should keep serving the last good clone")
+	}
+}
+
+func TestRun_TriggerCausesPull(t *testing.T) {
+	dir, repo := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+
+	changed := make(chan string, 1)
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main", PollInterval: time.Hour}, func(commit string) {
+		changed <- commit
+	})
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+
+	commitFiles(t, dir, repo, map[string]string{"app.hcl": `job "app" { type = "batch" }`}, "update")
+	w.Trigger()
+
+	select {
+	case <-changed:
+	case <-time.After(10 * time.Second):
+		t.Fatal("onChange did not fire after Trigger")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}
+
+func TestRun_PollIntervalCausesPull(t *testing.T) {
+	dir, repo := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+
+	changed := make(chan string, 1)
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main", PollInterval: 20 * time.Millisecond}, func(commit string) {
+		changed <- commit
+	})
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+
+	commitFiles(t, dir, repo, map[string]string{"app.hcl": `job "app" { type = "batch" }`}, "update")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.Run(ctx)
+
+	select {
+	case <-changed:
+	case <-time.After(10 * time.Second):
+		t.Fatal("onChange did not fire from the poll ticker")
+	}
+}
+
+func TestBuildAuth_SSHKey_Valid(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	block, err := xssh.MarshalPrivateKey(priv, "test key")
+	if err != nil {
+		t.Fatalf("marshalling key: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("writing key: %v", err)
+	}
+
+	w := newTestWatcher(&config.Config{RepoURL: "git@example.com:x/y.git", Branch: "main", GitSSHKeyPath: keyPath}, nil)
+	auth, err := w.buildAuth()
+	if err != nil {
+		t.Fatalf("buildAuth with valid SSH key: %v", err)
+	}
+	if auth == nil {
+		t.Fatal("expected non-nil auth for SSH key config")
+	}
+	if _, ok := auth.(*githttp.BasicAuth); ok {
+		t.Error("SSH key config should not produce HTTP basic auth")
+	}
+}
+
+// TestNew_DefaultRegistry exercises the production constructor, which
+// registers metrics into the default Prometheus registry. Called once per
+// test binary to avoid duplicate-registration panics.
+func TestNew_DefaultRegistry(t *testing.T) {
+	w := New(&config.Config{PollInterval: time.Minute}, nil)
+	if w == nil {
+		t.Fatal("New returned nil")
+	}
+	if w.Ready() {
+		t.Error("a fresh watcher should not be Ready")
+	}
+}
+
+func TestReadHCLFiles_EmptyRepo_HeadError(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	w := newTestWatcher(&config.Config{}, nil)
+	w.repo = repo // no commits: repo.Head() fails
+
+	if _, err := w.ReadHCLFiles(); err == nil {
+		t.Error("ReadHCLFiles on a repo with no commits should fail")
+	}
+}
+
+func TestPull_BareRepo_WorktreeError(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, true) // bare: no worktree
+	if err != nil {
+		t.Fatalf("init bare: %v", err)
+	}
+
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, nil)
+	w.repo = repo
+	w.lastCommit = "before"
+
+	w.pull(context.Background())
+
+	if w.lastCommit != "before" {
+		t.Error("pull on a bare repo should leave state unchanged")
+	}
+}
+
+func TestHeadCommit_EmptyRepo(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := headCommit(repo); err == nil {
+		t.Error("headCommit on a repo with no commits should fail")
+	}
+}
+
+func TestBuildAuth_SSHKey_BadKnownHosts(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	block, err := xssh.MarshalPrivateKey(priv, "test key")
+	if err != nil {
+		t.Fatalf("marshalling key: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("writing key: %v", err)
+	}
+
+	w := newTestWatcher(&config.Config{
+		RepoURL:              "git@example.com:x/y.git",
+		Branch:               "main",
+		GitSSHKeyPath:        keyPath,
+		GitSSHKnownHostsFile: filepath.Join(t.TempDir(), "no-such-known-hosts"),
+	}, nil)
+	if _, err := w.buildAuth(); err == nil {
+		t.Error("valid key with an unreadable known_hosts file should fail")
+	}
+}

--- a/internal/nomad/differ_paths_test.go
+++ b/internal/nomad/differ_paths_test.go
@@ -1,0 +1,89 @@
+package nomad_test
+
+import (
+	"testing"
+
+	nomadapi "github.com/hashicorp/nomad/api"
+
+	"github.com/gerrowadat/nomad-botherer/internal/config"
+	"github.com/gerrowadat/nomad-botherer/internal/nomad"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestNewDiffer_RealClient verifies the production constructor builds a Differ
+// from config without contacting the cluster. Called once per test binary:
+// it registers metrics into the default Prometheus registry.
+func TestNewDiffer_RealClient(t *testing.T) {
+	d, err := nomad.NewDiffer(&config.Config{
+		NomadAddr:      "http://127.0.0.1:4646",
+		NomadToken:     "test-token",
+		NomadNamespace: "default",
+	})
+	if err != nil {
+		t.Fatalf("NewDiffer: %v", err)
+	}
+	if d == nil {
+		t.Fatal("NewDiffer returned nil Differ")
+	}
+	if d.Ready() {
+		t.Error("a fresh Differ should not be Ready before any check")
+	}
+}
+
+func TestNewDiffer_BadAddress(t *testing.T) {
+	_, err := nomad.NewDiffer(&config.Config{NomadAddr: "://not-a-url"})
+	if err == nil {
+		t.Error("NewDiffer with an unparseable address should fail")
+	}
+}
+
+// TestDiffer_StoppedJob_StopCopiedToPlan verifies that when the live job has
+// Stop=true (deregistered), the flag is copied onto the HCL job before
+// planning so the plan does not report a spurious Stop field diff.
+func TestDiffer_StoppedJob_StopCopiedToPlan(t *testing.T) {
+	var plannedStop *bool
+	mock := defaultMock()
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return &nomadapi.Job{ID: strPtr(jobID), Stop: boolPtr(true), Status: strPtr("running")}, nil, nil
+	}
+	mock.planFn = func(job *nomadapi.Job, diff bool, q *nomadapi.WriteOptions) (*nomadapi.JobPlanResponse, *nomadapi.WriteMeta, error) {
+		plannedStop = job.Stop
+		return &nomadapi.JobPlanResponse{Diff: &nomadapi.JobDiff{Type: "None"}}, nil, nil
+	}
+	d := newTestDiffer(mock)
+
+	if err := d.Check(map[string]string{"jobs/test-job.hcl": `job "test-job" {}`}, "abc123"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plannedStop == nil || !*plannedStop {
+		t.Error("Stop=true on the live job should be copied onto the planned job")
+	}
+}
+
+// TestDiffer_DeadJob_BookkeepingOnlyDiff_Suppressed verifies that with
+// --include-dead-jobs, a plan against a dead job whose diff contains only
+// allocation bookkeeping (Type="None" task groups) is not reported as drift.
+func TestDiffer_DeadJob_BookkeepingOnlyDiff_Suppressed(t *testing.T) {
+	mock := defaultMock()
+	mock.infoFn = func(jobID string, q *nomadapi.QueryOptions) (*nomadapi.Job, *nomadapi.QueryMeta, error) {
+		return &nomadapi.Job{ID: strPtr(jobID), Status: strPtr("dead")}, nil, nil
+	}
+	mock.planFn = func(job *nomadapi.Job, diff bool, q *nomadapi.WriteOptions) (*nomadapi.JobPlanResponse, *nomadapi.WriteMeta, error) {
+		return &nomadapi.JobPlanResponse{Diff: &nomadapi.JobDiff{
+			Type: "Edited",
+			TaskGroups: []*nomadapi.TaskGroupDiff{
+				{Type: "None", Name: "web"},
+			},
+		}}, nil, nil
+	}
+	d := newTestDifferWithDeadJobs(mock)
+
+	if err := d.Check(map[string]string{"jobs/test-job.hcl": `job "test-job" {}`}, "abc123"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 0 {
+		t.Errorf("bookkeeping-only diff on a dead job should be suppressed, got %+v", diffs)
+	}
+}

--- a/internal/nomad/redact_test.go
+++ b/internal/nomad/redact_test.go
@@ -152,3 +152,24 @@ func TestRedactJobDiff_NilAndEmpty(t *testing.T) {
 		t.Errorf("empty-valued env field should not be annotated: %v", d.Fields[0].Annotations)
 	}
 }
+
+func TestRedactJobDiff_NilEntriesSkipped(t *testing.T) {
+	d := &nomadapi.JobDiff{
+		Type:   "Edited",
+		Fields: []*nomadapi.FieldDiff{nil, {Type: "Edited", Name: "Env[X]", Old: "a", New: "b"}},
+		Objects: []*nomadapi.ObjectDiff{
+			nil,
+			{Type: "Edited", Name: "Meta", Fields: []*nomadapi.FieldDiff{nil}},
+		},
+		TaskGroups: []*nomadapi.TaskGroupDiff{
+			nil,
+			{Type: "Edited", Name: "web", Tasks: []*nomadapi.TaskDiff{nil}},
+		},
+	}
+	if n := nomad.RedactJobDiff(d); n != 1 {
+		t.Errorf("nil entries should be skipped without panic; want 1 redaction, got %d", n)
+	}
+	if d.Fields[1].New != nomad.RedactedValue {
+		t.Errorf("non-nil env field should still be redacted: %q", d.Fields[1].New)
+	}
+}

--- a/internal/server/server_run_test.go
+++ b/internal/server/server_run_test.go
@@ -1,0 +1,125 @@
+package server_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gerrowadat/nomad-botherer/internal/config"
+	"github.com/gerrowadat/nomad-botherer/internal/server"
+)
+
+// TestServer_Run_ShutsDownOnContextCancel starts the real HTTP server on an
+// ephemeral port and verifies that cancelling the context shuts it down
+// cleanly (nil error).
+func TestServer_Run_ShutsDownOnContextCancel(t *testing.T) {
+	cfg := &config.Config{ListenAddr: "127.0.0.1:0", WebhookPath: "/webhook", Branch: "main"}
+	diffSrc := &mockDiffSource{lastCheck: time.Now()}
+	gitSrc := &mockGitSource{lastUpdate: time.Now()}
+	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Run(ctx) }()
+
+	// Give ListenAndServe a moment to bind before cancelling.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("Run should return nil on graceful shutdown, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}
+
+// TestServer_Run_BadListenAddr verifies that an unbindable address surfaces
+// as an error from Run.
+func TestServer_Run_BadListenAddr(t *testing.T) {
+	cfg := &config.Config{ListenAddr: "256.256.256.256:0", WebhookPath: "/webhook", Branch: "main"}
+	diffSrc := &mockDiffSource{lastCheck: time.Now()}
+	gitSrc := &mockGitSource{lastUpdate: time.Now()}
+	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := srv.Run(ctx); err == nil {
+		t.Error("Run with an unbindable address should return an error")
+	}
+}
+
+// TestNew_DefaultRegistry exercises the production constructor, which
+// registers into the default Prometheus registry. Called once per test
+// binary to avoid duplicate-registration panics.
+func TestNew_DefaultRegistry(t *testing.T) {
+	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main"}
+	diffSrc := &mockDiffSource{lastCheck: time.Now()}
+	gitSrc := &mockGitSource{lastUpdate: time.Now()}
+	srv := server.New(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"})
+	if srv == nil {
+		t.Fatal("New returned nil")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("healthz on default-registry server: want 200, got %d", rec.Code)
+	}
+}
+
+// nonGathererRegisterer wraps a Registry so it satisfies only
+// prometheus.Registerer, forcing NewWithRegistry's fallback to the global
+// /metrics handler.
+type nonGathererRegisterer struct{ inner prometheus.Registerer }
+
+func (r nonGathererRegisterer) Register(c prometheus.Collector) error  { return r.inner.Register(c) }
+func (r nonGathererRegisterer) MustRegister(c ...prometheus.Collector) { r.inner.MustRegister(c...) }
+func (r nonGathererRegisterer) Unregister(c prometheus.Collector) bool { return r.inner.Unregister(c) }
+
+func TestNewWithRegistry_NonGathererFallback(t *testing.T) {
+	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main"}
+	diffSrc := &mockDiffSource{lastCheck: time.Now()}
+	gitSrc := &mockGitSource{lastUpdate: time.Now()}
+	reg := nonGathererRegisterer{inner: prometheus.NewRegistry()}
+	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"}, reg)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("/metrics with non-Gatherer registerer: want 200, got %d", rec.Code)
+	}
+}
+
+// TestIndex_ManagedMetaKeyShown verifies the index page renders the opt-in
+// meta key hint when a managed-meta prefix is configured.
+func TestIndex_ManagedMetaKeyShown(t *testing.T) {
+	cfg := &config.Config{
+		ListenAddr:        ":0",
+		WebhookPath:       "/webhook",
+		Branch:            "main",
+		ManagedMetaPrefix: "gitops",
+	}
+	diffSrc := &mockDiffSource{lastCheck: time.Now()}
+	gitSrc := &mockGitSource{lastUpdate: time.Now()}
+	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("index: want 200, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "gitops_managed") {
+		t.Error("index page should mention the gitops_managed opt-in key")
+	}
+}


### PR DESCRIPTION
Tests only; no production code changed.

| Package | Before | After |
|---|---|---|
| internal/config | 95.7% | 100% |
| internal/nomad | 94.5% | 100% |
| internal/server | 93.3% | 98.8% |
| internal/gitwatch | 65.5% | 92.3% |
| cmd/nomad-botherer | 0% | 8.1% (setupLogging) |
| **total** | **78.3%** | **87.9%** |

## What changed

**gitwatch (the big one).** The existing tests built in-memory repos by hand and could not reach Clone, pull, or Run. A new helper builds real git repositories on disk (go-git `PlainInit` + commits) and points the watcher at them via the local-path transport, so the actual clone/fetch machinery runs. Now covered: Clone success/bad-URL/bad-branch/auth-build-failure; pull where a new commit fires onChange, a no-op pull doesn't, an auth failure bails early, and a deleted remote falls through to a failed re-clone without losing the last good state; Run reacting to both the webhook trigger and the poll ticker; and SSH auth with a generated ed25519 key (valid key, and valid key with an unreadable known_hosts file).

**nomad.** NewDiffer constructor (success and unparseable address), the Stop=true copy onto planned jobs for deregistered live jobs, suppression of bookkeeping-only diffs on dead jobs, and nil entries in the redaction walk.

**server.** Run (graceful shutdown on context cancel; unbindable address returns an error), the New default-registry constructor, the fallback /metrics handler when the Registerer is not a Gatherer, and the managed-meta-key hint on the index page.

**config / cmd.** Load() via a swapped flag.CommandLine, unknown-flag parse errors, and setupLogging level mapping including the unknown-level fallback.

## What's deliberately not covered

main() (exercised end-to-end by the regression suite) and error branches that need a corrupt git object store or a webhook-library failure mode that cannot occur with our configuration.

## What to test

`go test ./... -count=1 -race` — passes. `go test ./... -coverprofile=...` to reproduce the numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)