### PR TITLE
Make all code gofmt clean

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Vet
-        run: go vet ./...
+      - name: Lint (gofmt + vet)
+        run: make lint
 
       - name: Test
         run: go test -race -timeout 60s -coverprofile=coverage.out -covermode=atomic ./...

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LDFLAGS := -X main.version=$(VERSION) \
 IMAGE     ?= ghcr.io/gerrowadat/$(BINARY)
 PLATFORMS := linux/amd64,linux/arm64
 
-.PHONY: all build install test test-regression test-regression-versions test-cover lint clean docker docker-push release-patch release-minor release-major version
+.PHONY: all build install test test-regression test-regression-versions test-cover fmt lint clean docker docker-push release-patch release-minor release-major version
 
 all: build
 
@@ -51,8 +51,18 @@ test-cover:
 	go test -race -timeout 60s -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
 
-## lint: run go vet
+## fmt: format all Go code with gofmt
+fmt:
+	gofmt -w .
+
+## lint: check gofmt formatting, then run go vet
 lint:
+	@unformatted=$$(gofmt -l .); \
+	if [ -n "$$unformatted" ]; then \
+		echo "These files are not gofmt-clean (run 'make fmt'):"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
 	go vet ./...
 
 ## clean: remove build artefacts

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,10 +10,10 @@ import (
 
 type Config struct {
 	// Git
-	RepoURL       string
-	Branch        string
-	PollInterval  time.Duration
-	HCLDir        string
+	RepoURL              string
+	Branch               string
+	PollInterval         time.Duration
+	HCLDir               string
 	GitToken             string
 	GitSSHKeyPath        string
 	GitSSHKeyPass        string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -422,7 +422,6 @@ func TestLoadFromArgs_StalenessIndependent(t *testing.T) {
 	}
 }
 
-
 func TestLoadFromArgs_ManagedMetaPrefixDefault(t *testing.T) {
 	os.Unsetenv("MANAGED_META_PREFIX")
 	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})

--- a/internal/gitwatch/watcher.go
+++ b/internal/gitwatch/watcher.go
@@ -14,9 +14,9 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
-	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -36,10 +36,10 @@ type Watcher struct {
 	triggerCh chan struct{}
 	onChange  func(commit string)
 
-	gitFetches          prometheus.Counter
-	gitFetchErrors      prometheus.Counter
-	gitLastUpdate       prometheus.Gauge
-	staleRefreshes      prometheus.Counter
+	gitFetches     prometheus.Counter
+	gitFetchErrors prometheus.Counter
+	gitLastUpdate  prometheus.Gauge
+	staleRefreshes prometheus.Counter
 }
 
 // New creates a Watcher that registers metrics into the default Prometheus registry.

