### PR TITLE
Spring-clean docs: implemented proposals graduate to docs/design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,8 +95,8 @@ conservative (detection-only).
 - **GitOps apply: nomad-botherer can now mutate jobs.** When drift is
   detected for a managed job, it can re-register the job from its HCL —
   implementing the async-queue design from
-  `docs/proposals/gitops-job-updates.md` and the policy model from
-  `docs/proposals/update-policies.md`. Everything defaults to
+  `docs/design/gitops-job-updates.md` and the policy model from
+  `docs/design/update-policies.md`. Everything defaults to
   detection-only:
   - Per-job update policies: `none` (default), `image-only` (apply only
     when the entire plan diff is Docker image fields), `full`. Set the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@
 
 **Always update docs.** Config flag added or changed? Update the README table. Behaviour changed? Update the relevant section. Keep docs current.
 
+**Proposals graduate to design docs when implemented.** `docs/proposals/` is for not-yet-built ideas; `docs/design/` is the retrospective record of *why* a shipped feature is the way it is. When a feature in a proposal lands, `git mv` the doc to `docs/design/`, retitle it `# Design: …`, update its status (what shipped, in which release, and where it diverged from the proposal), fix cross-links, and leave any still-unimplemented parts behind in `docs/proposals/`. Do this as part of the feature's own PR going forward, so the split never drifts.
+
 **Do not merge PRs.** Create the branch, commit, push, open the PR — then stop. Leave merging to the human.
 
 **Never push directly to main.** All changes go through a branch and PR, no matter how small. This includes docs, README, and config-only changes.
@@ -54,11 +56,14 @@ Do not weaken these defaults. Detection and application are decoupled
 deliberately not persisted — Git and Nomad hold all durable truth and a
 restart costs one diff cycle.
 
-The design proposals in `docs/proposals/` record the reasoning; read them
-before extending the apply side (deregister, checkpointing, Diun
-integration all remain unimplemented). `docs/prior-art.md` surveys the
-existing tooling (nomad-gitops-operator, nomad-ops, Levant, Waypoint) and
-explains the mistakes nomad-botherer deliberately avoids.
+The reasoning is recorded in two places: `docs/design/` holds the design
+records for shipped features (the register/apply path, update policies),
+and `docs/proposals/` holds not-yet-built ideas (automatic rollback,
+checkpointing, Diun integration). Read the relevant doc before extending
+the apply side; the register and deregister paths have shipped.
+`docs/prior-art.md` surveys the existing tooling (nomad-gitops-operator,
+nomad-ops, Levant, Waypoint) and explains the mistakes nomad-botherer
+deliberately avoids.
 
 ### Core design principles for the apply side (implemented — preserve them)
 

--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ each does and where each falls short, and describes the design decisions
 behind nomad-botherer's apply side: plan before every write, CAS on every
 register, opt-in scope, and never writing to Git.
 
-The design proposals that shaped the implementation are in
-[`docs/proposals/`](docs/proposals/).
+Design records for shipped features live in
+[`docs/design/`](docs/design/) (the thinking behind what was built);
+not-yet-built ideas live in [`docs/proposals/`](docs/proposals/).
 
 ---
 
@@ -501,8 +502,8 @@ Each update carries a stable ID (`<job_id>/<short_commit>`), the operation,
 status (`PENDING`, `IN_PROGRESS`, `SUCCEEDED`, `FAILED`, `SUPERSEDED`), the
 policy that allowed it, and the CAS token used.
 
-The design background is in `docs/proposals/gitops-job-updates.md` and
-`docs/proposals/update-policies.md`.
+The design background is in `docs/design/gitops-job-updates.md` and
+`docs/design/update-policies.md`.
 
 ### Deregistration (jobs removed from the repo)
 

--- a/docs/design/gitops-job-updates.md
+++ b/docs/design/gitops-job-updates.md
@@ -1,13 +1,22 @@
-# Proposal: GitOps job updates
+# Design: GitOps job updates
 
-**Status**: implemented (register path, in-memory queue) — see CHANGELOG  
-**Date**: 2026-05-13  
-**Updated**: 2026-06-11
+**Status**: implemented — apply/register path and async queue in v0.5.0,
+deregistration in v0.7.0. See the CHANGELOG.
+**Date**: 2026-05-13 (proposed) · moved to design 2026-06-17
 
