### PR TITLE
Release v0.7.0: changelog roll + compatibility matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.7.0 — 2026-06-14
 
 ### New features
 

--- a/docs/nomad-versions.md
+++ b/docs/nomad-versions.md
@@ -22,6 +22,7 @@ After a successful run, add a row to the table below and update `tests/regressio
 
 | nomad-botherer | Nomad 1.9.x | Nomad 1.10.x | Nomad 1.11.x | Nomad 2.0.x | Notes |
 |----------------|:-----------:|:------------:|:------------:|:-----------:|-------|
+| v0.7.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Adds deregistration of repo-removed jobs |
 | v0.6.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Full apply suite (policies, pre-existing drift, apply_action) |
 | v0.4.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    |       |
 | v0.1.2         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    |       |

--- a/tests/regression/compat.go
+++ b/tests/regression/compat.go
@@ -52,6 +52,30 @@ type VersionRecord struct {
 var TestedVersions = []VersionRecord{
 	{
 		NomadVersion:    "2.0.2",
+		BothererRelease: "v0.7.0",
+		TestedAt:        time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.11.3",
+		BothererRelease: "v0.7.0",
+		TestedAt:        time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.10.5",
+		BothererRelease: "v0.7.0",
+		TestedAt:        time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.9.6",
+		BothererRelease: "v0.7.0",
+		TestedAt:        time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "2.0.2",
 		BothererRelease: "v0.6.0",
 		TestedAt:        time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC),
 		Passed:          true,


### PR DESCRIPTION
Release prep for **v0.7.0**, which adds deregistration of jobs removed from the repo (PR #59, now merged to `main`).

- Rolls the deregistration entry from `## Unreleased` into `## v0.7.0 — 2026-06-14`.
- Records v0.7.0 in `docs/nomad-versions.md` and `tests/regression/compat.go`: the full suite — including the new deregister regression tests (`TestDeregisterE2E_RemovedFromRepo`) — passes against Nomad **1.9.6, 1.10.5, 1.11.3, 2.0.2** (run today).

After merge: tag `v0.7.0` and publish the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)