### PR TITLE
Gate applying drift that pre-existed a job's entry into scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,15 +69,23 @@
     update's fields, which the applier reads without the queue lock.
     In-progress updates are now left strictly untouched.
   - **Drift that pre-existed a job entering scope is not applied by
-    default.** When a job gains the managed meta tag while nomad-botherer is
-    running, any drift already present at that moment (e.g. an image bumped
-    in Git before the tag was added) is not retroactively applied — only
-    changes committed after opt-in are. `--apply-existing-drift` /
-    `APPLY_EXISTING_DRIFT` (default off) applies it instead. The gate is tied
-    to the witnessed opt-in transition, so jobs already managed at startup
-    reconcile normally (a restart does not freeze the cluster) and
-    glob-selected jobs are unaffected. Counted in
+    default.** When the managed tag is added to a job that already differs
+    from its HCL (e.g. an image bumped in Git before the tag), that drift is
+    not retroactively applied — only changes committed after opt-in are.
+    `--apply-existing-drift` / `APPLY_EXISTING_DRIFT` (default off) applies it
+    instead. The decision is derived from git history (was the tag present in
+    the commit before HEAD for the job's file?), so it holds identically
+    whether the tag was added while running or before startup — a restart
+    never freezes an already-managed cluster. A file created with the tag in
+    one commit is not a retroactive opt-in and applies. Glob-selected jobs
+    have no opt-in moment and are unaffected. Counted in
     `nomad_botherer_updates_blocked_preexisting_total{job}`.
+  - **Every diff carries an `apply_action` explaining whether and why it
+    will (not) be applied** — `queued`, `blocked_by_policy`,
+    `blocked_preexisting_drift`, `blocked_creation_disabled`,
+    `skipped_meta_only`, `observation_only`, or `no_actionable_change`.
+    Shown on `/diffs`, in the `/api/v1/diffs` and `/healthz` JSON, and in the
+    OpenAPI spec.
   - The web console index shows the apply mode (default policy, job
     creation flag, pending update count), and the regression suite gains
     end-to-end apply scenarios against a real cluster, including the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,16 @@
     update with the same ID while it was IN_PROGRESS mutated the in-flight
     update's fields, which the applier reads without the queue lock.
     In-progress updates are now left strictly untouched.
+  - **Drift that pre-existed a job entering scope is not applied by
+    default.** When a job gains the managed meta tag while nomad-botherer is
+    running, any drift already present at that moment (e.g. an image bumped
+    in Git before the tag was added) is not retroactively applied — only
+    changes committed after opt-in are. `--apply-existing-drift` /
+    `APPLY_EXISTING_DRIFT` (default off) applies it instead. The gate is tied
+    to the witnessed opt-in transition, so jobs already managed at startup
+    reconcile normally (a restart does not freeze the cluster) and
+    glob-selected jobs are unaffected. Counted in
+    `nomad_botherer_updates_blocked_preexisting_total{job}`.
   - The web console index shows the apply mode (default policy, job
     creation flag, pending update count), and the regression suite gains
     end-to-end apply scenarios against a real cluster, including the

--- a/README.md
+++ b/README.md
@@ -450,15 +450,20 @@ reviewed; only changes committed *after* the tag is added are applied.
 Set `--apply-existing-drift` to apply pre-existing drift at opt-in instead —
 then the job converges to its HCL as soon as the tag lands.
 
-This is scoped precisely to the opt-in moment, which nomad-botherer must
-*witness*: a job that gains the tag while the process is running is frozen at
-that commit until a later commit arrives (or the flag is set). A job that
-already carries the tag when the process starts is **established**, not
-freshly opted in, so its drift reconciles normally — a restart does not
-freeze your whole cluster. The freeze is counted in
-`nomad_botherer_updates_blocked_preexisting_total{job}`. Jobs selected by
-`--job-selector-glob` are always in scope and have no opt-in moment, so this
-gate never applies to them.
+The decision is made from **git history**, so it holds the same whether the
+tag is added while nomad-botherer is running or before it starts (a fresh
+start or a restart). For a job's HCL file, the rule is: if the managed tag
+was present in the commit *before* HEAD, the job was already managed and its
+drift reconciles normally; if the tag was *added* in the HEAD commit (the
+file existed before without it), the drift pre-dates opt-in and is held. A
+file created with the tag in a single commit is not a retroactive opt-in —
+the tag and the spec arrived together — so it applies. Because the signal is
+git-derived rather than remembered, a restart never freezes an
+already-managed cluster. Jobs selected by `--job-selector-glob` are always in
+scope and have no opt-in moment, so this gate never applies to them. The
+freeze is counted in `nomad_botherer_updates_blocked_preexisting_total{job}`,
+and each held diff is shown on `/diffs` and the API with its reason (see
+[Why a diff is or is not applied](#why-a-diff-is-or-is-not-applied)).
 
 ### What gets applied, and how
 
@@ -495,6 +500,24 @@ policy that allowed it, and the CAS token used.
 
 The design background is in `docs/proposals/gitops-job-updates.md` and
 `docs/proposals/update-policies.md`.
+
+### Why a diff is or is not applied
+
+Every diff carries an `apply_action` describing what nomad-botherer will do
+about it, so you never have to scrape logs to find out why a drift is sitting
+unapplied. It appears on `/diffs` (as a `→ …` line under each job), in the
+`/api/v1/diffs` and `/healthz` JSON (the `apply_action` field), and is
+documented in the OpenAPI spec. Values:
+
+| `apply_action` | Meaning |
+|---|---|
+| `queued` | An update was enqueued and will be applied. |
+| `blocked_by_policy` | The effective update policy disallows it (e.g. `none`, or `image-only` for a non-image change). |
+| `blocked_preexisting_drift` | The drift pre-dates the job's opt-in; set `--apply-existing-drift` to apply. |
+| `blocked_creation_disabled` | First-time registration needs `--enable-job-creation`. |
+| `skipped_meta_only` | The change is confined to `gitops_*` meta keys (only shown when `--count-meta-only-changes` is on). |
+| `observation_only` | `missing_from_hcl`; deregistration is not implemented. |
+| `no_actionable_change` | The only diff is autoscaler-owned Count/Scaling churn. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Every flag has a corresponding environment variable. Environment variables are r
 | `--apply-interval` | `APPLY_INTERVAL` | `10s` | Fallback cadence of the apply loop; enqueued updates are also applied immediately. |
 | `--apply-meta-only-changes` | `APPLY_META_ONLY_CHANGES` | `false` | Apply a diff whose only change is to nomad-botherer's own meta keys (e.g. `gitops_managed`). Off by default — re-registering a running job just to push these keys is disruptive and unnecessary; they ride along the next real update. |
 | `--count-meta-only-changes` | `COUNT_META_ONLY_CHANGES` | `false` | Count a managed-meta-only diff as drift (surface it on `/diffs`, `/healthz`, and the drift metrics). Off by default so these expected differences do not trigger alerts. |
+| `--apply-existing-drift` | `APPLY_EXISTING_DRIFT` | `false` | When a job gains the managed meta tag while nomad-botherer is running, apply drift that already existed at that moment. Off by default — opting a job in does not retroactively mutate it; only changes committed after opt-in apply. Jobs already managed at startup reconcile normally. |
 | `--job-selector-glob` | `JOB_SELECTOR_GLOB` | *(empty — no glob)* | Glob pattern selecting jobs to watch by name (e.g. `myprefix-*`, `*` for all). Combined with `--managed-meta-prefix` as a union. |
 | `--managed-meta-prefix` | `MANAGED_META_PREFIX` | `gitops` | Prefix for job meta keys used by nomad-botherer. With prefix `gitops`, the key `gitops_managed = "true"` opts a job in. Empty disables meta-based selection. |
 | `--max-git-staleness` | `MAX_GIT_STALENESS` | `0` (disabled) | If the git repo has not been successfully fetched within this window, force an immediate fetch. Set to `0` to disable. E.g. `--max-git-staleness=30m` |
@@ -436,6 +437,28 @@ meta change is still not an image change, so `image-only` keeps blocking it),
 and `--count-meta-only-changes` makes it count as drift. A diff that mixes a
 meta-key change with any *other* change is a normal diff and is unaffected by
 these flags.
+
+### Opting in a job that already drifted
+
+When you add the meta tag to a job that *already* differs from its HCL — say
+you bumped its image in Git a while ago, and only now add `gitops_managed` —
+that drift is **pre-existing**: it was there before the job entered scope.
+By default nomad-botherer does **not** apply it. Opting a job into management
+should not, on its own, trigger a mutation based on drift you may not have
+reviewed; only changes committed *after* the tag is added are applied.
+
+Set `--apply-existing-drift` to apply pre-existing drift at opt-in instead —
+then the job converges to its HCL as soon as the tag lands.
+
+This is scoped precisely to the opt-in moment, which nomad-botherer must
+*witness*: a job that gains the tag while the process is running is frozen at
+that commit until a later commit arrives (or the flag is set). A job that
+already carries the tag when the process starts is **established**, not
+freshly opted in, so its drift reconciles normally — a restart does not
+freeze your whole cluster. The freeze is counted in
+`nomad_botherer_updates_blocked_preexisting_total{job}`. Jobs selected by
+`--job-selector-glob` are always in scope and have no opt-in moment, so this
+gate never applies to them.
 
 ### What gets applied, and how
 
@@ -618,6 +641,7 @@ These counters and timestamps describe the diff check loop itself — how often 
 | `nomad_botherer_meta_key_issues_total` | Counter | `job`, `issue` | Job meta keys under the managed prefix that nomad-botherer cannot act on: `unknown_key` (e.g. a typo like `gitops_managd` or `gitops.managed`) or `invalid_value` (a recognised key with an unusable value, e.g. `gitops_managed = "True"`). Counted every cycle the issue persists; logged once per unique issue (WARN for unknown keys, ERROR for bad values). |
 | `nomad_botherer_meta_key_changes_total` | Counter | `job`, `source` | Managed-prefix meta keys added, removed, or changed between check cycles, on the HCL side (a commit changed them) or the live side (someone re-registered the job manually). Each transition is also logged at INFO with the behavioural consequence. |
 | `nomad_botherer_meta_only_diffs_total` | Counter | `job` | Diffs confined to nomad-botherer's own meta keys, detected per check cycle. By default these are neither counted as drift nor applied (`--count-meta-only-changes`, `--apply-meta-only-changes`); they converge on the next real update. A non-zero rate is normal after opting a running job in via a commit. |
+| `nomad_botherer_updates_blocked_preexisting_total` | Counter | `job` | Updates not enqueued because the drift pre-existed the job entering scope (opt-in via meta tag while running). Enable applying it with `--apply-existing-drift`. |
 
 #### Git tracking
 

--- a/cmd/nomad-botherer/main.go
+++ b/cmd/nomad-botherer/main.go
@@ -62,6 +62,9 @@ func main() {
 	}
 
 	watcher = gitwatch.New(cfg, onChange)
+	// The differ reads prior git state (via the watcher) to tell whether drift
+	// pre-dates a job's opt-in.
+	differ.SetHistorySource(watcher)
 
 	if err := watcher.Clone(ctx); err != nil {
 		slog.Error("Cloning repository", "err", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,12 @@ type Config struct {
 	ApplyMetaOnlyChanges bool
 	CountMetaOnlyChanges bool
 
+	// ApplyExistingDrift controls whether drift that already existed when a
+	// job entered management scope (gained the meta tag while the process was
+	// running) is applied. Off by default: opting a job in does not retroactively
+	// mutate it; only changes committed after opt-in apply.
+	ApplyExistingDrift bool
+
 	// Job selection. Git is always the source of truth for nomad-botherer's
 	// own meta keys: when a job has an HCL file in the repo, that file alone
 	// decides selection and policy. There is deliberately no flag to invert
@@ -98,6 +104,7 @@ func LoadFromArgs(fs *flag.FlagSet, args []string) (*Config, error) {
 	fs.DurationVar(&c.ApplyInterval, "apply-interval", envDurationOrDefault("APPLY_INTERVAL", 10*time.Second), "Fallback cadence of the apply loop; enqueued updates are also applied immediately")
 	fs.BoolVar(&c.ApplyMetaOnlyChanges, "apply-meta-only-changes", envBoolOrDefault("APPLY_META_ONLY_CHANGES", false), "Apply a diff whose only change is to nomad-botherer's own meta keys (e.g. gitops_managed). Off by default: re-registering a running job just to push these keys is disruptive and unnecessary (the HCL is already authoritative), so they ride along the next real update instead.")
 	fs.BoolVar(&c.CountMetaOnlyChanges, "count-meta-only-changes", envBoolOrDefault("COUNT_META_ONLY_CHANGES", false), "Count a managed-meta-only diff as drift (surface it on /diffs, /healthz, and the drift metrics). Off by default so these expected differences do not trigger drift alerts.")
+	fs.BoolVar(&c.ApplyExistingDrift, "apply-existing-drift", envBoolOrDefault("APPLY_EXISTING_DRIFT", false), "When a job enters management scope (gains the managed meta tag while nomad-botherer is running), apply drift that already existed at that moment. Off by default (conservative): opting a job in does not retroactively mutate it; only changes committed after opt-in apply. Jobs already managed when the process starts are unaffected — their drift reconciles normally.")
 	fs.StringVar(&c.JobSelectorGlob, "job-selector-glob", envOrDefault("JOB_SELECTOR_GLOB", ""), "Glob pattern selecting jobs by name (e.g. 'myprefix-*', '*' for all). Jobs matching either this or --managed-meta-prefix are watched. Empty means no glob selection.")
 	fs.StringVar(&c.ManagedMetaPrefix, "managed-meta-prefix", envOrDefault("MANAGED_META_PREFIX", "gitops"), "Prefix for job meta keys used by nomad-botherer (e.g. 'gitops' means 'gitops_managed = true' in a job's HCL opts it in). Git is always the source of truth for these keys: when a job has an HCL file, the live job's keys are ignored for selection. Empty disables meta-based selection.")
 	fs.DurationVar(&c.MaxGitStaleness, "max-git-staleness", envDurationOrDefault("MAX_GIT_STALENESS", 0), "Maximum time since last successful git fetch before forcing a refresh (0 disables)")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -690,3 +690,37 @@ func TestLoadFromArgs_MetaOnlyFlagsEnv(t *testing.T) {
 		t.Errorf("env vars not honoured: %+v", cfg)
 	}
 }
+
+func TestLoadFromArgs_ApplyExistingDriftDefault(t *testing.T) {
+	os.Unsetenv("APPLY_EXISTING_DRIFT")
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ApplyExistingDrift {
+		t.Error("ApplyExistingDrift should default to false")
+	}
+}
+
+func TestLoadFromArgs_ApplyExistingDriftSet(t *testing.T) {
+	os.Unsetenv("APPLY_EXISTING_DRIFT")
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git", "--apply-existing-drift"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.ApplyExistingDrift {
+		t.Error("ApplyExistingDrift: want true after flag")
+	}
+}
+
+func TestLoadFromArgs_ApplyExistingDriftEnv(t *testing.T) {
+	os.Setenv("APPLY_EXISTING_DRIFT", "true")
+	t.Cleanup(func() { os.Unsetenv("APPLY_EXISTING_DRIFT") })
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.ApplyExistingDrift {
+		t.Error("ApplyExistingDrift: want true from env")
+	}
+}

--- a/internal/gitwatch/watcher.go
+++ b/internal/gitwatch/watcher.go
@@ -228,28 +228,27 @@ func (w *Watcher) ReadHCLFiles() (map[string]string, error) {
 	return result, nil
 }
 
-// FileAtParent returns the content of path as it was at the first parent of
-// the current HEAD commit. ok is false when the repo is not cloned, HEAD has
-// no parent (the root commit), or the file did not exist at the parent. It is
-// used to decide whether a change at HEAD (such as adding the managed meta
-// tag) is new relative to the previous commit.
-func (w *Watcher) FileAtParent(path string) (content string, ok bool) {
+// FileAtParentOf returns the content of path as it was at the first parent of
+// the named commit. ok is false when the repo is not cloned, the commit is
+// unknown or has no parent (the root commit), or the file did not exist at the
+// parent. Keying off an explicit commit — rather than the repo's current HEAD —
+// keeps the answer consistent with the HCL snapshot being evaluated even if a
+// concurrent pull has advanced HEAD. It is used to decide whether a change at
+// that commit (such as adding the managed meta tag) is new relative to the
+// previous commit.
+func (w *Watcher) FileAtParentOf(commit, path string) (content string, ok bool) {
 	w.mu.RLock()
 	repo := w.repo
 	w.mu.RUnlock()
-	if repo == nil {
+	if repo == nil || commit == "" {
 		return "", false
 	}
 
-	ref, err := repo.Head()
-	if err != nil {
+	c, err := repo.CommitObject(plumbing.NewHash(commit))
+	if err != nil || c.NumParents() == 0 {
 		return "", false
 	}
-	head, err := repo.CommitObject(ref.Hash())
-	if err != nil || head.NumParents() == 0 {
-		return "", false
-	}
-	parent, err := head.Parent(0)
+	parent, err := c.Parent(0)
 	if err != nil {
 		return "", false
 	}
@@ -258,11 +257,11 @@ func (w *Watcher) FileAtParent(path string) (content string, ok bool) {
 		// Includes object.ErrFileNotFound: the file did not exist at the parent.
 		return "", false
 	}
-	c, err := f.Contents()
+	content, err = f.Contents()
 	if err != nil {
 		return "", false
 	}
-	return c, true
+	return content, true
 }
 
 // pull fetches the latest changes and calls onChange if the HEAD moved.

--- a/internal/gitwatch/watcher.go
+++ b/internal/gitwatch/watcher.go
@@ -228,6 +228,43 @@ func (w *Watcher) ReadHCLFiles() (map[string]string, error) {
 	return result, nil
 }
 
+// FileAtParent returns the content of path as it was at the first parent of
+// the current HEAD commit. ok is false when the repo is not cloned, HEAD has
+// no parent (the root commit), or the file did not exist at the parent. It is
+// used to decide whether a change at HEAD (such as adding the managed meta
+// tag) is new relative to the previous commit.
+func (w *Watcher) FileAtParent(path string) (content string, ok bool) {
+	w.mu.RLock()
+	repo := w.repo
+	w.mu.RUnlock()
+	if repo == nil {
+		return "", false
+	}
+
+	ref, err := repo.Head()
+	if err != nil {
+		return "", false
+	}
+	head, err := repo.CommitObject(ref.Hash())
+	if err != nil || head.NumParents() == 0 {
+		return "", false
+	}
+	parent, err := head.Parent(0)
+	if err != nil {
+		return "", false
+	}
+	f, err := parent.File(path)
+	if err != nil {
+		// Includes object.ErrFileNotFound: the file did not exist at the parent.
+		return "", false
+	}
+	c, err := f.Contents()
+	if err != nil {
+		return "", false
+	}
+	return c, true
+}
+
 // pull fetches the latest changes and calls onChange if the HEAD moved.
 func (w *Watcher) pull(ctx context.Context) {
 	auth, err := w.buildAuth()

--- a/internal/gitwatch/watcher_clone_test.go
+++ b/internal/gitwatch/watcher_clone_test.go
@@ -390,3 +390,51 @@ func TestBuildAuth_SSHKey_BadKnownHosts(t *testing.T) {
 		t.Error("valid key with an unreadable known_hosts file should fail")
 	}
 }
+
+func TestFileAtParent(t *testing.T) {
+	dir, repo := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" { v = 1 }`})
+	commitFiles(t, dir, repo, map[string]string{"app.hcl": `job "app" { v = 2 }`}, "bump")
+
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, nil)
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+
+	// HEAD has v=2; the parent had v=1.
+	content, ok := w.FileAtParent("app.hcl")
+	if !ok {
+		t.Fatal("FileAtParent should find app.hcl at the parent commit")
+	}
+	if content != `job "app" { v = 1 }` {
+		t.Errorf("unexpected parent content: %q", content)
+	}
+
+	// A file that did not exist at the parent.
+	commitFiles(t, dir, repo, map[string]string{"new.hcl": `job "new" {}`}, "add new")
+	w2 := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, nil)
+	if err := w2.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	if _, ok := w2.FileAtParent("new.hcl"); ok {
+		t.Error("FileAtParent should report ok=false for a file new at HEAD")
+	}
+}
+
+func TestFileAtParent_RootCommit(t *testing.T) {
+	dir, _ := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, nil)
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	// HEAD is the root commit (makeDiskRepo makes a single commit): no parent.
+	if _, ok := w.FileAtParent("app.hcl"); ok {
+		t.Error("FileAtParent should report ok=false at the root commit")
+	}
+}
+
+func TestFileAtParent_NoRepo(t *testing.T) {
+	w := newTestWatcher(&config.Config{}, nil)
+	if _, ok := w.FileAtParent("app.hcl"); ok {
+		t.Error("FileAtParent should report ok=false before clone")
+	}
+}

--- a/internal/gitwatch/watcher_clone_test.go
+++ b/internal/gitwatch/watcher_clone_test.go
@@ -391,7 +391,7 @@ func TestBuildAuth_SSHKey_BadKnownHosts(t *testing.T) {
 	}
 }
 
-func TestFileAtParent(t *testing.T) {
+func TestFileAtParentOf(t *testing.T) {
 	dir, repo := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" { v = 1 }`})
 	commitFiles(t, dir, repo, map[string]string{"app.hcl": `job "app" { v = 2 }`}, "bump")
 
@@ -400,41 +400,63 @@ func TestFileAtParent(t *testing.T) {
 		t.Fatalf("Clone: %v", err)
 	}
 
-	// HEAD has v=2; the parent had v=1.
-	content, ok := w.FileAtParent("app.hcl")
+	// HEAD (v=2) has a parent holding v=1.
+	head := w.LastCommit()
+	content, ok := w.FileAtParentOf(head, "app.hcl")
 	if !ok {
-		t.Fatal("FileAtParent should find app.hcl at the parent commit")
+		t.Fatal("FileAtParentOf should find app.hcl at the parent commit")
 	}
 	if content != `job "app" { v = 1 }` {
 		t.Errorf("unexpected parent content: %q", content)
 	}
 
-	// A file that did not exist at the parent.
-	commitFiles(t, dir, repo, map[string]string{"new.hcl": `job "new" {}`}, "add new")
+	// An advancing HEAD must not change the answer for an earlier commit: the
+	// lookup is keyed off the named commit, not current HEAD.
+	commitFiles(t, dir, repo, map[string]string{"app.hcl": `job "app" { v = 3 }`}, "bump again")
 	w2 := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, nil)
 	if err := w2.Clone(context.Background()); err != nil {
 		t.Fatalf("Clone: %v", err)
 	}
-	if _, ok := w2.FileAtParent("new.hcl"); ok {
-		t.Error("FileAtParent should report ok=false for a file new at HEAD")
+	content, ok = w2.FileAtParentOf(head, "app.hcl") // same earlier commit
+	if !ok || content != `job "app" { v = 1 }` {
+		t.Errorf("parent of an earlier commit should be stable across HEAD advances, got %q ok=%v", content, ok)
+	}
+
+	// Unknown commit hash.
+	if _, ok := w2.FileAtParentOf("0000000000000000000000000000000000000000", "app.hcl"); ok {
+		t.Error("FileAtParentOf should report ok=false for an unknown commit")
 	}
 }
 
-func TestFileAtParent_RootCommit(t *testing.T) {
+func TestFileAtParentOf_FileNew(t *testing.T) {
+	dir, repo := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+	commitFiles(t, dir, repo, map[string]string{"new.hcl": `job "new" {}`}, "add new")
+
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, nil)
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	// new.hcl was created at HEAD; it did not exist at the parent.
+	if _, ok := w.FileAtParentOf(w.LastCommit(), "new.hcl"); ok {
+		t.Error("FileAtParentOf should report ok=false for a file new at the commit")
+	}
+}
+
+func TestFileAtParentOf_RootCommit(t *testing.T) {
 	dir, _ := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
 	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, nil)
 	if err := w.Clone(context.Background()); err != nil {
 		t.Fatalf("Clone: %v", err)
 	}
-	// HEAD is the root commit (makeDiskRepo makes a single commit): no parent.
-	if _, ok := w.FileAtParent("app.hcl"); ok {
-		t.Error("FileAtParent should report ok=false at the root commit")
+	// The single commit is the root: no parent.
+	if _, ok := w.FileAtParentOf(w.LastCommit(), "app.hcl"); ok {
+		t.Error("FileAtParentOf should report ok=false at the root commit")
 	}
 }
 
-func TestFileAtParent_NoRepo(t *testing.T) {
+func TestFileAtParentOf_NoRepo(t *testing.T) {
 	w := newTestWatcher(&config.Config{}, nil)
-	if _, ok := w.FileAtParent("app.hcl"); ok {
-		t.Error("FileAtParent should report ok=false before clone")
+	if _, ok := w.FileAtParentOf("deadbeef", "app.hcl"); ok {
+		t.Error("FileAtParentOf should report ok=false before clone")
 	}
 }

--- a/internal/nomad/apply_test.go
+++ b/internal/nomad/apply_test.go
@@ -561,8 +561,8 @@ func TestApply_AutoscalerOnlyChurn_NotEnqueued(t *testing.T) {
 	}
 }
 
-// metaSelectCfg selects jobs by meta only (no glob), so a job can be out of
-// scope until its HCL gains the managed key.
+// metaSelectCfg selects jobs by meta only (no glob), so the pre-existing-drift
+// gate (which exempts glob-selected jobs) applies.
 func metaSelectCfg(applyExisting bool) *config.Config {
 	return &config.Config{
 		NomadNamespace:      "default",
@@ -572,89 +572,125 @@ func metaSelectCfg(applyExisting bool) *config.Config {
 	}
 }
 
-// optInMock returns a mock whose HCL job gains the gitops keys once *hasKey is
-// set. The live job exists with the given ModifyIndex; the plan reports an
-// image+meta diff (pre-existing drift plus the opt-in).
-func optInMock(hasKey *bool, calls *[]registerCall) *mockJobsClient {
-	mock := applyMock(nil, editedImagePlusMetaDiff(), 42, calls)
-	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
-		if *hasKey {
-			return &nomadapi.Job{ID: strPtr("test-job"), Meta: map[string]string{
-				"gitops_managed": "true", "gitops_update_policy": "full",
-			}}, nil
-		}
-		return &nomadapi.Job{ID: strPtr("test-job")}, nil
-	}
+// fakeHistory implements nomad.HistorySource. A path present in parent returns
+// that content (ok=true); an absent path returns ok=false (file new at HEAD).
+type fakeHistory struct {
+	parent map[string]string
+}
+
+func (f fakeHistory) FileAtParent(path string) (string, bool) {
+	c, ok := f.parent[path]
+	return c, ok
+}
+
+const testJobFile = "jobs/test-job.hcl"
+
+// optInMock returns a mock whose HCL job carries the gitops keys (opted in at
+// HEAD); the live job exists with a real image diff (pre-existing drift).
+func optInMock(calls *[]registerCall) *mockJobsClient {
+	mock := applyMock(map[string]string{
+		"gitops_managed": "true", "gitops_update_policy": "full",
+	}, editedImagePlusMetaDiff(), 42, calls)
 	return mock
 }
 
-func TestApply_ExistingDrift_NotAppliedOnScopeEntry(t *testing.T) {
+func TestApply_ExistingDrift_TagAddedAtHead_NotApplied(t *testing.T) {
 	var calls []registerCall
-	var hasKey bool
-	d := nomad.NewWithClient(metaSelectCfg(false), optInMock(&hasKey, &calls))
+	d := nomad.NewWithClient(metaSelectCfg(false), optInMock(&calls))
+	// The tag was added at HEAD: the parent version of the file lacks it.
+	d.SetHistorySource(fakeHistory{parent: map[string]string{testJobFile: `job "test-job" {}`}})
 
-	// Cycle 1: job not opted in (no key, no glob) — out of scope.
-	runCheck(t, d, "commit0aaaaaa")
-	// Cycle 2: key added while running — scope entry; image drift is pre-existing.
-	hasKey = true
-	runCheck(t, d, "commit1bbbbbb")
+	runCheck(t, d, "aaaa111fffff")
 	nomad.DrainUpdates(d)
 
 	if len(calls) != 0 {
-		t.Errorf("pre-existing drift must not apply on scope entry by default, got %d calls", len(calls))
+		t.Errorf("drift that pre-dates opt-in must not apply by default, got %d calls", len(calls))
 	}
 	if got := testutil.ToFloat64(nomad.UpdatesBlockedExistingDrift(d).WithLabelValues("test-job")); got != 1 {
 		t.Errorf("blocked-preexisting metric: want 1, got %v", got)
 	}
-}
-
-func TestApply_ExistingDrift_AppliedWithFlag(t *testing.T) {
-	var calls []registerCall
-	var hasKey bool
-	d := nomad.NewWithClient(metaSelectCfg(true), optInMock(&hasKey, &calls))
-
-	runCheck(t, d, "commit0aaaaaa")
-	hasKey = true
-	runCheck(t, d, "commit1bbbbbb")
-	nomad.DrainUpdates(d)
-
-	if len(calls) != 1 {
-		t.Errorf("with --apply-existing-drift, drift should apply on scope entry, got %d calls", len(calls))
+	// The diff is still surfaced, annotated with the reason.
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 1 || diffs[0].ApplyAction != nomad.ApplyActionPreExisting {
+		t.Errorf("diff should be surfaced with the pre-existing reason, got %+v", diffs)
 	}
 }
 
-func TestApply_ExistingDrift_AppliesAfterLaterCommit(t *testing.T) {
+func TestApply_ExistingDrift_TagAddedAtHead_AppliedWithFlag(t *testing.T) {
 	var calls []registerCall
-	var hasKey bool
-	d := nomad.NewWithClient(metaSelectCfg(false), optInMock(&hasKey, &calls))
+	d := nomad.NewWithClient(metaSelectCfg(true), optInMock(&calls))
+	d.SetHistorySource(fakeHistory{parent: map[string]string{testJobFile: `job "test-job" {}`}})
 
-	runCheck(t, d, "commit0aaaaaa") // out of scope
-	hasKey = true
-	runCheck(t, d, "commit1bbbbbb") // scope entry: frozen, not applied
-	if len(calls) != 0 {
-		t.Fatalf("precondition: nothing applied at scope entry, got %d", len(calls))
-	}
-	// A later commit arrives: the freeze lifts and drift applies.
-	runCheck(t, d, "commit2cccccc")
+	runCheck(t, d, "aaaa111fffff")
 	nomad.DrainUpdates(d)
 
 	if len(calls) != 1 {
-		t.Errorf("a commit after scope entry should lift the freeze and apply, got %d calls", len(calls))
+		t.Errorf("with --apply-existing-drift the pre-existing drift should apply, got %d calls", len(calls))
 	}
 }
 
-// TestApply_ExistingDrift_ReconcilesAtStartup verifies the gate does not fire
-// for jobs already in scope on the first cycle (the reconcile-on-start path):
-// prevSelected is nil, so nothing is frozen.
-func TestApply_ExistingDrift_ReconcilesAtStartup(t *testing.T) {
+// TestApply_ExistingDrift_TagPresentAtParent_Applied is the established /
+// reconcile-on-start case: the tag was already present before HEAD, so the job
+// is not freshly opted in and its drift reconciles normally.
+func TestApply_ExistingDrift_TagPresentAtParent_Applied(t *testing.T) {
 	var calls []registerCall
-	hasKey := true // already opted in before the process started observing
-	d := nomad.NewWithClient(metaSelectCfg(false), optInMock(&hasKey, &calls))
+	d := nomad.NewWithClient(metaSelectCfg(false), optInMock(&calls))
+	d.SetHistorySource(fakeHistory{parent: map[string]string{
+		testJobFile: `job "test-job" { meta { gitops_managed = "true" } }`,
+	}})
 
-	runCheck(t, d, "commit0aaaaaa") // first cycle: established, not frozen
+	runCheck(t, d, "aaaa111fffff")
 	nomad.DrainUpdates(d)
 
 	if len(calls) != 1 {
-		t.Errorf("a job already in scope at startup should reconcile, got %d calls", len(calls))
+		t.Errorf("an established job (tag present before HEAD) should reconcile, got %d calls", len(calls))
+	}
+}
+
+// TestApply_ExistingDrift_NoHistory_Applied verifies that without a history
+// source the gate is skipped so reconciliation is not broken.
+func TestApply_ExistingDrift_NoHistory_Applied(t *testing.T) {
+	var calls []registerCall
+	d := nomad.NewWithClient(metaSelectCfg(false), optInMock(&calls))
+	// No SetHistorySource call.
+
+	runCheck(t, d, "aaaa111fffff")
+	nomad.DrainUpdates(d)
+
+	if len(calls) != 1 {
+		t.Errorf("without history the pre-existing gate must not block, got %d calls", len(calls))
+	}
+}
+
+// TestApply_ExistingDrift_GlobSelectedExempt verifies that glob-selected jobs
+// (no opt-in moment) are never frozen, even when the tag was added at HEAD.
+func TestApply_ExistingDrift_GlobSelectedExempt(t *testing.T) {
+	var calls []registerCall
+	cfg := metaSelectCfg(false)
+	cfg.JobSelectorGlob = "*"
+	d := nomad.NewWithClient(cfg, optInMock(&calls))
+	d.SetHistorySource(fakeHistory{parent: map[string]string{testJobFile: `job "test-job" {}`}})
+
+	runCheck(t, d, "aaaa111fffff")
+	nomad.DrainUpdates(d)
+
+	if len(calls) != 1 {
+		t.Errorf("glob-selected jobs have no opt-in moment and must not be frozen, got %d calls", len(calls))
+	}
+}
+
+// TestApply_ExistingDrift_FileNewAtHead_Applied verifies that a file created
+// at HEAD (no parent version) is not treated as a retroactive opt-in: the tag
+// and spec arrived together, so the drift is applied (subject to policy).
+func TestApply_ExistingDrift_FileNewAtHead_Applied(t *testing.T) {
+	var calls []registerCall
+	d := nomad.NewWithClient(metaSelectCfg(false), optInMock(&calls))
+	d.SetHistorySource(fakeHistory{parent: map[string]string{}}) // file absent at parent
+
+	runCheck(t, d, "aaaa111fffff")
+	nomad.DrainUpdates(d)
+
+	if len(calls) != 1 {
+		t.Errorf("a file created with the tag at HEAD should apply (tag present when spec introduced), got %d calls", len(calls))
 	}
 }

--- a/internal/nomad/apply_test.go
+++ b/internal/nomad/apply_test.go
@@ -573,12 +573,14 @@ func metaSelectCfg(applyExisting bool) *config.Config {
 }
 
 // fakeHistory implements nomad.HistorySource. A path present in parent returns
-// that content (ok=true); an absent path returns ok=false (file new at HEAD).
+// that content (ok=true); an absent path returns ok=false (file new at the
+// commit). The commit argument is ignored: these tests use a single commit per
+// job, so keying off the path is sufficient.
 type fakeHistory struct {
 	parent map[string]string
 }
 
-func (f fakeHistory) FileAtParent(path string) (string, bool) {
+func (f fakeHistory) FileAtParentOf(_, path string) (string, bool) {
 	c, ok := f.parent[path]
 	return c, ok
 }

--- a/internal/nomad/apply_test.go
+++ b/internal/nomad/apply_test.go
@@ -560,3 +560,101 @@ func TestApply_AutoscalerOnlyChurn_NotEnqueued(t *testing.T) {
 		t.Errorf("count drift should still be surfaced as a diff, got %d", len(diffs))
 	}
 }
+
+// metaSelectCfg selects jobs by meta only (no glob), so a job can be out of
+// scope until its HCL gains the managed key.
+func metaSelectCfg(applyExisting bool) *config.Config {
+	return &config.Config{
+		NomadNamespace:      "default",
+		ManagedMetaPrefix:   "gitops",
+		DefaultUpdatePolicy: "none",
+		ApplyExistingDrift:  applyExisting,
+	}
+}
+
+// optInMock returns a mock whose HCL job gains the gitops keys once *hasKey is
+// set. The live job exists with the given ModifyIndex; the plan reports an
+// image+meta diff (pre-existing drift plus the opt-in).
+func optInMock(hasKey *bool, calls *[]registerCall) *mockJobsClient {
+	mock := applyMock(nil, editedImagePlusMetaDiff(), 42, calls)
+	mock.parseHCLFn = func(jobHCL string, normalize bool) (*nomadapi.Job, error) {
+		if *hasKey {
+			return &nomadapi.Job{ID: strPtr("test-job"), Meta: map[string]string{
+				"gitops_managed": "true", "gitops_update_policy": "full",
+			}}, nil
+		}
+		return &nomadapi.Job{ID: strPtr("test-job")}, nil
+	}
+	return mock
+}
+
+func TestApply_ExistingDrift_NotAppliedOnScopeEntry(t *testing.T) {
+	var calls []registerCall
+	var hasKey bool
+	d := nomad.NewWithClient(metaSelectCfg(false), optInMock(&hasKey, &calls))
+
+	// Cycle 1: job not opted in (no key, no glob) — out of scope.
+	runCheck(t, d, "commit0aaaaaa")
+	// Cycle 2: key added while running — scope entry; image drift is pre-existing.
+	hasKey = true
+	runCheck(t, d, "commit1bbbbbb")
+	nomad.DrainUpdates(d)
+
+	if len(calls) != 0 {
+		t.Errorf("pre-existing drift must not apply on scope entry by default, got %d calls", len(calls))
+	}
+	if got := testutil.ToFloat64(nomad.UpdatesBlockedExistingDrift(d).WithLabelValues("test-job")); got != 1 {
+		t.Errorf("blocked-preexisting metric: want 1, got %v", got)
+	}
+}
+
+func TestApply_ExistingDrift_AppliedWithFlag(t *testing.T) {
+	var calls []registerCall
+	var hasKey bool
+	d := nomad.NewWithClient(metaSelectCfg(true), optInMock(&hasKey, &calls))
+
+	runCheck(t, d, "commit0aaaaaa")
+	hasKey = true
+	runCheck(t, d, "commit1bbbbbb")
+	nomad.DrainUpdates(d)
+
+	if len(calls) != 1 {
+		t.Errorf("with --apply-existing-drift, drift should apply on scope entry, got %d calls", len(calls))
+	}
+}
+
+func TestApply_ExistingDrift_AppliesAfterLaterCommit(t *testing.T) {
+	var calls []registerCall
+	var hasKey bool
+	d := nomad.NewWithClient(metaSelectCfg(false), optInMock(&hasKey, &calls))
+
+	runCheck(t, d, "commit0aaaaaa") // out of scope
+	hasKey = true
+	runCheck(t, d, "commit1bbbbbb") // scope entry: frozen, not applied
+	if len(calls) != 0 {
+		t.Fatalf("precondition: nothing applied at scope entry, got %d", len(calls))
+	}
+	// A later commit arrives: the freeze lifts and drift applies.
+	runCheck(t, d, "commit2cccccc")
+	nomad.DrainUpdates(d)
+
+	if len(calls) != 1 {
+		t.Errorf("a commit after scope entry should lift the freeze and apply, got %d calls", len(calls))
+	}
+}
+
+// TestApply_ExistingDrift_ReconcilesAtStartup verifies the gate does not fire
+// for jobs already in scope on the first cycle (the reconcile-on-start path):
+// prevSelected is nil, so nothing is frozen.
+func TestApply_ExistingDrift_ReconcilesAtStartup(t *testing.T) {
+	var calls []registerCall
+	hasKey := true // already opted in before the process started observing
+	d := nomad.NewWithClient(metaSelectCfg(false), optInMock(&hasKey, &calls))
+
+	runCheck(t, d, "commit0aaaaaa") // first cycle: established, not frozen
+	nomad.DrainUpdates(d)
+
+	if len(calls) != 1 {
+		t.Errorf("a job already in scope at startup should reconcile, got %d calls", len(calls))
+	}
+}

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -110,9 +110,9 @@ func (a ApplyAction) Describe() string {
 	case ApplyActionCreationBlocked:
 		return "not applied: job creation disabled (set --enable-job-creation)"
 	case ApplyActionMetaOnly:
-		return "not applied: change is only to gitops meta keys"
+		return "not applied: change is confined to managed meta keys"
 	case ApplyActionDeregister:
-		return "not applied: deregistration is not enabled"
+		return "not applied: deregistration is not implemented"
 	case ApplyActionNoChange:
 		return "no actionable change (autoscaler-owned)"
 	default:
@@ -134,9 +134,13 @@ type hclEntry struct {
 // satisfies it. When nil, pre-existing-drift detection is disabled and drift
 // reconciles normally.
 type HistorySource interface {
-	// FileAtParent returns the content of path at the parent of the current
-	// HEAD commit; ok is false at the root commit or when the file is absent.
-	FileAtParent(path string) (content string, ok bool)
+	// FileAtParentOf returns the content of path at the first parent of the
+	// named commit. ok is false when the commit is unknown, has no parent
+	// (root commit), or the file is absent there. The lookup is keyed off the
+	// commit being evaluated — not the repo's current HEAD — so the decision
+	// stays consistent with the HCL snapshot passed to Check even if the
+	// watcher pulls a newer commit concurrently.
+	FileAtParentOf(commit, path string) (content string, ok bool)
 }
 
 // NomadJobsClient is the subset of the Nomad API jobs client we use.
@@ -743,7 +747,7 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 		if cand != nil {
 			// Decide the disposition once; it is recorded on the diff (for the
 			// API/console) and drives whether the update is enqueued below.
-			cand.action = d.decideApplyAction(cand)
+			cand.action = d.decideApplyAction(cand, commit)
 		}
 		if diff != nil {
 			metaOnly := cand != nil && cand.class == DiffClassManagedMetaOnly
@@ -859,30 +863,31 @@ func (d *Differ) SetHistorySource(h HistorySource) {
 
 // isPreExistingDrift reports whether a candidate's drift pre-dates the job
 // entering management scope — i.e. the managed opt-in tag was added in the
-// HEAD commit (absent in HEAD's parent version of the job's HCL file). This is
-// derived from git history, so it holds identically whether the tag was added
-// while the process was running or before it started: a job already managed in
-// an earlier commit is established and reconciles normally; one opted in at
-// HEAD is frozen until a later commit arrives.
+// commit being evaluated (absent in that commit's parent version of the job's
+// HCL file). This is derived from git history, so it holds identically whether
+// the tag was added while the process was running or before it started: a job
+// already managed in an earlier commit is established and reconciles normally;
+// one opted in at this commit is frozen until a later commit arrives.
 //
 // Glob-selected jobs are always in scope and have no opt-in moment, so they
 // are never pre-existing. Creations have no live job to pre-date. When history
 // is unavailable the check is skipped (not pre-existing) so reconciliation is
 // not broken.
-func (d *Differ) isPreExistingDrift(c *updateCandidate) bool {
+func (d *Differ) isPreExistingDrift(c *updateCandidate, commit string) bool {
 	if c.isCreation || c.globSel || d.history == nil || d.managedKeyRe == nil || c.hclFile == "" {
 		return false
 	}
-	parent, ok := d.history.FileAtParent(c.hclFile)
+	parent, ok := d.history.FileAtParentOf(commit, c.hclFile)
 	if !ok {
-		// No parent version: the file was created at HEAD (or HEAD is the root
-		// commit). The tag and the spec were introduced together, so the tag
-		// was present when the diff was introduced — not a retroactive opt-in.
+		// No parent version: the file was created at this commit (or it is the
+		// root commit). The tag and the spec were introduced together, so the
+		// tag was present when the diff was introduced — not a retroactive
+		// opt-in.
 		return false
 	}
-	// Tag present at the parent → the job was already managed before HEAD →
-	// established. Absent → the tag was added to a pre-existing file at HEAD →
-	// retroactive opt-in, so the drift pre-dates it.
+	// Tag present at the parent → the job was already managed before this
+	// commit → established. Absent → the tag was added to a pre-existing file
+	// at this commit → retroactive opt-in, so the drift pre-dates it.
 	return !d.managedKeyRe.MatchString(parent)
 }
 
@@ -890,14 +895,14 @@ func (d *Differ) isPreExistingDrift(c *updateCandidate) bool {
 // reason via metrics/logs. It does not enqueue anything; the caller enqueues
 // when the action is ApplyActionQueued. The gates are ordered most-conservative
 // first so the surfaced reason is the primary one.
-func (d *Differ) decideApplyAction(c *updateCandidate) ApplyAction {
+func (d *Differ) decideApplyAction(c *updateCandidate, commit string) ApplyAction {
 	if c.class == DiffClassNone && !c.isCreation {
 		// Everything in the diff is autoscaler-owned Count/Scaling churn;
 		// Git has nothing to apply. The diff stays visible as an observation.
 		return ApplyActionNoChange
 	}
 
-	if !c.isCreation && d.isPreExistingDrift(c) && !d.applyExistingDrift {
+	if !c.isCreation && d.isPreExistingDrift(c, commit) && !d.applyExistingDrift {
 		// The drift was already there when the job entered scope (the managed
 		// tag was added in the HEAD commit). Conservative default: opting a job
 		// in does not retroactively mutate it; only changes committed after

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -66,9 +66,58 @@ type JobDiff struct {
 	DiffType DiffType `json:"diff_type"`
 	Detail   string   `json:"detail"`
 
+	// ApplyAction records what nomad-botherer will do about this diff and,
+	// when it will not apply it, why. Lets the API and web console explain
+	// non-application without log scraping.
+	ApplyAction ApplyAction `json:"apply_action,omitempty"`
+
 	// PlanDiff holds the structured diff from the Nomad plan API.
 	// Only populated for DiffTypeModified entries.
 	PlanDiff *nomadapi.JobDiff `json:"-"`
+}
+
+// ApplyAction is the disposition of a detected diff: whether it will be
+// applied and, if not, the reason.
+type ApplyAction string
+
+const (
+	// ApplyActionQueued means an update was enqueued and will be applied.
+	ApplyActionQueued ApplyAction = "queued"
+	// ApplyActionPolicyBlocked means the effective update policy disallows it.
+	ApplyActionPolicyBlocked ApplyAction = "blocked_by_policy"
+	// ApplyActionPreExisting means the drift pre-dated the job's opt-in.
+	ApplyActionPreExisting ApplyAction = "blocked_preexisting_drift"
+	// ApplyActionCreationBlocked means first-time registration is disabled.
+	ApplyActionCreationBlocked ApplyAction = "blocked_creation_disabled"
+	// ApplyActionMetaOnly means the diff is confined to our own meta keys.
+	ApplyActionMetaOnly ApplyAction = "skipped_meta_only"
+	// ApplyActionDeregister means the job is missing from HCL; deregistration
+	// is not implemented, so it is observation-only.
+	ApplyActionDeregister ApplyAction = "observation_only"
+	// ApplyActionNoChange means the only diff is autoscaler-owned churn.
+	ApplyActionNoChange ApplyAction = "no_actionable_change"
+)
+
+// Describe returns a human-readable explanation for display.
+func (a ApplyAction) Describe() string {
+	switch a {
+	case ApplyActionQueued:
+		return "queued for apply"
+	case ApplyActionPolicyBlocked:
+		return "not applied: blocked by update policy"
+	case ApplyActionPreExisting:
+		return "not applied: drift pre-dates opt-in (set --apply-existing-drift)"
+	case ApplyActionCreationBlocked:
+		return "not applied: job creation disabled (set --enable-job-creation)"
+	case ApplyActionMetaOnly:
+		return "not applied: change is only to gitops meta keys"
+	case ApplyActionDeregister:
+		return "not applied: deregistration is not enabled"
+	case ApplyActionNoChange:
+		return "no actionable change (autoscaler-owned)"
+	default:
+		return string(a)
+	}
 }
 
 // hclEntry is a parsed HCL job that has passed the preliminary selection filter.
@@ -78,6 +127,16 @@ type hclEntry struct {
 	file    string
 	globSel bool // matched by job-selector-glob
 	metaHCL bool // managed meta key present in parsed HCL
+}
+
+// HistorySource provides read-only access to prior git state, used to decide
+// whether drift pre-dates a job entering management scope. *gitwatch.Watcher
+// satisfies it. When nil, pre-existing-drift detection is disabled and drift
+// reconciles normally.
+type HistorySource interface {
+	// FileAtParent returns the content of path at the parent of the current
+	// HEAD commit; ok is false at the root commit or when the file is absent.
+	FileAtParent(path string) (content string, ok bool)
 }
 
 // NomadJobsClient is the subset of the Nomad API jobs client we use.
@@ -115,8 +174,14 @@ type Differ struct {
 	applyMetaOnlyChanges bool
 	countMetaOnlyChanges bool
 	// applyExistingDrift allows drift that pre-existed a job's scope entry
-	// (gaining the meta tag while running) to be applied. Off by default.
+	// (the managed tag added in the HEAD commit) to be applied. Off by default.
 	applyExistingDrift bool
+	// history answers whether the managed tag was present before HEAD, used to
+	// detect pre-existing drift. nil disables the check.
+	history HistorySource
+	// managedKeyRe matches the opt-in key set to "true" in raw HCL text, for
+	// the cheap parent-content check.
+	managedKeyRe *regexp.Regexp
 	// applyInterval is the fallback cadence of the applier loop; enqueues
 	// also wake it immediately via applyCh.
 	applyInterval time.Duration
@@ -129,15 +194,10 @@ type Differ struct {
 	metaIssuesLogged sync.Map
 
 	// prevMeta holds the previous cycle's prefix-key snapshots per
-	// (source, job), used to notice and log meta-key transitions.
-	// prevSelected is the set of job IDs in scope at the previous cycle, and
-	// scopeEntryCommit holds, for jobs that entered scope while the process
-	// was running and have not yet seen a later commit, the commit at which
-	// they entered. All three are protected by metaMu.
-	metaMu           sync.Mutex
-	prevMeta         map[string]metaState
-	prevSelected     map[string]bool
-	scopeEntryCommit map[string]string
+	// (source, job), used to notice and log meta-key transitions. Protected
+	// by metaMu.
+	metaMu   sync.Mutex
+	prevMeta map[string]metaState
 
 	mu             sync.RWMutex
 	diffs          []JobDiff
@@ -181,6 +241,13 @@ func newDifferBase(jobs NomadJobsClient, cfg *config.Config, reg prometheus.Regi
 		applyInterval = 10 * time.Second
 	}
 
+	var managedKeyRe *regexp.Regexp
+	if cfg.ManagedMetaPrefix != "" {
+		// Matches <prefix>_managed = "true" in raw HCL, in both the block form
+		// (bare key) and the object-expression form (quoted key).
+		managedKeyRe = regexp.MustCompile(`(?m)"?` + regexp.QuoteMeta(cfg.ManagedMetaPrefix) + `_managed"?\s*=\s*"true"`)
+	}
+
 	f := promauto.With(reg)
 	d := &Differ{
 		jobs:              jobs,
@@ -194,6 +261,7 @@ func newDifferBase(jobs NomadJobsClient, cfg *config.Config, reg prometheus.Regi
 		applyMetaOnlyChanges: cfg.ApplyMetaOnlyChanges,
 		countMetaOnlyChanges: cfg.CountMetaOnlyChanges,
 		applyExistingDrift:   cfg.ApplyExistingDrift,
+		managedKeyRe:         managedKeyRe,
 		applyInterval:        applyInterval,
 		updateQueue:       NewUpdateQueue(),
 		applyCh:           make(chan struct{}, 1),
@@ -439,7 +507,9 @@ type updateCandidate struct {
 	job         *nomadapi.Job
 	modifyIndex uint64
 	class       DiffClass
-	isCreation  bool // job absent (or dead) in Nomad: first-time registration
+	isCreation  bool        // job absent (or dead) in Nomad: first-time registration
+	globSel     bool        // selected by job-selector-glob (no opt-in moment)
+	action      ApplyAction // disposition, decided in decideApplyAction
 }
 
 // jobModifyIndex safely extracts a job's ModifyIndex.
@@ -479,7 +549,7 @@ func (d *Differ) checkHCLCandidate(jobID string, entry hclEntry, q *nomadapi.Que
 		// is exactly the guard a first registration wants.
 		cand := &updateCandidate{
 			jobID: jobID, hclFile: entry.file, job: entry.job,
-			modifyIndex: 0, class: DiffClassOther, isCreation: true,
+			modifyIndex: 0, class: DiffClassOther, isCreation: true, globSel: entry.globSel,
 		}
 		return true, reason, diff, cand
 	}
@@ -503,7 +573,7 @@ func (d *Differ) checkHCLCandidate(jobID string, entry hclEntry, q *nomadapi.Que
 		// token is its current ModifyIndex, not 0.
 		cand := &updateCandidate{
 			jobID: jobID, hclFile: entry.file, job: entry.job,
-			modifyIndex: jobModifyIndex(nomadJob), class: DiffClassOther, isCreation: true,
+			modifyIndex: jobModifyIndex(nomadJob), class: DiffClassOther, isCreation: true, globSel: entry.globSel,
 		}
 		return true, reason, diff, cand
 	}
@@ -551,7 +621,7 @@ func (d *Differ) checkHCLCandidate(jobID string, entry hclEntry, q *nomadapi.Que
 		}
 		cand := &updateCandidate{
 			jobID: jobID, hclFile: entry.file, job: entry.job,
-			modifyIndex: jobModifyIndex(nomadJob), class: class,
+			modifyIndex: jobModifyIndex(nomadJob), class: class, globSel: entry.globSel,
 		}
 		return true, reason, diff, cand
 	}
@@ -670,10 +740,18 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 		}
 		selReasons[jobID] = mergeSelectionReason(selReasons[jobID], reason)
 		hclJobSet[jobID] = struct{}{}
+		if cand != nil {
+			// Decide the disposition once; it is recorded on the diff (for the
+			// API/console) and drives whether the update is enqueued below.
+			cand.action = d.decideApplyAction(cand)
+		}
 		if diff != nil {
 			metaOnly := cand != nil && cand.class == DiffClassManagedMetaOnly
 			if metaOnly {
 				d.metaOnlyDiffs.WithLabelValues(jobID).Inc()
+			}
+			if cand != nil {
+				diff.ApplyAction = cand.action
 			}
 			// A diff confined to our own meta keys is an expected,
 			// non-disruptive difference. By default it is not counted as
@@ -726,16 +804,16 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 		selReasons[j.ID] = mergeSelectionReason(selReasons[j.ID], reason)
 		if _, ok := hclJobSet[j.ID]; !ok {
 			diffs = append(diffs, JobDiff{
-				JobID:    j.ID,
-				DiffType: DiffTypeMissingFromHCL,
-				Detail:   fmt.Sprintf("job is running in Nomad (status: %s) but has no HCL definition in the repo", j.Status),
+				JobID:       j.ID,
+				DiffType:    DiffTypeMissingFromHCL,
+				Detail:      fmt.Sprintf("job is running in Nomad (status: %s) but has no HCL definition in the repo", j.Status),
+				ApplyAction: ApplyActionDeregister,
 			})
 		}
 	}
 
 	d.commitResults(diffs, selReasons, commit, listMeta, time.Now())
 	d.logMetaChanges(metaSeen)
-	d.recordScopeEntry(selReasons, commit)
 
 	var raftIndex uint64
 	if listMeta != nil {
@@ -743,7 +821,8 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 	}
 	enqueued := 0
 	for _, cand := range candidates {
-		if d.maybeEnqueueUpdate(cand, commit, raftIndex, d.isPreExistingDrift(cand.jobID)) {
+		if cand.action == ApplyActionQueued {
+			d.enqueueUpdate(cand, commit, raftIndex)
 			enqueued++
 		}
 	}
@@ -772,66 +851,60 @@ func (d *Differ) effectivePolicy(meta map[string]string) UpdatePolicy {
 	return d.defaultPolicy
 }
 
-// recordScopeEntry updates the cross-cycle scope tracking. A job that is
-// selected this cycle but was not selected last cycle has just entered scope
-// while the process was running; it is frozen at the current commit so its
-// pre-existing drift is not applied until a later commit arrives. Jobs in
-// scope at startup (prevSelected nil on the first cycle) are never frozen, so
-// reconcile-on-start is preserved. The freeze lifts once the commit advances
-// past the entry commit or the job leaves scope.
-func (d *Differ) recordScopeEntry(selected map[string]SelectionReason, commit string) {
-	d.metaMu.Lock()
-	defer d.metaMu.Unlock()
-
-	next := make(map[string]string)
-	for jobID := range selected {
-		if entry, frozen := d.scopeEntryCommit[jobID]; frozen {
-			// Keep the freeze only while the commit has not advanced.
-			if entry == commit {
-				next[jobID] = entry
-			}
-		} else if d.prevSelected != nil && !d.prevSelected[jobID] {
-			// Newly entered scope while running.
-			next[jobID] = commit
-		}
-	}
-	d.scopeEntryCommit = next
-
-	d.prevSelected = make(map[string]bool, len(selected))
-	for jobID := range selected {
-		d.prevSelected[jobID] = true
-	}
+// SetHistorySource wires the git-history accessor used to detect pre-existing
+// drift. Called once at startup after the watcher exists.
+func (d *Differ) SetHistorySource(h HistorySource) {
+	d.history = h
 }
 
-// isPreExistingDrift reports whether jobID is currently frozen at its scope
-// entry — i.e. its drift pre-dates the job entering scope and no later commit
-// has arrived.
-func (d *Differ) isPreExistingDrift(jobID string) bool {
-	d.metaMu.Lock()
-	defer d.metaMu.Unlock()
-	_, frozen := d.scopeEntryCommit[jobID]
-	return frozen
+// isPreExistingDrift reports whether a candidate's drift pre-dates the job
+// entering management scope — i.e. the managed opt-in tag was added in the
+// HEAD commit (absent in HEAD's parent version of the job's HCL file). This is
+// derived from git history, so it holds identically whether the tag was added
+// while the process was running or before it started: a job already managed in
+// an earlier commit is established and reconciles normally; one opted in at
+// HEAD is frozen until a later commit arrives.
+//
+// Glob-selected jobs are always in scope and have no opt-in moment, so they
+// are never pre-existing. Creations have no live job to pre-date. When history
+// is unavailable the check is skipped (not pre-existing) so reconciliation is
+// not broken.
+func (d *Differ) isPreExistingDrift(c *updateCandidate) bool {
+	if c.isCreation || c.globSel || d.history == nil || d.managedKeyRe == nil || c.hclFile == "" {
+		return false
+	}
+	parent, ok := d.history.FileAtParent(c.hclFile)
+	if !ok {
+		// No parent version: the file was created at HEAD (or HEAD is the root
+		// commit). The tag and the spec were introduced together, so the tag
+		// was present when the diff was introduced — not a retroactive opt-in.
+		return false
+	}
+	// Tag present at the parent → the job was already managed before HEAD →
+	// established. Absent → the tag was added to a pre-existing file at HEAD →
+	// retroactive opt-in, so the drift pre-dates it.
+	return !d.managedKeyRe.MatchString(parent)
 }
 
-// maybeEnqueueUpdate applies the policy, scope-entry, and creation gates to a
-// candidate and enqueues a JobUpdate if it passes. preExisting reports whether
-// the drift pre-dates the job entering scope. Reports whether an update was
-// enqueued.
-func (d *Differ) maybeEnqueueUpdate(c *updateCandidate, commit string, raftIndex uint64, preExisting bool) bool {
+// decideApplyAction determines a candidate's disposition and records the
+// reason via metrics/logs. It does not enqueue anything; the caller enqueues
+// when the action is ApplyActionQueued. The gates are ordered most-conservative
+// first so the surfaced reason is the primary one.
+func (d *Differ) decideApplyAction(c *updateCandidate) ApplyAction {
 	if c.class == DiffClassNone && !c.isCreation {
 		// Everything in the diff is autoscaler-owned Count/Scaling churn;
 		// Git has nothing to apply. The diff stays visible as an observation.
-		return false
+		return ApplyActionNoChange
 	}
 
-	if preExisting && !c.isCreation && !d.applyExistingDrift {
-		// The drift was already there when the job entered scope (opted in
-		// via meta tag while running). Conservative default: do not mutate a
-		// job just because it was opted in; only changes committed after
+	if !c.isCreation && d.isPreExistingDrift(c) && !d.applyExistingDrift {
+		// The drift was already there when the job entered scope (the managed
+		// tag was added in the HEAD commit). Conservative default: opting a job
+		// in does not retroactively mutate it; only changes committed after
 		// opt-in apply. Enable with --apply-existing-drift.
-		slog.Info("Pre-existing drift not applied on scope entry; set --apply-existing-drift to apply", "job", c.jobID)
+		slog.Info("Pre-existing drift not applied on opt-in; set --apply-existing-drift to apply", "job", c.jobID)
 		d.updatesBlockedExistingDrift.WithLabelValues(c.jobID).Inc()
-		return false
+		return ApplyActionPreExisting
 	}
 
 	if c.class == DiffClassManagedMetaOnly && !c.isCreation && !d.applyMetaOnlyChanges {
@@ -841,29 +914,35 @@ func (d *Differ) maybeEnqueueUpdate(c *updateCandidate, commit string, raftIndex
 		// converge on the next real update (registering from HCL carries them
 		// along, even under an image-only policy). Enable with
 		// --apply-meta-only-changes.
-		return false
+		return ApplyActionMetaOnly
 	}
 
 	policy := d.effectivePolicy(c.job.Meta)
 	switch policy {
 	case UpdatePolicyNone:
 		d.updatesBlockedByPolicy.WithLabelValues(c.jobID, string(policy)).Inc()
-		return false
+		return ApplyActionPolicyBlocked
 	case UpdatePolicyImageOnly:
 		// Initial registration is full-only by design: registering a job
 		// for the first time is not an image-only change.
 		if c.isCreation || c.class != DiffClassImageOnly {
 			d.updatesBlockedByPolicy.WithLabelValues(c.jobID, string(policy)).Inc()
-			return false
+			return ApplyActionPolicyBlocked
 		}
 	}
 
 	if c.isCreation && !d.enableJobCreation {
 		slog.Info("Job creation blocked: --enable-job-creation is off", "job", c.jobID)
 		d.updatesBlockedCreationDisabled.WithLabelValues(c.jobID).Inc()
-		return false
+		return ApplyActionCreationBlocked
 	}
 
+	return ApplyActionQueued
+}
+
+// enqueueUpdate places an approved candidate's update on the queue.
+func (d *Differ) enqueueUpdate(c *updateCandidate, commit string, raftIndex uint64) {
+	policy := d.effectivePolicy(c.job.Meta)
 	superseded := d.updateQueue.Enqueue(JobUpdate{
 		UpdateID:            updateID(c.jobID, commit),
 		JobID:               c.jobID,
@@ -883,7 +962,6 @@ func (d *Differ) maybeEnqueueUpdate(c *updateCandidate, commit string, raftIndex
 	}
 	d.pendingUpdates.Set(float64(d.updateQueue.PendingCount()))
 	slog.Info("Enqueued job update", "job", c.jobID, "update_id", updateID(c.jobID, commit), "policy", policy, "creation", c.isCreation)
-	return true
 }
 
 // ForceCheck runs a diff check unconditionally because the Nomad state has

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -114,6 +114,9 @@ type Differ struct {
 	// Both off by default.
 	applyMetaOnlyChanges bool
 	countMetaOnlyChanges bool
+	// applyExistingDrift allows drift that pre-existed a job's scope entry
+	// (gaining the meta tag while running) to be applied. Off by default.
+	applyExistingDrift bool
 	// applyInterval is the fallback cadence of the applier loop; enqueues
 	// also wake it immediately via applyCh.
 	applyInterval time.Duration
@@ -127,8 +130,14 @@ type Differ struct {
 
 	// prevMeta holds the previous cycle's prefix-key snapshots per
 	// (source, job), used to notice and log meta-key transitions.
-	metaMu   sync.Mutex
-	prevMeta map[string]metaState
+	// prevSelected is the set of job IDs in scope at the previous cycle, and
+	// scopeEntryCommit holds, for jobs that entered scope while the process
+	// was running and have not yet seen a later commit, the commit at which
+	// they entered. All three are protected by metaMu.
+	metaMu           sync.Mutex
+	prevMeta         map[string]metaState
+	prevSelected     map[string]bool
+	scopeEntryCommit map[string]string
 
 	mu             sync.RWMutex
 	diffs          []JobDiff
@@ -158,6 +167,7 @@ type Differ struct {
 	metaKeyIssues                  *prometheus.CounterVec
 	metaKeyChanges                 *prometheus.CounterVec
 	metaOnlyDiffs                  *prometheus.CounterVec
+	updatesBlockedExistingDrift    *prometheus.CounterVec
 }
 
 // newDifferBase constructs a Differ from config with metrics registered into reg.
@@ -183,6 +193,7 @@ func newDifferBase(jobs NomadJobsClient, cfg *config.Config, reg prometheus.Regi
 		enableJobCreation:    cfg.EnableJobCreation,
 		applyMetaOnlyChanges: cfg.ApplyMetaOnlyChanges,
 		countMetaOnlyChanges: cfg.CountMetaOnlyChanges,
+		applyExistingDrift:   cfg.ApplyExistingDrift,
 		applyInterval:        applyInterval,
 		updateQueue:       NewUpdateQueue(),
 		applyCh:           make(chan struct{}, 1),
@@ -262,6 +273,10 @@ func newDifferBase(jobs NomadJobsClient, cfg *config.Config, reg prometheus.Regi
 		metaOnlyDiffs: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "nomad_botherer_meta_only_diffs_total",
 			Help: "Diffs confined to nomad-botherer's own meta keys, detected per check cycle. By default these are neither counted as drift nor applied (see --count-meta-only-changes, --apply-meta-only-changes); they converge on the next real update.",
+		}, []string{"job"}),
+		updatesBlockedExistingDrift: f.NewCounterVec(prometheus.CounterOpts{
+			Name: "nomad_botherer_updates_blocked_preexisting_total",
+			Help: "Updates not enqueued because the drift pre-existed the job entering scope (opt-in via meta tag while running). Enable with --apply-existing-drift.",
 		}, []string{"job"}),
 	}
 
@@ -720,6 +735,7 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 
 	d.commitResults(diffs, selReasons, commit, listMeta, time.Now())
 	d.logMetaChanges(metaSeen)
+	d.recordScopeEntry(selReasons, commit)
 
 	var raftIndex uint64
 	if listMeta != nil {
@@ -727,7 +743,7 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 	}
 	enqueued := 0
 	for _, cand := range candidates {
-		if d.maybeEnqueueUpdate(cand, commit, raftIndex) {
+		if d.maybeEnqueueUpdate(cand, commit, raftIndex, d.isPreExistingDrift(cand.jobID)) {
 			enqueued++
 		}
 	}
@@ -756,13 +772,65 @@ func (d *Differ) effectivePolicy(meta map[string]string) UpdatePolicy {
 	return d.defaultPolicy
 }
 
-// maybeEnqueueUpdate applies the policy and creation gates to a candidate
-// and enqueues a JobUpdate if it passes. Reports whether an update was
+// recordScopeEntry updates the cross-cycle scope tracking. A job that is
+// selected this cycle but was not selected last cycle has just entered scope
+// while the process was running; it is frozen at the current commit so its
+// pre-existing drift is not applied until a later commit arrives. Jobs in
+// scope at startup (prevSelected nil on the first cycle) are never frozen, so
+// reconcile-on-start is preserved. The freeze lifts once the commit advances
+// past the entry commit or the job leaves scope.
+func (d *Differ) recordScopeEntry(selected map[string]SelectionReason, commit string) {
+	d.metaMu.Lock()
+	defer d.metaMu.Unlock()
+
+	next := make(map[string]string)
+	for jobID := range selected {
+		if entry, frozen := d.scopeEntryCommit[jobID]; frozen {
+			// Keep the freeze only while the commit has not advanced.
+			if entry == commit {
+				next[jobID] = entry
+			}
+		} else if d.prevSelected != nil && !d.prevSelected[jobID] {
+			// Newly entered scope while running.
+			next[jobID] = commit
+		}
+	}
+	d.scopeEntryCommit = next
+
+	d.prevSelected = make(map[string]bool, len(selected))
+	for jobID := range selected {
+		d.prevSelected[jobID] = true
+	}
+}
+
+// isPreExistingDrift reports whether jobID is currently frozen at its scope
+// entry — i.e. its drift pre-dates the job entering scope and no later commit
+// has arrived.
+func (d *Differ) isPreExistingDrift(jobID string) bool {
+	d.metaMu.Lock()
+	defer d.metaMu.Unlock()
+	_, frozen := d.scopeEntryCommit[jobID]
+	return frozen
+}
+
+// maybeEnqueueUpdate applies the policy, scope-entry, and creation gates to a
+// candidate and enqueues a JobUpdate if it passes. preExisting reports whether
+// the drift pre-dates the job entering scope. Reports whether an update was
 // enqueued.
-func (d *Differ) maybeEnqueueUpdate(c *updateCandidate, commit string, raftIndex uint64) bool {
+func (d *Differ) maybeEnqueueUpdate(c *updateCandidate, commit string, raftIndex uint64, preExisting bool) bool {
 	if c.class == DiffClassNone && !c.isCreation {
 		// Everything in the diff is autoscaler-owned Count/Scaling churn;
 		// Git has nothing to apply. The diff stays visible as an observation.
+		return false
+	}
+
+	if preExisting && !c.isCreation && !d.applyExistingDrift {
+		// The drift was already there when the job entered scope (opted in
+		// via meta tag while running). Conservative default: do not mutate a
+		// job just because it was opted in; only changes committed after
+		// opt-in apply. Enable with --apply-existing-drift.
+		slog.Info("Pre-existing drift not applied on scope entry; set --apply-existing-drift to apply", "job", c.jobID)
+		d.updatesBlockedExistingDrift.WithLabelValues(c.jobID).Inc()
 		return false
 	}
 

--- a/internal/nomad/export_test.go
+++ b/internal/nomad/export_test.go
@@ -34,6 +34,11 @@ func MetaOnlyDiffs(d *Differ) *prometheus.CounterVec {
 	return d.metaOnlyDiffs
 }
 
+// UpdatesBlockedExistingDrift exposes the pre-existing-drift block counter.
+func UpdatesBlockedExistingDrift(d *Differ) *prometheus.CounterVec {
+	return d.updatesBlockedExistingDrift
+}
+
 // LastNomadIndex exposes the cached Raft index for skip-invalidation tests.
 func LastNomadIndex(d *Differ) uint64 {
 	d.mu.RLock()

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -183,7 +183,8 @@ const openAPISpec = `{
           "job_id":    {"type": "string"},
           "hcl_file":  {"type": "string"},
           "diff_type": {"type": "string", "enum": ["modified", "missing_from_nomad", "missing_from_hcl"]},
-          "detail":    {"type": "string"}
+          "detail":    {"type": "string"},
+          "apply_action": {"type": "string", "description": "Disposition of this diff: whether it will be applied and, if not, why.", "enum": ["queued", "blocked_by_policy", "blocked_preexisting_drift", "blocked_creation_disabled", "skipped_meta_only", "observation_only", "no_actionable_change"]}
         }
       },
       "SelectedJob": {

--- a/internal/server/render.go
+++ b/internal/server/render.go
@@ -50,6 +50,9 @@ func renderDiffsText(diffs []nomad.JobDiff, lastCheck time.Time, commit string, 
 				fmt.Fprintf(&b, "  %s\n", d.Detail)
 			}
 		}
+		if d.ApplyAction != "" {
+			fmt.Fprintf(&b, "  → %s\n", d.ApplyAction.Describe())
+		}
 	}
 
 	return b.String()

--- a/internal/server/render_test.go
+++ b/internal/server/render_test.go
@@ -290,3 +290,31 @@ func TestDiffs_RedactionEnabled_NoDiffs_NoBanner(t *testing.T) {
 		t.Error("expected 'No differences' message")
 	}
 }
+
+// ── apply action / reason ──────────────────────────────────────────────────────
+
+func TestDiffs_ShowsApplyActionReason(t *testing.T) {
+	diffs := []nomad.JobDiff{
+		{
+			JobID:       "hass",
+			HCLFile:     "hass.hcl",
+			DiffType:    nomad.DiffTypeModified,
+			Detail:      "plan shows Edited",
+			ApplyAction: nomad.ApplyActionPreExisting,
+		},
+	}
+	body := diffsResponse(t, diffs, time.Now())
+	if !strings.Contains(body, "drift pre-dates opt-in") {
+		t.Errorf("/diffs should explain why the diff is not applied, got:\n%s", body)
+	}
+}
+
+func TestDiffs_NoApplyActionWhenEmpty(t *testing.T) {
+	diffs := []nomad.JobDiff{
+		{JobID: "api", DiffType: nomad.DiffTypeModified, Detail: "x"},
+	}
+	body := diffsResponse(t, diffs, time.Now())
+	if strings.Contains(body, "→") {
+		t.Errorf("no reason arrow expected when ApplyAction is empty, got:\n%s", body)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -363,10 +363,11 @@ type HealthResponse struct {
 
 // DiffEntry is one element of HealthResponse.Diffs.
 type DiffEntry struct {
-	JobID    string `json:"job_id"`
-	HCLFile  string `json:"hcl_file,omitempty"`
-	DiffType string `json:"diff_type"`
-	Detail   string `json:"detail"`
+	JobID       string `json:"job_id"`
+	HCLFile     string `json:"hcl_file,omitempty"`
+	DiffType    string `json:"diff_type"`
+	Detail      string `json:"detail"`
+	ApplyAction string `json:"apply_action,omitempty"`
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
@@ -391,10 +392,11 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 	entries := make([]DiffEntry, 0, len(diffs))
 	for _, d := range diffs {
 		entries = append(entries, DiffEntry{
-			JobID:    d.JobID,
-			HCLFile:  d.HCLFile,
-			DiffType: string(d.DiffType),
-			Detail:   d.Detail,
+			JobID:       d.JobID,
+			HCLFile:     d.HCLFile,
+			DiffType:    string(d.DiffType),
+			Detail:      d.Detail,
+			ApplyAction: string(d.ApplyAction),
 		})
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1172,3 +1172,46 @@ func TestIndex_ApplyMode_EnabledWithPending(t *testing.T) {
 		t.Errorf("index should count only non-terminal updates as pending, got:\n%.500s", body)
 	}
 }
+
+func TestAPIDiffs_IncludesApplyAction(t *testing.T) {
+	key := "k-" + strings.Repeat("x", 16)
+	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main", APIKey: key}
+	diffSrc := &mockDiffSource{
+		lastCheck: time.Now(),
+		diffs: []nomad.JobDiff{
+			{JobID: "hass", DiffType: nomad.DiffTypeModified, Detail: "x", ApplyAction: nomad.ApplyActionPreExisting},
+		},
+	}
+	srv := server.NewWithRegistry(cfg, diffSrc, &mockGitSource{lastUpdate: time.Now()},
+		server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/diffs", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"apply_action":"blocked_preexisting_drift"`) {
+		t.Errorf("API diffs should include apply_action, got %s", rec.Body.String())
+	}
+}
+
+func TestHealthz_IncludesApplyAction(t *testing.T) {
+	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main"}
+	diffSrc := &mockDiffSource{
+		lastCheck: time.Now(),
+		diffs: []nomad.JobDiff{
+			{JobID: "hass", DiffType: nomad.DiffTypeModified, Detail: "x", ApplyAction: nomad.ApplyActionPreExisting},
+		},
+	}
+	srv := server.NewWithRegistry(cfg, diffSrc, &mockGitSource{lastUpdate: time.Now()},
+		server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), `"apply_action":"blocked_preexisting_drift"`) {
+		t.Errorf("/healthz should include apply_action, got %s", rec.Body.String())
+	}
+}

--- a/tests/regression/apply_test.go
+++ b/tests/regression/apply_test.go
@@ -444,3 +444,44 @@ func TestApplyE2E_ExistingDrift(t *testing.T) {
 		waitForTaskArgs(t, jobID, "999", 60*time.Second)
 	})
 }
+
+// TestApplyE2E_ExistingDrift_AtStartup verifies the git-history-based gate
+// works when nomad-botherer starts up already pointing at the opt-in commit
+// (it did not witness the tag being added). The job ran drifted, the drift and
+// then the tag were committed, and only then is the binary started.
+func TestApplyE2E_ExistingDrift_AtStartup(t *testing.T) {
+	run := func(t *testing.T, applyExisting bool) string {
+		repoURL, workDir, branch := createGitRepo(t)
+		jobID := uniqueJobID("existing-startup")
+
+		// Running job: args ["600"], no gitops keys.
+		registerJobHCL(t, testJobHCL(jobID))
+		waitForJobStatus(t, jobID, "running", 60*time.Second)
+
+		// Commit 1: drift the args, still no tag.
+		commitToGit(t, workDir, map[string]string{jobID + ".hcl": testJobHCLModified(jobID)})
+		// Commit 2: add the tag (opt-in). HEAD's parent (commit 1) lacks the tag.
+		commitToGit(t, workDir, map[string]string{jobID + ".hcl": testJobHCLWithPolicy(jobID, "full")})
+
+		// Only now start the binary — it never witnessed the opt-in.
+		extra := []string{"--repo-url=" + repoURL, "--branch=" + branch, "--apply-interval=1s"}
+		if applyExisting {
+			extra = append(extra, "--apply-existing-drift")
+		}
+		startBotherer(t, extra...)
+		return jobID
+	}
+
+	t.Run("default leaves pre-existing drift alone on startup", func(t *testing.T) {
+		jobID := run(t, false)
+		time.Sleep(8 * time.Second)
+		if args := jobTaskArgs(t, jobID); len(args) != 1 || args[0] != "600" {
+			t.Errorf("startup pre-existing drift must not apply by default; args are now %v", args)
+		}
+	})
+
+	t.Run("flag applies pre-existing drift on startup", func(t *testing.T) {
+		jobID := run(t, true)
+		waitForTaskArgs(t, jobID, "999", 60*time.Second)
+	})
+}

--- a/tests/regression/apply_test.go
+++ b/tests/regression/apply_test.go
@@ -398,3 +398,49 @@ func TestApplyE2E_MetaOnlyChange_AppliedWithFlag(t *testing.T) {
 	}
 	t.Error("with --apply-meta-only-changes the live meta should converge to carry gitops_managed")
 }
+
+// TestApplyE2E_ExistingDrift reproduces the "opt a drifted job in" scenario:
+// a running job already differs from its HCL (args), then the gitops meta tag
+// is added by a later commit while nomad-botherer is watching. By default the
+// pre-existing drift is not applied; with --apply-existing-drift it is.
+func TestApplyE2E_ExistingDrift(t *testing.T) {
+	run := func(t *testing.T, applyExisting bool) (jobID, baseURL string) {
+		repoURL, workDir, branch := createGitRepo(t)
+		jobID = uniqueJobID("existing-drift")
+
+		// Running job: args ["600"], no gitops keys.
+		registerJobHCL(t, testJobHCL(jobID))
+		waitForJobStatus(t, jobID, "running", 60*time.Second)
+
+		// Commit 1: HCL drifts the args to ["999"], still no gitops keys, so
+		// the job is not yet in scope (no glob configured).
+		commitToGit(t, workDir, map[string]string{jobID + ".hcl": testJobHCLModified(jobID)})
+
+		extra := []string{"--repo-url=" + repoURL, "--branch=" + branch, "--apply-interval=1s", "--poll-interval=1s"}
+		if applyExisting {
+			extra = append(extra, "--apply-existing-drift")
+		}
+		baseURL = startBotherer(t, extra...)
+
+		// Let it observe the out-of-scope job for a couple of cycles.
+		time.Sleep(3 * time.Second)
+
+		// Commit 2: add the gitops tag while running — the job enters scope
+		// with the args drift already present.
+		commitToGit(t, workDir, map[string]string{jobID + ".hcl": testJobHCLWithPolicy(jobID, "full")})
+		return jobID, baseURL
+	}
+
+	t.Run("default leaves pre-existing drift alone", func(t *testing.T) {
+		jobID, _ := run(t, false)
+		time.Sleep(8 * time.Second)
+		if args := jobTaskArgs(t, jobID); len(args) != 1 || args[0] != "600" {
+			t.Errorf("pre-existing drift must not be applied on opt-in by default; args are now %v", args)
+		}
+	})
+
+	t.Run("flag applies pre-existing drift", func(t *testing.T) {
+		jobID, _ := run(t, true)
+		waitForTaskArgs(t, jobID, "999", 60*time.Second)
+	})
+}


### PR DESCRIPTION
Addresses the hass case (a running job's image was bumped in Git, the `gitops_managed` tag added later, and the update never landed) and adds control + visibility over applying drift that pre-dates a job entering scope.

## Behaviour

When the managed tag is added to a job that **already** differs from its HCL, that drift is **pre-existing** — it was there before the job entered scope. By default nomad-botherer does **not** apply it: opting a job in should not retroactively mutate it based on drift you may not have reviewed; only changes committed *after* the tag is added apply. `--apply-existing-drift` / `APPLY_EXISTING_DRIFT` (default off, the conservative choice) applies it instead — so hass converges as soon as the tag lands.

## Decided from git history (works on startup)

The decision is derived from git history, not a remembered in-process event, so it holds identically whether the tag is added while running or before the process starts. For a job's HCL file: if the managed tag was present in the commit **before HEAD**, the job was already managed and reconciles normally; if it was **added at HEAD** to a pre-existing file, the drift pre-dates opt-in and is held. A file created *with* the tag in a single commit is not a retroactive opt-in (tag and spec arrived together) and applies. Because the signal is git-derived, a **restart never freezes an already-managed cluster** — the failure mode of a naive in-memory approach. Glob-selected jobs have no opt-in moment and are exempt.

(This supersedes the earlier in-memory "witnessed transition" approach in this PR's first commit; the final commit reworks it to be git-derived. The `file created with the tag` case was caught by the regression suite — a brand-new HCL file with the tag must apply, not freeze.)

## Why a diff is or is not applied (new visibility)

Every diff now carries an `apply_action` so you never have to scrape logs to see why a drift is sitting unapplied: `queued`, `blocked_by_policy`, `blocked_preexisting_drift`, `blocked_creation_disabled`, `skipped_meta_only`, `observation_only`, `no_actionable_change`. It's shown on `/diffs` (a `→ reason` line per job), in the `/api/v1/diffs` and `/healthz` JSON, and in the OpenAPI spec.

## Surface

- `--apply-existing-drift` / `APPLY_EXISTING_DRIFT`, default false.
- `nomad_botherer_updates_blocked_preexisting_total{job}` counts held updates.
- `JobDiff.apply_action` on `/diffs`, API, healthz, OpenAPI.
- New `HistorySource` interface; `gitwatch.Watcher.FileAtParent`.
- README (flag, the "Opting in a job that already drifted" and "Why a diff is or is not applied" sections), CHANGELOG.

## Tests

- Unit: tag-added-at-head held (+ metric + diff reason); applied with flag; tag-present-at-parent reconciles; no history → applies; glob exempt; file-new-at-head applies. Render + API/healthz `apply_action`. Config flag.
- gitwatch `FileAtParent` (parent content, file-new, root commit, no repo).
- Regression e2e: pre-existing drift held/applied both **while running** and **on a fresh startup** (binary started already at the opt-in commit), for default and `--apply-existing-drift`.
- Full `-race` unit suite and complete regression suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