-Related proposals: [change-checkpointing.md](change-checkpointing.md)
-(persisting queue state), [update-policies.md](update-policies.md) (per-job
-control over what gets applied), [diun-integration.md](diun-integration.md)
-(tracking upstream image updates).
+> This was a forward-looking proposal; it now records the thinking behind the
+> shipped implementation. **Alternative B (async queue with reconciliation
+> loop)** was chosen and the **in-process** applier (not the dispatched
+> executor). The code lives in `internal/nomad/` (`update.go`, `applier.go`,
+> `differ.go`). Where reality diverged from the proposal it is noted inline.
+> Some "open questions" at the end remain genuinely open.
+
+Related docs: [update-policies.md](update-policies.md) (per-job control over
+what gets applied — also implemented),
+[change-checkpointing.md](../proposals/change-checkpointing.md) (persisting
+queue state — the checkpoint store remains a proposal; the queue is in-memory),
+[diun-integration.md](../proposals/diun-integration.md) (tracking upstream
+image updates — proposed).
 
 ## Background
 
@@ -43,7 +52,7 @@ Not every diff becomes an update. Two filters sit between detection and
 enqueueing:
 
 - **Opt-in scope**: only jobs with `gitops_managed = "true"` are considered
-  at all (see [change-checkpointing.md](change-checkpointing.md),
+  at all (see [change-checkpointing.md](../proposals/change-checkpointing.md),
   Alternative 3).
 - **Per-job update policy**: the job's `gitops_update_policy` meta key
   (`full` / `image-only` / `none`) decides whether this *kind* of change may
@@ -191,7 +200,7 @@ What makes interruption at each point safe:
   current HEAD). A stored intent is never sufficient on its own, so a stale
   replayed intent is harmless by construction.
 
-The [checkpointing proposal](change-checkpointing.md) layers durability on
+The [checkpointing proposal](../proposals/change-checkpointing.md) layers durability on
 top of this for visibility and audit — an operator mid-rollout can see what
 was applied — but it is an optimisation, never a correctness dependency. If
 the checkpoint store is empty, wrong, or unreachable, the system falls back

--- a/docs/design/update-policies.md
+++ b/docs/design/update-policies.md
@@ -1,7 +1,15 @@
-# Proposal: per-job update policies
+# Design: per-job update policies
 
-**Status**: implemented (register path, in-memory queue) — see CHANGELOG  
-**Date**: 2026-06-11
+**Status**: implemented — v0.5.0 (`full`/`image-only`/`none`, the diff
+classifier), with later refinements (meta-only handling, pre-existing-drift
+gate) in v0.6.0. See the CHANGELOG.
+**Date**: 2026-06-11 (proposed) · moved to design 2026-06-17
+
+> This records the thinking behind the shipped policy model. One notable
+> change from the original proposal: the **default policy is `none`, not
+> `full`**, and there is no separate global apply switch — the policy flag is
+> the deployment-level gate (see the "policy key" section, corrected inline).
+> The classifier lives in `internal/nomad/classify.go`.
 
 ## Background
 
@@ -19,7 +27,7 @@ want drift *reported* but never applied.
 This proposal adds a per-job policy key to the existing meta opt-in mechanism,
 so that the degree of automation is declared in the job's HCL alongside the
 opt-in flag — version-controlled, reviewable, and human-written (no
-meta-drift; see [change-checkpointing.md](change-checkpointing.md)).
+meta-drift; see [change-checkpointing.md](../proposals/change-checkpointing.md)).
 
 ---
 