--- a/internal/gitwatch/watcher_test.go
+++ b/internal/gitwatch/watcher_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
-	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -354,10 +354,10 @@ func TestWatcher_ReadHCLFiles_Subdir(t *testing.T) {
 
 func TestWatcher_ReadHCLFiles_NonHCLIgnored(t *testing.T) {
 	repo := makeTestRepo(t, map[string]string{
-		"job.hcl":    `job "x" {}`,
-		"job.json":   `{}`,
-		"job.yml":    ``,
-		"README.md":  `# docs`,
+		"job.hcl":      `job "x" {}`,
+		"job.json":     `{}`,
+		"job.yml":      ``,
+		"README.md":    `# docs`,
 		"nested/x.hcl": `job "nested" {}`,
 	})
 	w := &Watcher{cfg: &config.Config{HCLDir: ""}, repo: repo}

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -271,18 +271,18 @@ type Differ struct {
 	lastNomadIndex uint64               // Raft index from the last successful List(); protected by mu
 	driftFirstSeen map[string]time.Time // key: driftKey(jobID, diffType); protected by mu
 
-	hclParseErrors   prometheus.Counter
-	hclFilesSkipped  prometheus.Counter
-	diffChecks       prometheus.Counter
+	hclParseErrors    prometheus.Counter
+	hclFilesSkipped   prometheus.Counter
+	diffChecks        prometheus.Counter
 	diffChecksSkipped prometheus.Counter
-	staleChecks      prometheus.Counter
-	redactedFields   prometheus.Counter
-	jobsSkippedBySel *prometheus.CounterVec
-	nomadAPIErrors   *prometheus.CounterVec
-	lastCheck        prometheus.Gauge
-	jobDiffs         *prometheus.GaugeVec
-	driftedJobs      *prometheus.GaugeVec
-	jobDriftSince    *prometheus.GaugeVec
+	staleChecks       prometheus.Counter
+	redactedFields    prometheus.Counter
+	jobsSkippedBySel  *prometheus.CounterVec
+	nomadAPIErrors    *prometheus.CounterVec
+	lastCheck         prometheus.Gauge
+	jobDiffs          *prometheus.GaugeVec
+	driftedJobs       *prometheus.GaugeVec
+	jobDriftSince     *prometheus.GaugeVec
 
 	updatesBlockedByPolicy         *prometheus.CounterVec
 	updatesBlockedCreationDisabled *prometheus.CounterVec
@@ -325,12 +325,12 @@ func newDifferBase(jobs NomadJobsClient, cfg *config.Config, reg prometheus.Regi
 
 	f := promauto.With(reg)
 	d := &Differ{
-		jobs:              jobs,
-		namespace:         cfg.NomadNamespace,
-		includeDeadJobs:   cfg.IncludeDeadJobs,
-		jobSelectorGlob:   cfg.JobSelectorGlob,
-		managedMetaPrefix: cfg.ManagedMetaPrefix,
-		redactSecrets:     cfg.RedactSecrets,
+		jobs:                 jobs,
+		namespace:            cfg.NomadNamespace,
+		includeDeadJobs:      cfg.IncludeDeadJobs,
+		jobSelectorGlob:      cfg.JobSelectorGlob,
+		managedMetaPrefix:    cfg.ManagedMetaPrefix,
+		redactSecrets:        cfg.RedactSecrets,
 		defaultPolicy:        defaultPolicy,
 		enableJobCreation:    cfg.EnableJobCreation,
 		applyMetaOnlyChanges: cfg.ApplyMetaOnlyChanges,
@@ -343,9 +343,9 @@ func newDifferBase(jobs NomadJobsClient, cfg *config.Config, reg prometheus.Regi
 		flapGuard:            flapGuard,
 		allowRollback:        cfg.AllowRollback,
 		applyInterval:        applyInterval,
-		updateQueue:       NewUpdateQueue(),
-		applyCh:           make(chan struct{}, 1),
-		driftFirstSeen:    make(map[string]time.Time),
+		updateQueue:          NewUpdateQueue(),
+		applyCh:              make(chan struct{}, 1),
+		driftFirstSeen:       make(map[string]time.Time),
 		hclParseErrors: f.NewCounter(prometheus.CounterOpts{
 			Name: "nomad_botherer_hcl_parse_errors_total",
 			Help: "Total number of HCL files that failed to parse as Nomad job definitions.",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,9 +55,9 @@ type Server struct {
 	mux       *http.ServeMux
 	handler   http.Handler // mux wrapped in securityHeaders
 
-	webhookMu               sync.RWMutex
-	lastWebhookSuccess      time.Time
-	lastWebhookFailure      time.Time
+	webhookMu          sync.RWMutex
+	lastWebhookSuccess time.Time
+	lastWebhookFailure time.Time
 
 	// Prometheus metrics
 	webhookEvents           *prometheus.CounterVec

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -626,7 +626,7 @@ func TestHealthz_NotReady_Returns503(t *testing.T) {
 func TestHealthz_GitNotReady_Returns503(t *testing.T) {
 	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main"}
 	diffSrc := &mockDiffSource{lastCheck: time.Now(), lastCommit: "abc"} // diffs ready
-	gitSrc := &mockGitSource{}                                            // git not ready
+	gitSrc := &mockGitSource{}                                           // git not ready
 	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
 
 	rec := httptest.NewRecorder()
@@ -638,7 +638,7 @@ func TestHealthz_GitNotReady_Returns503(t *testing.T) {
 
 func TestHealthz_DiffsNotReady_Returns503(t *testing.T) {
 	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main"}
-	diffSrc := &mockDiffSource{}                                                // diffs not ready
+	diffSrc := &mockDiffSource{}                                        // diffs not ready
 	gitSrc := &mockGitSource{lastCommit: "abc", lastUpdate: time.Now()} // git ready
 	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
 
@@ -997,7 +997,7 @@ func TestAPI_NotReady_Status_Returns503(t *testing.T) {
 	const key = "testkey"
 	cfg := &config.Config{ListenAddr: ":0", WebhookPath: "/webhook", Branch: "main", APIKey: key}
 	diffSrc := &mockDiffSource{lastCheck: time.Now()} // diffs ready
-	gitSrc := &mockGitSource{}                         // git NOT ready (zero lastUpdate)
+	gitSrc := &mockGitSource{}                        // git NOT ready (zero lastUpdate)
 	srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)

--- a/tests/regression/infra_test.go
+++ b/tests/regression/infra_test.go
@@ -551,9 +551,9 @@ type mockGitSource struct {
 	triggered bool
 }
 
-func (m *mockGitSource) Trigger()                           { m.triggered = true }
-func (m *mockGitSource) Status() (string, time.Time)        { return "deadbeef", time.Now() }
-func (m *mockGitSource) Ready() bool                        { return m.ready }
+func (m *mockGitSource) Trigger()                    { m.triggered = true }
+func (m *mockGitSource) Status() (string, time.Time) { return "deadbeef", time.Now() }
+func (m *mockGitSource) Ready() bool                 { return m.ready }
 
 // ── Full binary helpers ───────────────────────────────────────────────────────
 

--- a/tests/regression/security_test.go
+++ b/tests/regression/security_test.go
@@ -59,10 +59,10 @@ func TestSecurity_Webhook_InvalidHMAC(t *testing.T) {
 
 	for _, badSig := range []string{
 		"sha256=" + strings.Repeat("0", 64), // all-zero signature
-		"sha256=",                            // empty hex after prefix
-		wrongSig,                             // correct format, wrong secret
+		"sha256=",                           // empty hex after prefix
+		wrongSig,                            // correct format, wrong secret
 		"sha1=" + strings.Repeat("0", 40),   // wrong algorithm prefix
-		"invalid-format",                     // no prefix at all
+		"invalid-format",                    // no prefix at all
 	} {
 		t.Run(fmt.Sprintf("sig=%q", badSig[:min(len(badSig), 20)]), func(t *testing.T) {
 			req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(body))
@@ -377,4 +377,3 @@ func minimalPushPayload(branch string) []byte {
 		}
 	}`, branch))
 }
-


### PR DESCRIPTION
Brings the codebase to gofmt-clean and keeps it that way.

## Format

Runs `gofmt -w` across the repo. Several files had drifted out of gofmt formatting (struct field/comment alignment, import ordering within groups, a couple of stray blank lines). Formatting only — no behaviour change. The only non-whitespace changes (`git diff --ignore-all-space`) are gofmt sorting two import lines and removing two blank lines.

## Guard against re-drift

`make lint` only ran `go vet`, which is why the formatting slipped. Now:

- New `make fmt` target — `gofmt -w .`.
- `make lint` checks `gofmt -l` first (failing with the offending file list and a "run `make fmt`" hint) and then runs `go vet`.
- CI's lint step runs `make lint`, so the same gofmt + vet check guards local runs and every pull request.

## Verified

- `gofmt -l` reports nothing.
- `make lint` passes; an intentionally-unformatted file makes it fail with a clear message.
- `go build ./...` and `go build -tags=regression ./tests/regression/` succeed; `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
