### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## v0.8.0 — 2026-06-20
+
+Verified against Nomad 1.9.6, 1.10.5, 1.11.3, and 2.0.2 (full regression
+suite). See [docs/nomad-versions.md](docs/nomad-versions.md).
 
 ### New features
 

--- a/docs/nomad-versions.md
+++ b/docs/nomad-versions.md
@@ -22,6 +22,7 @@ After a successful run, add a row to the table below and update `tests/regressio
 
 | nomad-botherer | Nomad 1.9.x | Nomad 1.10.x | Nomad 1.11.x | Nomad 2.0.x | Notes |
 |----------------|:-----------:|:------------:|:------------:|:-----------:|-------|
+| v0.8.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Adds flap-loop guard and optional active rollback |
 | v0.7.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Adds deregistration of repo-removed jobs |
 | v0.6.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Full apply suite (policies, pre-existing drift, apply_action) |
 | v0.4.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    |       |

--- a/tests/regression/compat.go
+++ b/tests/regression/compat.go
@@ -52,6 +52,30 @@ type VersionRecord struct {
 var TestedVersions = []VersionRecord{
 	{
 		NomadVersion:    "2.0.2",
+		BothererRelease: "v0.8.0",
+		TestedAt:        time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.11.3",
+		BothererRelease: "v0.8.0",
+		TestedAt:        time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.10.5",
+		BothererRelease: "v0.8.0",
+		TestedAt:        time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.9.6",
+		BothererRelease: "v0.8.0",
+		TestedAt:        time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "2.0.2",
 		BothererRelease: "v0.7.0",
 		TestedAt:        time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC),
 		Passed:          true,


### PR DESCRIPTION
Cuts v0.8.0 (flap-loop guard + optional active rollback, merged in #64).

- Roll the rollback / flap-guard notes from `Unreleased` to `## v0.8.0` in the CHANGELOG.
- Record the full regression suite passing against Nomad **1.9.6, 1.10.5, 1.11.3, and 2.0.2** in `docs/nomad-versions.md` and `tests/regression/compat.go`.

Regression suite run today against all four versions — all green (~110s each). Unit suite green.

Merge this, then the `v0.8.0` tag goes on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)