@@ -146,7 +154,7 @@ meta {
 }
 ```
 
-The [Diun integration proposal](diun-integration.md) reuses Diun's dotted
+The [Diun integration proposal](../proposals/diun-integration.md) reuses Diun's dotted
 `diun.*` meta vocabulary, and dotted keys require the object-expression form.
 HCL does not allow mixing the two forms in one block, so a job using both
 families of keys writes:
@@ -170,7 +178,7 @@ because the error HCL produces when you mix forms is unhelpful.
 This proposal governs the *downstream* direction: Git has changed, how much
 of that change may be applied to Nomad automatically.
 
-The [Diun integration proposal](diun-integration.md) governs the *upstream*
+The [Diun integration proposal](../proposals/diun-integration.md) governs the *upstream*
 direction: a newer image exists in a registry, but Git still pins the old
 tag. That is not drift — Git and Nomad agree — so no policy value causes it
 to be applied, and nomad-botherer does not even consume the notification:

--- a/docs/proposals/change-checkpointing.md
+++ b/docs/proposals/change-checkpointing.md
@@ -48,7 +48,7 @@ database, and records one considered-and-rejected alternative.
   comes from CAS and re-planning, and deregister safety comes from
   rechecking live state immediately before the call, not from remembered
   intent. See "Restart safety and recovery" in
-  [gitops-job-updates.md](gitops-job-updates.md). This rule is
+  [gitops-job-updates.md](../design/gitops-job-updates.md). This rule is
   exception-free: anything that would require nomad-botherer to hold
   non-recomputable state belongs outside the tool (the
   [Diun integration proposal](diun-integration.md) keeps once-only

--- a/docs/proposals/diun-integration.md
+++ b/docs/proposals/diun-integration.md
@@ -36,7 +36,7 @@ The constraints that frame the design:
    that is not this tool.
 2. **nomad-botherer acts only on Git and Nomad state.** Everything it knows
    must be recomputable from those two (see "Restart safety and recovery" in
-   [gitops-job-updates.md](gitops-job-updates.md)). Diun notifications are
+   [gitops-job-updates.md](../design/gitops-job-updates.md)). Diun notifications are
    delivered exactly once and are not recomputable, so nomad-botherer does
    not consume them.
 
@@ -78,7 +78,7 @@ managed jobs that meta is written in the HCL and flows to the live job
 through registration. So tag-filter policy remains version-controlled and
 reviewable even though nomad-botherer never touches Diun. (Dotted meta keys
 need HCL's object-expression form; see the syntax note in
-[update-policies.md](update-policies.md).)
+[update-policies.md](../design/update-policies.md).)
 
 Accepted tradeoffs of watching the cluster rather than the repo:
 
@@ -180,7 +180,7 @@ correctness and state are untouched. Tools like Renovate occupy the same
 seat (see [prior-art.md](../prior-art.md)).
 
 Either way, the merged PR is ordinary Git drift and flows through the apply
-path under the job's [update policy](update-policies.md) — for jobs set to
+path under the job's [update policy](../design/update-policies.md) — for jobs set to
 `image-only`, this circle is precisely the automation they opted into.
 
 ---

--- a/internal/nomad/update.go
+++ b/internal/nomad/update.go
@@ -121,7 +121,7 @@ const maxTerminalUpdates = 200
 // UpdateQueue is the in-memory queue between detection and application.
 // Restart loses it by design: the next diff cycle recreates any update whose
 // drift still exists, and CAS plus re-planning make a re-apply harmless. See
-// docs/proposals/gitops-job-updates.md ("Restart safety and recovery").
+// docs/design/gitops-job-updates.md ("Restart safety and recovery").
 type UpdateQueue struct {
 	mu      sync.Mutex
 	updates []*JobUpdate // newest last


### PR DESCRIPTION
Establishes a docs lifecycle and applies it:

- **`docs/proposals/`** — not-yet-built ideas.
- **`docs/design/`** — retrospective design records of shipped features (the *why* behind the implementation).

## Moves (tracked as renames)

- `gitops-job-updates.md` → `docs/design/` — register/apply path + async queue (v0.5.0), deregistration (v0.7.0). Retitled `# Design:`, status updated, notes that Alternative B (async queue) and the in-process applier were the choices made.
- `update-policies.md` → `docs/design/` — `full`/`image-only`/`none` policy model (v0.5.0). Retitled, status updated, notes the shipped default became `none` (not `full`) with no separate apply switch.

## Stays in `docs/proposals/`

- `change-checkpointing.md` — the checkpoint store is unimplemented (only the Alternative 3 meta opt-in shipped), so the doc stays.
- `diun-integration.md` — unimplemented.

## Link surgery

Every cross-reference fixed for the new locations: moved docs → `../proposals/…`; staying proposals → `../design/…`; and `README.md`, `CLAUDE.md`, `CHANGELOG.md`, and a code comment in `internal/nomad/update.go` now point at `docs/design/`. A script verified all `docs/` markdown links resolve; `go build`/`vet`/tests are clean (the only code change is a comment).

## Maintained going forward

Added a **rule in `CLAUDE.md`**: when a proposal's feature ships, `git mv` it to `docs/design/`, retitle, update status/divergences, and fix links — as part of the feature's own PR, so the split never drifts. Also saved to project memory.

## Note on merge order

This renames `docs/proposals/gitops-job-updates.md`, which the open **PR #62** (rollback research) edits in place (it adds a cross-link to `automatic-rollback.md`). Whichever merges second will hit a rename/edit conflict — trivial to resolve (keep this rename; re-apply #62's one-line cross-link under `docs/design/`). Happy to rebase whichever you merge second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)