### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## v0.9.0 — 2026-06-29
+
+Verified against Nomad 1.9.6, 1.10.5, 1.11.3, and 2.0.2 (full regression
+suite). See [docs/nomad-versions.md](docs/nomad-versions.md).
 
 ### New features
 
@@ -15,9 +18,9 @@
   `NOMAD_TOKEN_FILE` and `--nomad-token-poll-interval` /
   `NOMAD_TOKEN_POLL_INTERVAL`. A token file takes precedence over a static
   `--nomad-token`, which is retained for manual running and testing. New counter
-  `nomad_botherer_nomad_token_refreshes_total{result}`. See the README
-  "Authenticating to Nomad" section and `docs/design/nomad-auth.md`; the example
-  job in `examples/nomad-botherer.hcl` now uses workload identity. Covered by a
+  `nomad_botherer_nomad_token_refreshes_total{result}`. See
+  `docs/setup/nomad-access.md` and `docs/design/nomad-auth.md`; the example job
+  in `examples/nomad-botherer.hcl` now uses workload identity. Covered by a
   regression test (`tests/regression/auth_test.go`) that runs against a real
   ACL-enabled Nomad: static token vs anonymous denial, token-file and
   auto-detected workload-identity auth, and live token rotation.
@@ -37,8 +40,21 @@
   behaviour. Drift on a job whose scope did not change reconciles normally. The
   decision is git-history-derived (no new state); surfaced as before by
   `apply_action=blocked_preexisting_drift` and
-  `nomad_botherer_updates_blocked_preexisting_total`. See the README
-  "Drift that pre-dates a scope change" section and `docs/design/update-policies.md`.
+  `nomad_botherer_updates_blocked_preexisting_total`. See
+  `docs/applying-changes.md` ("Drift that pre-dates a scope change") and
+  `docs/design/update-policies.md`.
+
+### Docs
+
+- **The documentation is now a guide set under `docs/`** instead of one giant
+  README. The README is a lean landing page; setup, configuration, applying
+  changes, rollback, monitoring, and the API each have their own doc, plus new
+  pages for common use cases, an FAQ / gotchas list, and the design philosophy.
+  Indexed by `docs/README.md`.
+- **Added a canonical [meta-key reference](docs/meta-keys.md)** listing every
+  `gitops_*` job meta key and its valid values.
+- **Added an Apache 2.0 `LICENSE`** and references to it (README, docs, and the
+  Docker image's `org.opencontainers.image.licenses` label).
 
 ## v0.8.0 — 2026-06-20
 

--- a/docs/nomad-versions.md
+++ b/docs/nomad-versions.md
@@ -22,6 +22,7 @@ After a successful run, add a row to the table below and update `tests/regressio
 
 | nomad-botherer | Nomad 1.9.x | Nomad 1.10.x | Nomad 1.11.x | Nomad 2.0.x | Notes |
 |----------------|:-----------:|:------------:|:------------:|:-----------:|-------|
+| v0.9.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Nomad workload-identity auth; policy-widening defers pre-existing drift (#69) |
 | v0.8.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Adds flap-loop guard and optional active rollback |
 | v0.7.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Adds deregistration of repo-removed jobs |
 | v0.6.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Full apply suite (policies, pre-existing drift, apply_action) |

--- a/tests/regression/compat.go
+++ b/tests/regression/compat.go
@@ -52,6 +52,30 @@ type VersionRecord struct {
 var TestedVersions = []VersionRecord{
 	{
 		NomadVersion:    "2.0.2",
+		BothererRelease: "v0.9.0",
+		TestedAt:        time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.11.3",
+		BothererRelease: "v0.9.0",
+		TestedAt:        time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.10.5",
+		BothererRelease: "v0.9.0",
+		TestedAt:        time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "1.9.6",
+		BothererRelease: "v0.9.0",
+		TestedAt:        time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC),
+		Passed:          true,
+	},
+	{
+		NomadVersion:    "2.0.2",
 		BothererRelease: "v0.8.0",
 		TestedAt:        time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
 		Passed:          true,


### PR DESCRIPTION
Cuts v0.9.0.

Headline changes since v0.8.0:
- **Nomad workload identity for authentication** (`--nomad-token-file` + auto-detect, with live token rotation), retaining the static `--nomad-token` for manual use.
- **`gitops_update_policy` widening now defers drift accumulated under the stricter policy** (#69), consistent with how opt-in treats pre-existing drift; `--apply-existing-drift` restores the old behaviour.
- **Docs restructured** into a `docs/` guide set, a canonical [meta-key reference](docs/meta-keys.md), and an Apache 2.0 `LICENSE`.

This PR:
- Rolls the `Unreleased` notes to `## v0.9.0` and adds a Docs entry; fixes two changelog references to README sections that moved in the docs restructure.
- Records the full regression suite passing against **Nomad 1.9.6, 1.10.5, 1.11.3, and 2.0.2** in `docs/nomad-versions.md` and `tests/regression/compat.go`.

Regression suite run today against all four versions — all green (~125s each). `make lint` clean.

Merge this, then the `v0.9.0` tag goes on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)