### PR TITLE
Defer drift accumulated under a stricter policy on widening (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,24 @@
   ACL-enabled Nomad: static token vs anonymous denial, token-file and
   auto-detected workload-identity auth, and live token rotation.
 
+### Changed
+
+- **A `gitops_update_policy` widening now defers drift that accumulated under the
+  stricter policy, the same way a job's opt-in does (issue #69).** Previously,
+  switching a job `image-only` → `full` (or `none` → either) applied *all* current
+  drift on the next reconcile — including non-image changes committed earlier and
+  deliberately deferred while the job was `image-only`. That is now treated as
+  pre-existing drift and held by default, exactly like drift that pre-dates a
+  job gaining the `gitops_managed` tag: changing scope expresses intent about
+  future reconciliation, not "deploy the backlog now". The existing
+  `--apply-existing-drift` / `APPLY_EXISTING_DRIFT` flag (default off) governs
+  both cases — set it to restore the previous apply-everything-on-promotion
+  behaviour. Drift on a job whose scope did not change reconciles normally. The
+  decision is git-history-derived (no new state); surfaced as before by
+  `apply_action=blocked_preexisting_drift` and
+  `nomad_botherer_updates_blocked_preexisting_total`. See the README
+  "Drift that pre-dates a scope change" section and `docs/design/update-policies.md`.
+
 ## v0.8.0 — 2026-06-20
 
 Verified against Nomad 1.9.6, 1.10.5, 1.11.3, and 2.0.2 (full regression

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ Every flag has a corresponding environment variable. Environment variables are r
 | `--apply-interval` | `APPLY_INTERVAL` | `10s` | Fallback cadence of the apply loop; enqueued updates are also applied immediately. |
 | `--apply-meta-only-changes` | `APPLY_META_ONLY_CHANGES` | `false` | Apply a diff whose only change is to nomad-botherer's own meta keys (e.g. `gitops_managed`). Off by default — re-registering a running job just to push these keys is disruptive and unnecessary; they ride along the next real update. |
 | `--count-meta-only-changes` | `COUNT_META_ONLY_CHANGES` | `false` | Count a managed-meta-only diff as drift (surface it on `/diffs`, `/healthz`, and the drift metrics). Off by default so these expected differences do not trigger alerts. |
-| `--apply-existing-drift` | `APPLY_EXISTING_DRIFT` | `false` | When a job gains the managed meta tag while nomad-botherer is running, apply drift that already existed at that moment. Off by default — opting a job in does not retroactively mutate it; only changes committed after opt-in apply. Jobs already managed at startup reconcile normally. |
+| `--apply-existing-drift` | `APPLY_EXISTING_DRIFT` | `false` | When a change widens a job's scope, apply drift that already existed at that moment. Scope widens two ways, treated identically: a job gains the managed meta tag (enablement), or its update policy is widened to cover drift it was deferring (e.g. `image-only` → `full`). Off by default — a scope change does not retroactively mutate the job; only changes committed after it apply. See [Drift that pre-dates a scope change](#drift-that-pre-dates-a-scope-change-opt-in-or-policy-widening). |
 | `--enable-deregister` | `ENABLE_DEREGISTER` | `false` | Deregister jobs removed from the repo entirely (HCL file deleted or job renamed) while still running. Off by default. Only acts on a live job carrying `gitops_managed=true` whose effective policy is `full`, and only after it has been orphaned for `--deregister-grace`. Removing only the tag (job still in the repo) never deregisters. See [Deregistration](#deregistration-jobs-removed-from-the-repo). |
 | `--deregister-purge` | `DEREGISTER_PURGE` | `false` | Purge the job from Nomad's state immediately instead of a graceful stop (queryable, GC'd later). |
 | `--deregister-grace` | `DEREGISTER_GRACE` | `5m` | How long a job must be continuously orphaned before being deregistered. Absorbs transient renames and mid-edit commits. |
@@ -536,31 +536,46 @@ and `--count-meta-only-changes` makes it count as drift. A diff that mixes a
 meta-key change with any *other* change is a normal diff and is unaffected by
 these flags.
 
-### Opting in a job that already drifted
+### Drift that pre-dates a scope change (opt-in or policy widening)
 
-When you add the meta tag to a job that *already* differs from its HCL — say
-you bumped its image in Git a while ago, and only now add `gitops_managed` —
-that drift is **pre-existing**: it was there before the job entered scope.
-By default nomad-botherer does **not** apply it. Opting a job into management
-should not, on its own, trigger a mutation based on drift you may not have
-reviewed; only changes committed *after* the tag is added are applied.
+A change can bring drift that was already there *into scope* to apply. Two such
+changes are treated **identically**:
 
-Set `--apply-existing-drift` to apply pre-existing drift at opt-in instead —
-then the job converges to its HCL as soon as the tag lands.
+- **Enablement** — you add `gitops_managed` to a job that already differs from
+  its HCL (say you bumped its image in Git a while ago, and only now opt it in).
+- **Policy widening** — you widen a managed job's `gitops_update_policy` to cover
+  drift the stricter policy had been deferring. The motivating case: an
+  `image-only` job has a non-image change (e.g. a memory bump) sitting unapplied;
+  you then switch it to `full`. The memory change was live drift the whole time,
+  merely held back by `image-only`.
+
+In both cases the drift is **pre-existing**, and by default nomad-botherer does
+**not** apply it. Changing a job's scope expresses intent about *future*
+reconciliation, not "deploy the backlog now": it should not, on its own, trigger
+a mutation from drift you may not have intended to ship at that moment. Only
+changes committed *after* the scope change apply.
+
+Set `--apply-existing-drift` to apply pre-existing drift at the scope change
+instead — then the job converges to its HCL as soon as the change lands. This is
+one switch for both cases, deliberately, so enablement and policy promotion never
+diverge (see [issue #69](https://github.com/gerrowadat/nomad-botherer/issues/69)).
 
 The decision is made from **git history**, so it holds the same whether the
-tag is added while nomad-botherer is running or before it starts (a fresh
-start or a restart). For a job's HCL file, the rule is: if the managed tag
-was present in the commit *before* HEAD, the job was already managed and its
-drift reconciles normally; if the tag was *added* in the HEAD commit (the
-file existed before without it), the drift pre-dates opt-in and is held. A
-file created with the tag in a single commit is not a retroactive opt-in —
-the tag and the spec arrived together — so it applies. Because the signal is
-git-derived rather than remembered, a restart never freezes an
-already-managed cluster. Jobs selected by `--job-selector-glob` are always in
-scope and have no opt-in moment, so this gate never applies to them. The
-freeze is counted in `nomad_botherer_updates_blocked_preexisting_total{job}`,
-and each held diff is shown on `/diffs` and the API with its reason (see
+change lands while nomad-botherer is running or before it starts (a fresh start
+or a restart). For a job's HCL file at HEAD, the rule is: a diff is pre-existing
+if it would **not** have been applied under the job's effective scope in the
+commit *before* HEAD — the job was unmanaged there, or its policy there did not
+cover this diff's class — but the scope at HEAD does cover it. A job whose tag
+and policy were already established before HEAD reconciles normally; a file
+created with the tag in a single commit is not a retroactive opt-in (the tag and
+spec arrived together) so it applies. Because the signal is git-derived rather
+than remembered, a restart never freezes an already-managed cluster. Jobs
+selected by `--job-selector-glob` are always in scope and have no opt-in moment,
+so this gate never applies to them. (The global `--default-update-policy` is not
+a per-job git change, so changing *that* flag is not detected as a per-job scope
+widening.) The freeze is counted in
+`nomad_botherer_updates_blocked_preexisting_total{job}`, and each held diff is
+shown on `/diffs` and the API with its reason (see
 [Why a diff is or is not applied](#why-a-diff-is-or-is-not-applied)).
 
 ### What gets applied, and how
@@ -645,7 +660,7 @@ documented in the OpenAPI spec. Values:
 |---|---|
 | `queued` | An update was enqueued and will be applied. |
 | `blocked_by_policy` | The effective update policy disallows it (e.g. `none`, or `image-only` for a non-image change). |
-| `blocked_preexisting_drift` | The drift pre-dates the job's opt-in; set `--apply-existing-drift` to apply. |
+| `blocked_preexisting_drift` | The drift pre-dates the scope change that brought it in — the job's opt-in, or a policy widening (e.g. `image-only` → `full`); set `--apply-existing-drift` to apply. |
 | `blocked_creation_disabled` | First-time registration needs `--enable-job-creation`. |
 | `skipped_meta_only` | The change is confined to `gitops_*` meta keys (only shown when `--count-meta-only-changes` is on). |
 | `observation_only` | `missing_from_hcl`: running but absent from the repo, left untouched (deregistration disabled, or the job is not deregister-eligible). |
@@ -897,7 +912,7 @@ These counters and timestamps describe the diff check loop itself — how often 
 | `nomad_botherer_meta_key_issues_total` | Counter | `job`, `issue` | Job meta keys under the managed prefix that nomad-botherer cannot act on: `unknown_key` (e.g. a typo like `gitops_managd` or `gitops.managed`) or `invalid_value` (a recognised key with an unusable value, e.g. `gitops_managed = "True"`). Counted every cycle the issue persists; logged once per unique issue (WARN for unknown keys, ERROR for bad values). |
 | `nomad_botherer_meta_key_changes_total` | Counter | `job`, `source` | Managed-prefix meta keys added, removed, or changed between check cycles, on the HCL side (a commit changed them) or the live side (someone re-registered the job manually). Each transition is also logged at INFO with the behavioural consequence. |
 | `nomad_botherer_meta_only_diffs_total` | Counter | `job` | Diffs confined to nomad-botherer's own meta keys, detected per check cycle. By default these are neither counted as drift nor applied (`--count-meta-only-changes`, `--apply-meta-only-changes`); they converge on the next real update. A non-zero rate is normal after opting a running job in via a commit. |
-| `nomad_botherer_updates_blocked_preexisting_total` | Counter | `job` | Updates not enqueued because the drift pre-existed the job entering scope (opt-in via meta tag while running). Enable applying it with `--apply-existing-drift`. |
+| `nomad_botherer_updates_blocked_preexisting_total` | Counter | `job` | Updates not enqueued because the drift pre-dated a scope change that brought it in — the job's opt-in (managed tag added) or a policy widening (e.g. `image-only` → `full`). Enable applying it with `--apply-existing-drift`. |
 | `nomad_botherer_jobs_left_management_total` | Counter | `job`, `reason` | Managed jobs that left GitOps management, by reason: `tag_removed` (the managed tag was dropped from HCL) or `removed_from_repo` (HCL file deleted or job renamed). Counted once per transition. |
 | `nomad_botherer_job_updates_total` (operation=`DEREGISTER`) | Counter | `operation`, `status` | Deregistrations reaching a terminal state. See [Deregistration](#deregistration-jobs-removed-from-the-repo). |
 | `nomad_botherer_updates_blocked_known_failed_total` | Counter | `job` | Registrations withheld by the flap-loop guard because the spec matches a recent failed deployment. A persistent non-zero value means a job is stuck on a known-bad commit awaiting a fix in Git. See [Rollback](#rollback-recovering-from-a-bad-change). |

--- a/docs/design/update-policies.md
+++ b/docs/design/update-policies.md
@@ -2,7 +2,8 @@
 
 **Status**: implemented — v0.5.0 (`full`/`image-only`/`none`, the diff
 classifier), with later refinements (meta-only handling, pre-existing-drift
-gate) in v0.6.0. See the CHANGELOG.
+gate) in v0.6.0, and the policy-widening ruling (issue #69) after v0.8.0.
+See the CHANGELOG.
 **Date**: 2026-06-11 (proposed) · moved to design 2026-06-17
 
 > This records the thinking behind the shipped policy model. One notable
@@ -98,6 +99,75 @@ The policy is read from the *HCL side* (the parsed job in Git) when both
 sides exist, because Git is the source of truth for intent. For
 `missing_from_hcl` there is no HCL; the live job's meta is all we have, which
 is consistent with the deregister guard already reading the live meta.
+
+---
+
+## Changing a policy: drift that accumulated under the stricter policy (issue #69)
+
+When a managed job's `gitops_update_policy` is widened — `image-only` → `full`,
+or `none` → either — the next reconcile could apply drift that was **live the
+whole time but deferred by the stricter policy**. The motivating case: an
+`image-only` job has a memory bump committed earlier and sitting unapplied
+(correctly held by `image-only`); the operator then switches it to `full`. Should
+the memory change ride along with the policy flip?
+
+**Ruling: no, not by default. A policy widening is treated exactly like a job's
+opt-in.** The reconciler already has a "pre-existing drift" gate
+(`--apply-existing-drift`, default off) for the enablement case: when a job gains
+`gitops_managed`, drift that pre-dates the opt-in is not retroactively applied;
+only changes committed *after* the opt-in apply. A policy widening is the same
+kind of event — it brings drift *into scope to apply* — so it gets the same
+treatment and the same switch.
+
+This was chosen over "apply all current drift on the switch" (the v0.8.0
+behaviour) because:
+
+- **Consistency.** Enablement and promotion are both "scope-widening" events;
+  having them behave differently is surprising and was never a deliberate
+  decision. One rule, one flag.
+- **Least astonishment.** Changing a policy expresses intent about *future*
+  reconciliation, not "deploy the backlog now." Bundling an older,
+  deliberately-deferred change into the same reconcile as the policy flip can
+  ship a change at a moment the operator didn't choose.
+- **It's free of new state.** The signal is git history, which is already used
+  for the opt-in gate.
+
+### How it is decided
+
+Generalise the opt-in test from "was the managed tag present at the parent
+commit?" to "**would this diff have been applied under the job's effective scope
+at the parent commit?**" A diff is pre-existing iff it would *not* have been
+applied at the parent (the job was unmanaged there, or the parent's policy did
+not cover this diff's class) but the scope at HEAD *does* cover it. Both inputs
+come from the parent version of the job's HCL file (`HistorySource.FileAtParentOf`):
+the managed tag via the existing regexp, the policy via a second regexp reading
+`<prefix>_update_policy`. `policyPermits(policy, class)` mirrors the apply-time
+policy gate.
+
+Worked outcomes (default `--apply-existing-drift=false`):
+
+| parent policy | HEAD policy | diff class | applied at HEAD? |
+|---|---|---|---|
+| image-only | full | other (e.g. memory) | **deferred** (came into scope) |
+| image-only | full | image | applied (was already in scope) |
+| none | full / image-only | any | **deferred** |
+| full | full | any | applied (no widening) |
+| full | image-only | other | n/a — blocked by HEAD policy anyway |
+
+With `--apply-existing-drift=true`, every "deferred" above applies immediately.
+
+### Boundaries
+
+- A change bundled into the *same commit* as the widening is deferred (it did not
+  predate the widening, but neither was it committed after it) — consistent with
+  the opt-in rule, where drift in the opt-in commit is deferred and only later
+  commits apply.
+- A managed-meta-only diff (the policy flip with no other drift) is governed by
+  the meta-only gate, not this one.
+- The global `--default-update-policy` flag is not a per-job git change, so
+  changing *that* is not detected as a per-job widening; only the per-job meta
+  key's history is consulted.
+- Glob-selected jobs have no opt-in moment and are exempt, as before.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,9 +58,11 @@ type Config struct {
 	CountMetaOnlyChanges bool
 
 	// ApplyExistingDrift controls whether drift that already existed when a
-	// job entered management scope (gained the meta tag while the process was
-	// running) is applied. Off by default: opting a job in does not retroactively
-	// mutate it; only changes committed after opt-in apply.
+	// change widened a job's scope is applied. Scope widens two ways, treated
+	// the same: a job gains the managed meta tag (enablement), or its update
+	// policy is widened to cover drift it was deferring (e.g. image-only → full).
+	// Off by default: a scope change does not retroactively mutate the job; only
+	// changes committed after it apply.
 	ApplyExistingDrift bool
 
 	// Deregistration of jobs removed from the repo (file deleted or job
@@ -141,7 +143,7 @@ func LoadFromArgs(fs *flag.FlagSet, args []string) (*Config, error) {
 	fs.DurationVar(&c.ApplyInterval, "apply-interval", envDurationOrDefault("APPLY_INTERVAL", 10*time.Second), "Fallback cadence of the apply loop; enqueued updates are also applied immediately")
 	fs.BoolVar(&c.ApplyMetaOnlyChanges, "apply-meta-only-changes", envBoolOrDefault("APPLY_META_ONLY_CHANGES", false), "Apply a diff whose only change is to nomad-botherer's own meta keys (e.g. gitops_managed). Off by default: re-registering a running job just to push these keys is disruptive and unnecessary (the HCL is already authoritative), so they ride along the next real update instead.")
 	fs.BoolVar(&c.CountMetaOnlyChanges, "count-meta-only-changes", envBoolOrDefault("COUNT_META_ONLY_CHANGES", false), "Count a managed-meta-only diff as drift (surface it on /diffs, /healthz, and the drift metrics). Off by default so these expected differences do not trigger drift alerts.")
-	fs.BoolVar(&c.ApplyExistingDrift, "apply-existing-drift", envBoolOrDefault("APPLY_EXISTING_DRIFT", false), "When a job enters management scope (gains the managed meta tag while nomad-botherer is running), apply drift that already existed at that moment. Off by default (conservative): opting a job in does not retroactively mutate it; only changes committed after opt-in apply. Jobs already managed when the process starts are unaffected — their drift reconciles normally.")
+	fs.BoolVar(&c.ApplyExistingDrift, "apply-existing-drift", envBoolOrDefault("APPLY_EXISTING_DRIFT", false), "When a change widens a job's scope, apply drift that already existed at that moment. Scope widens two ways, treated the same: a job gains the managed meta tag (enablement), or its update policy is widened to cover drift it was deferring (e.g. image-only → full applying a non-image change committed earlier). Off by default (conservative): a scope change does not retroactively mutate the job; only changes committed after it apply. Drift reconciles normally when scope is unchanged.")
 	fs.BoolVar(&c.EnableDeregister, "enable-deregister", envBoolOrDefault("ENABLE_DEREGISTER", false), "Deregister jobs that were removed from the repo entirely (HCL file deleted or job renamed) while still running in Nomad. Off by default. Only ever acts on a job carrying gitops_managed=true in its live meta whose effective update policy is full, and only after it has been continuously orphaned for --deregister-grace. Removing only the gitops_managed tag (with the job still in the repo) never deregisters — it just stops management.")
 	fs.BoolVar(&c.DeregisterPurge, "deregister-purge", envBoolOrDefault("DEREGISTER_PURGE", false), "When deregistering, purge the job from Nomad's state immediately instead of a graceful stop (which leaves it queryable and garbage-collected later). Off by default.")
 	fs.DurationVar(&c.DeregisterGrace, "deregister-grace", envDurationOrDefault("DEREGISTER_GRACE", 5*time.Minute), "How long a job must be continuously orphaned (running in Nomad, removed from the repo) before it is deregistered. Absorbs transient renames and mid-edit commits.")

--- a/internal/nomad/apply_test.go
+++ b/internal/nomad/apply_test.go
@@ -632,20 +632,21 @@ func TestApply_ExistingDrift_TagAddedAtHead_AppliedWithFlag(t *testing.T) {
 }
 
 // TestApply_ExistingDrift_TagPresentAtParent_Applied is the established /
-// reconcile-on-start case: the tag was already present before HEAD, so the job
-// is not freshly opted in and its drift reconciles normally.
+// reconcile-on-start case: the tag and the same effective policy were already
+// present before HEAD, so the job is not freshly opted in, its scope did not
+// widen, and its drift reconciles normally.
 func TestApply_ExistingDrift_TagPresentAtParent_Applied(t *testing.T) {
 	var calls []registerCall
 	d := nomad.NewWithClient(metaSelectCfg(false), optInMock(&calls))
 	d.SetHistorySource(fakeHistory{parent: map[string]string{
-		testJobFile: `job "test-job" { meta { gitops_managed = "true" } }`,
+		testJobFile: `job "test-job" { meta { gitops_managed = "true" gitops_update_policy = "full" } }`,
 	}})
 
 	runCheck(t, d, "aaaa111fffff")
 	nomad.DrainUpdates(d)
 
 	if len(calls) != 1 {
-		t.Errorf("an established job (tag present before HEAD) should reconcile, got %d calls", len(calls))
+		t.Errorf("an established job (tag and policy present before HEAD) should reconcile, got %d calls", len(calls))
 	}
 }
 
@@ -694,5 +695,120 @@ func TestApply_ExistingDrift_FileNewAtHead_Applied(t *testing.T) {
 
 	if len(calls) != 1 {
 		t.Errorf("a file created with the tag at HEAD should apply (tag present when spec introduced), got %d calls", len(calls))
+	}
+}
+
+// promotionMock builds a mock for a job managed at HEAD with the given policy,
+// drifting against the live job per planDiff.
+func promotionMock(policy string, planDiff *nomadapi.JobDiff, calls *[]registerCall) *mockJobsClient {
+	return applyMock(map[string]string{
+		"gitops_managed": "true", "gitops_update_policy": policy,
+	}, planDiff, 42, calls)
+}
+
+// parentWithPolicy is a history source whose parent version of the job file is
+// managed with the given policy.
+func parentWithPolicy(policy string) fakeHistory {
+	return fakeHistory{parent: map[string]string{
+		testJobFile: fmt.Sprintf(`job "test-job" { meta { gitops_managed = "true" gitops_update_policy = %q } }`, policy),
+	}}
+}
+
+// Issue #69: a policy change that widens what is applied (e.g. image-only → full)
+// must treat drift that accumulated under the stricter policy the same way an
+// opt-in treats pre-existing drift — deferred by default, applied with the flag.
+
+func TestApply_PolicyPromotion_ImageOnlyToFull_DefersAccumulatedDrift(t *testing.T) {
+	var calls []registerCall
+	d := nomad.NewWithClient(metaSelectCfg(false), promotionMock("full", editedMixedDiff(), &calls))
+	d.SetHistorySource(parentWithPolicy("image-only"))
+
+	runCheck(t, d, "aaaa111fffff")
+	nomad.DrainUpdates(d)
+
+	if len(calls) != 0 {
+		t.Errorf("non-image drift accumulated under image-only must not apply on promotion to full by default, got %d calls", len(calls))
+	}
+	if got := testutil.ToFloat64(nomad.UpdatesBlockedExistingDrift(d).WithLabelValues("test-job")); got != 1 {
+		t.Errorf("blocked-preexisting metric: want 1, got %v", got)
+	}
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 1 || diffs[0].ApplyAction != nomad.ApplyActionPreExisting {
+		t.Errorf("diff should surface the pre-existing reason, got %+v", diffs)
+	}
+}
+
+func TestApply_PolicyPromotion_ImageOnlyToFull_AppliedWithFlag(t *testing.T) {
+	var calls []registerCall
+	d := nomad.NewWithClient(metaSelectCfg(true), promotionMock("full", editedMixedDiff(), &calls))
+	d.SetHistorySource(parentWithPolicy("image-only"))
+
+	runCheck(t, d, "aaaa111fffff")
+	nomad.DrainUpdates(d)
+
+	if len(calls) != 1 {
+		t.Errorf("with --apply-existing-drift the accumulated drift should apply on promotion, got %d calls", len(calls))
+	}
+}
+
+func TestApply_PolicyPromotion_NoneToFull_DefersAccumulatedDrift(t *testing.T) {
+	// none → full: all drift was out of scope under none, so it is pre-existing.
+	var calls []registerCall
+	d := nomad.NewWithClient(metaSelectCfg(false), promotionMock("full", editedMixedDiff(), &calls))
+	d.SetHistorySource(parentWithPolicy("none"))
+
+	runCheck(t, d, "aaaa111fffff")
+	nomad.DrainUpdates(d)
+
+	if len(calls) != 0 {
+		t.Errorf("drift accumulated under none must not apply on promotion to full by default, got %d calls", len(calls))
+	}
+}
+
+func TestApply_PolicyPromotion_ImageDriftRemainsInScope_Applies(t *testing.T) {
+	// image-only → full where the pending drift is image-class: it was already in
+	// scope under image-only, so promotion does not defer it.
+	var calls []registerCall
+	d := nomad.NewWithClient(metaSelectCfg(false), promotionMock("full", editedImageDiff(), &calls))
+	d.SetHistorySource(parentWithPolicy("image-only"))
+
+	runCheck(t, d, "aaaa111fffff")
+	nomad.DrainUpdates(d)
+
+	if len(calls) != 1 {
+		t.Errorf("image drift already in scope under image-only should apply on promotion to full, got %d calls", len(calls))
+	}
+}
+
+func TestApply_PolicyStable_NoWidening_Applies(t *testing.T) {
+	// Same policy (full) at parent and HEAD: no widening, so drift reconciles
+	// normally even though it pre-dates the commit being evaluated.
+	var calls []registerCall
+	d := nomad.NewWithClient(metaSelectCfg(false), promotionMock("full", editedMixedDiff(), &calls))
+	d.SetHistorySource(parentWithPolicy("full"))
+
+	runCheck(t, d, "aaaa111fffff")
+	nomad.DrainUpdates(d)
+
+	if len(calls) != 1 {
+		t.Errorf("a stable full policy should reconcile drift normally, got %d calls", len(calls))
+	}
+}
+
+func TestApply_PolicyPromotion_MetaOnlyChange_NotPreExisting(t *testing.T) {
+	// A commit that only changes gitops_* meta (no other drift) is governed by
+	// the meta-only gate, not the pre-existing gate.
+	var calls []registerCall
+	d := nomad.NewWithClient(metaSelectCfg(false), promotionMock("full", metaOnlyManagedDiff(), &calls))
+	d.SetHistorySource(parentWithPolicy("image-only"))
+
+	runCheck(t, d, "aaaa111fffff")
+	nomad.DrainUpdates(d)
+
+	if got := testutil.ToFloat64(nomad.UpdatesBlockedExistingDrift(d).WithLabelValues("test-job")); got != 0 {
+		t.Errorf("a meta-only change must not be flagged pre-existing, got %v", got)
+	}
+	if len(calls) != 0 {
+		t.Errorf("a meta-only change should not register by default, got %d calls", len(calls))
 	}
 }

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -86,7 +86,8 @@ const (
 	ApplyActionQueued ApplyAction = "queued"
 	// ApplyActionPolicyBlocked means the effective update policy disallows it.
 	ApplyActionPolicyBlocked ApplyAction = "blocked_by_policy"
-	// ApplyActionPreExisting means the drift pre-dated the job's opt-in.
+	// ApplyActionPreExisting means the drift pre-dated the scope change that
+	// brought it into scope — the job's opt-in, or a policy widening.
 	ApplyActionPreExisting ApplyAction = "blocked_preexisting_drift"
 	// ApplyActionCreationBlocked means first-time registration is disabled.
 	ApplyActionCreationBlocked ApplyAction = "blocked_creation_disabled"
@@ -118,7 +119,7 @@ func (a ApplyAction) Describe() string {
 	case ApplyActionPolicyBlocked:
 		return "not applied: blocked by update policy"
 	case ApplyActionPreExisting:
-		return "not applied: drift pre-dates opt-in (set --apply-existing-drift)"
+		return "not applied: drift pre-dates the scope change that brought it in — opt-in or policy widening (set --apply-existing-drift)"
 	case ApplyActionCreationBlocked:
 		return "not applied: job creation disabled (set --enable-job-creation)"
 	case ApplyActionMetaOnly:
@@ -237,8 +238,11 @@ type Differ struct {
 	// detect pre-existing drift. nil disables the check.
 	history HistorySource
 	// managedKeyRe matches the opt-in key set to "true" in raw HCL text, for
-	// the cheap parent-content check.
+	// the cheap parent-content check. policyKeyRe captures the value of the
+	// <prefix>_update_policy key in raw HCL text, used to read a job's policy at
+	// the parent commit without re-parsing.
 	managedKeyRe *regexp.Regexp
+	policyKeyRe  *regexp.Regexp
 	// applyInterval is the fallback cadence of the applier loop; enqueues
 	// also wake it immediately via applyCh.
 	applyInterval time.Duration
@@ -316,11 +320,13 @@ func newDifferBase(jobs NomadJobsClient, cfg *config.Config, reg prometheus.Regi
 		flapGuard = "history"
 	}
 
-	var managedKeyRe *regexp.Regexp
+	var managedKeyRe, policyKeyRe *regexp.Regexp
 	if cfg.ManagedMetaPrefix != "" {
 		// Matches <prefix>_managed = "true" in raw HCL, in both the block form
 		// (bare key) and the object-expression form (quoted key).
 		managedKeyRe = regexp.MustCompile(`(?m)"?` + regexp.QuoteMeta(cfg.ManagedMetaPrefix) + `_managed"?\s*=\s*"true"`)
+		// Captures the value of <prefix>_update_policy in either HCL form.
+		policyKeyRe = regexp.MustCompile(`(?m)"?` + regexp.QuoteMeta(cfg.ManagedMetaPrefix) + `_update_policy"?\s*=\s*"([^"]*)"`)
 	}
 
 	f := promauto.With(reg)
@@ -340,6 +346,7 @@ func newDifferBase(jobs NomadJobsClient, cfg *config.Config, reg prometheus.Regi
 		deregisterPurge:      cfg.DeregisterPurge,
 		deregisterGrace:      cfg.DeregisterGrace,
 		managedKeyRe:         managedKeyRe,
+		policyKeyRe:          policyKeyRe,
 		flapGuard:            flapGuard,
 		allowRollback:        cfg.AllowRollback,
 		applyInterval:        applyInterval,
@@ -424,7 +431,7 @@ func newDifferBase(jobs NomadJobsClient, cfg *config.Config, reg prometheus.Regi
 		}, []string{"job"}),
 		updatesBlockedExistingDrift: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "nomad_botherer_updates_blocked_preexisting_total",
-			Help: "Updates not enqueued because the drift pre-existed the job entering scope (opt-in via meta tag while running). Enable with --apply-existing-drift.",
+			Help: "Updates not enqueued because the drift pre-dated a scope change that brought it in: the job's opt-in (managed tag added) or a policy widening (e.g. image-only to full). Enable with --apply-existing-drift.",
 		}, []string{"job"}),
 		jobsLeftManagement: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "nomad_botherer_jobs_left_management_total",
@@ -1052,18 +1059,29 @@ func (d *Differ) SetHistorySource(h HistorySource) {
 	d.history = h
 }
 
-// isPreExistingDrift reports whether a candidate's drift pre-dates the job
-// entering management scope — i.e. the managed opt-in tag was added in the
-// commit being evaluated (absent in that commit's parent version of the job's
-// HCL file). This is derived from git history, so it holds identically whether
-// the tag was added while the process was running or before it started: a job
-// already managed in an earlier commit is established and reconciles normally;
-// one opted in at this commit is frozen until a later commit arrives.
+// isPreExistingDrift reports whether a candidate's drift pre-dates the change,
+// at the commit being evaluated, that brought it into scope to apply. Two such
+// scope-widening changes are treated the same way (issue #69):
 //
-// Glob-selected jobs are always in scope and have no opt-in moment, so they
-// are never pre-existing. Creations have no live job to pre-date. When history
-// is unavailable the check is skipped (not pre-existing) so reconciliation is
-// not broken.
+//   - Enablement: the managed opt-in tag (<prefix>_managed) was added at this
+//     commit (absent in the parent version of the file). The whole job entered
+//     management; its existing drift pre-dates the opt-in.
+//   - Policy promotion: the job was managed at the parent, but its effective
+//     update policy there would not have applied this diff's class, while the
+//     policy at this commit does (e.g. image-only → full applying a memory
+//     change that image-only had been deferring). The drift was live the whole
+//     time, merely held back by the stricter policy.
+//
+// In both cases the conservative default is not to retroactively apply the
+// accumulated drift: changing scope expresses intent about future
+// reconciliation, not "deploy the backlog now". --apply-existing-drift opts in
+// to applying it.
+//
+// Derived from git history, so it holds identically whether the change landed
+// while the process was running or before it started. Glob-selected jobs are
+// always in scope and have no opt-in moment, so they are never pre-existing.
+// Creations have no live job to pre-date. When history is unavailable the check
+// is skipped (not pre-existing) so reconciliation is not broken.
 func (d *Differ) isPreExistingDrift(c *updateCandidate, commit string) bool {
 	if c.isCreation || c.globSel || d.history == nil || d.managedKeyRe == nil || c.hclFile == "" {
 		return false
@@ -1071,15 +1089,55 @@ func (d *Differ) isPreExistingDrift(c *updateCandidate, commit string) bool {
 	parent, ok := d.history.FileAtParentOf(commit, c.hclFile)
 	if !ok {
 		// No parent version: the file was created at this commit (or it is the
-		// root commit). The tag and the spec were introduced together, so the
-		// tag was present when the diff was introduced — not a retroactive
-		// opt-in.
+		// root commit). The tag, policy, and spec were introduced together, so
+		// nothing was deferred under an earlier scope — not retroactive.
 		return false
 	}
-	// Tag present at the parent → the job was already managed before this
-	// commit → established. Absent → the tag was added to a pre-existing file
-	// at this commit → retroactive opt-in, so the drift pre-dates it.
-	return !d.managedKeyRe.MatchString(parent)
+	if !d.managedKeyRe.MatchString(parent) {
+		// The opt-in tag was added at this commit: the job entered management
+		// here, so its drift pre-dates the opt-in.
+		return true
+	}
+	// Managed at the parent too. A managed-meta-only diff is governed by the
+	// meta-only gate, not this one.
+	if c.class == DiffClassManagedMetaOnly {
+		return false
+	}
+	// Pre-existing iff the parent's effective policy would not have applied this
+	// diff's class but the current one does — a scope-widening policy change at
+	// this commit.
+	return !policyPermits(d.effectivePolicyFromText(parent), c.class) &&
+		policyPermits(d.effectivePolicy(c.job.Meta), c.class)
+}
+
+// policyPermits reports whether an update policy would apply a diff of the given
+// class. Mirrors the policy gate in decideApplyAction (creation, which is
+// full-only, is handled separately and never reaches the pre-existing check).
+func policyPermits(policy UpdatePolicy, class DiffClass) bool {
+	switch policy {
+	case UpdatePolicyFull:
+		return true
+	case UpdatePolicyImageOnly:
+		return class == DiffClassImageOnly
+	default: // none, or an unrecognised value treated as none
+		return false
+	}
+}
+
+// effectivePolicyFromText resolves a job's update policy from a raw HCL snapshot
+// (e.g. a parent commit's version of the file), without re-parsing: the
+// <prefix>_update_policy value wins, an unrecognised value is treated as none
+// (matching effectivePolicy), and an absent key falls back to the default.
+func (d *Differ) effectivePolicyFromText(hclText string) UpdatePolicy {
+	if d.policyKeyRe != nil {
+		if m := d.policyKeyRe.FindStringSubmatch(hclText); m != nil {
+			if ValidUpdatePolicy(m[1]) {
+				return UpdatePolicy(m[1])
+			}
+			return UpdatePolicyNone
+		}
+	}
+	return d.defaultPolicy
 }
 
 // logScopeExits logs, once per transition, when a job leaves active GitOps
@@ -1164,11 +1222,12 @@ func (d *Differ) decideApplyAction(c *updateCandidate, commit string, q *nomadap
 	}
 
 	if !c.isCreation && d.isPreExistingDrift(c, commit) && !d.applyExistingDrift {
-		// The drift was already there when the job entered scope (the managed
-		// tag was added in the HEAD commit). Conservative default: opting a job
-		// in does not retroactively mutate it; only changes committed after
-		// opt-in apply. Enable with --apply-existing-drift.
-		slog.Info("Pre-existing drift not applied on opt-in; set --apply-existing-drift to apply", "job", c.jobID)
+		// The drift was already there when the change that brought it into scope
+		// landed at the HEAD commit — the job's opt-in tag was added, or its
+		// policy was widened to cover this diff. Conservative default: a scope
+		// change does not retroactively mutate the job; only changes committed
+		// after it apply. Enable with --apply-existing-drift.
+		slog.Info("Pre-existing drift not applied on scope change (opt-in or policy widening); set --apply-existing-drift to apply", "job", c.jobID)
 		d.updatesBlockedExistingDrift.WithLabelValues(c.jobID).Inc()
 		return ApplyActionPreExisting
 	}

--- a/internal/server/render_test.go
+++ b/internal/server/render_test.go
@@ -304,7 +304,7 @@ func TestDiffs_ShowsApplyActionReason(t *testing.T) {
 		},
 	}
 	body := diffsResponse(t, diffs, time.Now())
-	if !strings.Contains(body, "drift pre-dates opt-in") {
+	if !strings.Contains(body, "drift pre-dates the scope change") {
 		t.Errorf("/diffs should explain why the diff is not applied, got:\n%s", body)
 	}
 }

--- a/tests/regression/apply_test.go
+++ b/tests/regression/apply_test.go
@@ -486,6 +486,52 @@ func TestApplyE2E_ExistingDrift_AtStartup(t *testing.T) {
 	})
 }
 
+// TestApplyE2E_PolicyPromotion verifies issue #69 against real git history:
+// widening gitops_update_policy (image-only → full) defers drift that
+// accumulated under the stricter policy, exactly as opt-in defers pre-existing
+// drift. The job is established managed+image-only with a non-image (args)
+// drift that image-only correctly held back; a later commit flips the policy to
+// full. The binary starts at HEAD so the parent commit (holding image-only) is
+// read from real git history via the policy regexp.
+func TestApplyE2E_PolicyPromotion(t *testing.T) {
+	run := func(t *testing.T, applyExisting bool) string {
+		repoURL, workDir, branch := createGitRepo(t)
+		jobID := uniqueJobID("policy-promo")
+
+		// Running job: args ["600"].
+		registerJobHCL(t, testJobHCL(jobID))
+		waitForJobStatus(t, jobID, "running", 60*time.Second)
+
+		// Commit 1 (established): managed + image-only, args ["999"]. The args
+		// change is non-image, so image-only defers it — it is live drift held
+		// back by policy.
+		commitToGit(t, workDir, map[string]string{jobID + ".hcl": testJobHCLWithPolicy(jobID, "image-only")})
+		// Commit 2 (promotion): same args, policy widened to full. HEAD's parent
+		// (commit 1) holds image-only.
+		commitToGit(t, workDir, map[string]string{jobID + ".hcl": testJobHCLWithPolicy(jobID, "full")})
+
+		extra := []string{"--repo-url=" + repoURL, "--branch=" + branch, "--apply-interval=1s"}
+		if applyExisting {
+			extra = append(extra, "--apply-existing-drift")
+		}
+		startBotherer(t, extra...)
+		return jobID
+	}
+
+	t.Run("default defers drift accumulated under image-only", func(t *testing.T) {
+		jobID := run(t, false)
+		time.Sleep(8 * time.Second)
+		if args := jobTaskArgs(t, jobID); len(args) != 1 || args[0] != "600" {
+			t.Errorf("non-image drift deferred under image-only must not apply on promotion to full by default; args are now %v", args)
+		}
+	})
+
+	t.Run("flag applies the accumulated drift on promotion", func(t *testing.T) {
+		jobID := run(t, true)
+		waitForTaskArgs(t, jobID, "999", 60*time.Second)
+	})
+}
+
 // TestDeregisterE2E_RemovedFromRepo verifies that a job removed from the repo
 // entirely (HCL deleted) while still running is deregistered only with
 // --enable-deregister, and only after the grace period. By default it is left


### PR DESCRIPTION
Fixes #69.

## Ruling

A change can bring drift that was already live *into scope* to apply. Two such changes are now treated **identically**:

- **Enablement** — a job gains `gitops_managed` (this already deferred pre-existing drift since v0.6.0, via `--apply-existing-drift`).
- **Policy widening** — a managed job's `gitops_update_policy` is widened to cover drift the stricter policy was deferring (e.g. `image-only` → `full` with a memory bump committed earlier — the exact case in the issue).

In both, the accumulated drift is **deferred by default** and applied with `--apply-existing-drift`. Changing scope expresses intent about future reconciliation, not "deploy the backlog now."

This is a **behaviour change**: previously `image-only` → `full` applied all current drift on the next reconcile. Set `--apply-existing-drift` (default off) to restore that.

## Interpretation note (please sanity-check)

Your comment said "behave the same way when we go from unmanaged to managed as we do here." I read that as: **unify** the two paths, with policy-widening adopting the conservative *defer-by-default* behaviour that enablement already has — not the reverse (making enablement apply-everything, which would regress the established `--apply-existing-drift` default and the conservative-by-default design). If you actually wanted both to *apply* accumulated drift by default, say so and I'll flip it.

## How

`isPreExistingDrift` generalises from "was the managed tag present at the parent commit?" to "**would this diff have been applied under the job's effective scope (managed-state *and* policy) at the parent commit?**" A diff is pre-existing iff it would *not* have applied at the parent but the scope at HEAD covers it. The parent's policy is read from the parent HCL snapshot via a new regexp (`policyKeyRe`), mirroring the existing managed-tag regexp; `policyPermits()` mirrors the apply-time policy gate. No new state — it's all git history, same as the opt-in gate.

Worked outcomes (default off):

| parent → HEAD policy | diff class | applied? |
|---|---|---|
| image-only → full | other (e.g. memory) | **deferred** |
| image-only → full | image | applied (already in scope) |
| none → full/image-only | any | **deferred** |
| full → full | any | applied (no widening) |

Boundaries: a change bundled in the *same commit* as the widening is deferred (consistent with the opt-in rule); a meta-only policy flip is handled by the meta-only gate; the global `--default-update-policy` flag is not a per-job git change so it isn't treated as a per-job widening; glob-selected jobs are exempt as before.

## Tests

- Unit (`internal/nomad/apply_test.go`): promotion deferred by default and applied with the flag; `none` → `full`; image drift stays in scope on promotion; stable policy reconciles; meta-only flip not flagged pre-existing. Existing enablement tests unchanged (one had a parent without an explicit policy — updated so it tests "stable policy", its actual intent).
- Regression (`tests/regression/apply_test.go`): `TestApplyE2E_PolicyPromotion` drives the scenario through **real git history** across commits against a live Nomad — the non-image drift is held on promotion by default and applied with `--apply-existing-drift`. Passes on Nomad 1.9.6; the existing apply regression tests still pass.

## Docs

README ("Drift that pre-dates a scope change" section, flag table, `apply_action` and metric rows), the design ruling in `docs/design/update-policies.md`, and a CHANGELOG `Changed` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
