### PR TITLE
Warn on the missing-ttl workload-identity footgun; document it (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 > `nomad_botherer_*` metric names, because that is what those releases actually
 > shipped.
 
+## Unreleased
+
+### Fixed
+
+- **Workload identity: warn about the missing-`ttl` footgun, and document it
+  (issue #76).** With a task `identity` block that has no `ttl`, Nomad issues a
+  non-expiring JWT and never rewrites the file, so login works for the first
+  `max_token_ttl` (e.g. 30 min) and then silently breaks — re-login uses the
+  stale JWT, `/v1/acl/login` rejects it, and every drift check fails with `ACL
+  token expired`. nomad-gitops now logs a WARN at startup when the workload
+  identity JWT it reads has no expiry claim, turning a delayed silent failure
+  into an immediate, actionable one. The `docs/setup/nomad-access.md` example
+  and `examples/nomad-gitops.hcl` now set `ttl` and `change_mode = "noop"` on
+  the identity block, with a prominent warning.
+
 ## v1.0.0 — 2026-07-01
 
 **Renamed from `nomad-botherer` to `nomad-gitops`.** This is a rename and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 > `nomad_botherer_*` metric names, because that is what those releases actually
 > shipped.
 
-## Unreleased
+## v1.0.1 — 2026-07-02
 
 ### Fixed
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -101,6 +101,19 @@ setup: [Nomad access → Workload identity](setup/nomad-access.md#workload-ident
 (Also don't use `identity { env = true }`: an env token is captured once at task
 start and never refreshed.)
 
+## Workload identity worked, then broke after ~30 minutes (`ACL token expired`)
+
+Your `identity` block is missing a `ttl`. Without one, Nomad issues a
+**non-expiring** JWT and **never rewrites the file**, so once the first exchanged
+ACL token expires (after the auth method's `max_token_ttl`), nomad-gitops
+re-logins with the stale JWT and `/v1/acl/login` rejects it — every check then
+fails with `ACL token expired`. Add `ttl` (and `change_mode = "noop"`) to the
+identity block; Nomad then renews the file before it expires. nomad-gitops logs
+a WARN at startup when the JWT has no expiry, so you don't have to wait for the
+delayed failure. See
+[Nomad access → Workload identity](setup/nomad-access.md#workload-identity-recommended-under-nomad)
+(issue #76).
+
 ## An apply is stuck as `blocked_known_failed`
 
 The flap-loop guard is holding it: this exact spec matches a recent deployment

--- a/docs/setup/nomad-access.md
+++ b/docs/setup/nomad-access.md
@@ -69,13 +69,25 @@ not match a custom auth method**, so use a named identity:
 ```hcl
 task "nomad-gitops" {
   identity {
-    name = "nomad-api"
-    aud  = ["nomad.io"]
-    file = true          # -> ${NOMAD_SECRETS_DIR}/nomad_nomad-api.jwt
+    name        = "nomad-api"
+    aud         = ["nomad.io"]
+    file        = true       # -> ${NOMAD_SECRETS_DIR}/nomad_nomad-api.jwt
+    ttl         = "1h"       # REQUIRED — see the warning below
+    change_mode = "noop"     # token renewals must not restart the task
   }
   # ...
 }
 ```
+
+> ⚠️ **`ttl` is required, and its omission is a silent footgun.** Without a
+> `ttl`, Nomad issues a **non-expiring** identity JWT and **never rewrites the
+> file**. Login works for the first ~`max_token_ttl` (e.g. 30 min) and then
+> **silently breaks**: once the exchanged ACL token expires, nomad-gitops
+> re-logins with the now-stale JWT, `/v1/acl/login` rejects it, and every drift
+> check fails with `ACL token expired`. Setting a `ttl` makes Nomad issue an
+> expiring JWT and renew the file well before it expires. nomad-gitops logs a
+> WARN at startup if the JWT it reads has no expiry, so you don't have to wait
+> for the delayed failure. (Issue #76.)
 
 Do **not** rely on `env = true` for the API token — env is captured once and
 never refreshed.

--- a/examples/nomad-gitops.hcl
+++ b/examples/nomad-gitops.hcl
@@ -85,7 +85,11 @@ job "nomad-gitops" {
         name = "nomad-api"
         aud  = ["nomad.io"]
         file = true
-        ttl  = "1h" # JWT lifetime; Nomad rotates the file before it expires
+        # ttl is REQUIRED. Without it Nomad issues a non-expiring JWT and never
+        # rewrites the file, so login silently breaks ~max_token_ttl after start
+        # (issue #76). With a ttl, Nomad renews the file well before expiry.
+        ttl         = "1h"
+        change_mode = "noop" # token renewals must not restart the task
       }
 
       env {

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -206,6 +206,7 @@ type Differ struct {
 	loginJWTFile      string
 	loginExpiry       *time.Time
 	loginFailed       bool
+	loginNoTTLWarned  sync.Once
 	namespace         string
 	includeDeadJobs   bool
 	jobSelectorGlob   string
@@ -594,6 +595,16 @@ func (d *Differ) login() (secretID string, expiry *time.Time, err error) {
 	}
 	if jwt == "" {
 		return "", nil, fmt.Errorf("workload-identity JWT file %q is empty", d.loginJWTFile)
+	}
+	// A WI JWT with no expiry means the identity block has no ttl: Nomad issues a
+	// non-expiring token and never rewrites the file, so login works now but
+	// fails once the exchanged ACL token expires (issue #76). Warn once, at the
+	// first login (startup), so this silent, delayed failure is caught early.
+	if jwtLacksExpiry(jwt) {
+		d.loginNoTTLWarned.Do(func() {
+			slog.Warn("Workload-identity JWT has no expiry (exp) claim: the identity block is missing a ttl, so Nomad will not renew the token file. Login will start failing once the current exchanged token expires (after the auth method's max_token_ttl). Set ttl on the identity block, e.g. `ttl = \"1h\"` with `change_mode = \"noop\"` (see docs/setup/nomad-access.md).",
+				"jwt_file", d.loginJWTFile)
+		})
 	}
 	tok, _, err := d.nomadClient.ACLAuth().Login(&nomadapi.ACLLoginRequest{
 		AuthMethodName: d.loginAuthMethod,

--- a/internal/nomad/token.go
+++ b/internal/nomad/token.go
@@ -2,6 +2,8 @@ package nomad
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -104,6 +106,29 @@ func defaultWorkloadTokenPath() string {
 // string, conventionally starting "ey".
 func looksLikeJWT(s string) bool {
 	return strings.HasPrefix(s, "ey") && strings.Count(s, ".") == 2
+}
+
+// jwtLacksExpiry reports whether token is a decodable JWT that carries no `exp`
+// claim. A workload-identity JWT with no expiry means the task's `identity`
+// block has no `ttl`, so Nomad issues a non-expiring token and never rewrites
+// the file — login works at first but fails once the exchanged ACL token
+// expires (issue #76). Returns false for anything it cannot positively decode
+// as a JWT, so a real SecretID or a malformed value never trips the warning.
+func jwtLacksExpiry(token string) bool {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	var claims map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return false
+	}
+	_, hasExp := claims["exp"]
+	return !hasExp
 }
 
 // readTokenFile reads and trims a token (SecretID or JWT) from a file.

--- a/internal/nomad/token_test.go
+++ b/internal/nomad/token_test.go
@@ -2,6 +2,7 @@ package nomad
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"os"
 	"path/filepath"
@@ -11,6 +12,34 @@ import (
 
 	"github.com/gerrowadat/nomad-gitops/internal/config"
 )
+
+// fakeJWT builds a header.payload.sig string with the given JSON claims payload.
+// jwtLacksExpiry only decodes the payload, so the signature is irrelevant.
+func fakeJWT(claimsJSON string) string {
+	b64 := func(s string) string { return base64.RawURLEncoding.EncodeToString([]byte(s)) }
+	return b64(`{"alg":"none","typ":"JWT"}`) + "." + b64(claimsJSON) + ".sig"
+}
+
+func TestJWTLacksExpiry(t *testing.T) {
+	if jwtLacksExpiry(fakeJWT(`{"sub":"x","exp":1893456000}`)) {
+		t.Error("a JWT with an exp claim must not be flagged")
+	}
+	if !jwtLacksExpiry(fakeJWT(`{"sub":"x","aud":["nomad.io"]}`)) {
+		t.Error("a JWT with no exp claim should be flagged (the ttl footgun)")
+	}
+	// Anything not positively a JWT must not trip the warning.
+	for _, s := range []string{
+		"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", // SecretID UUID
+		"",
+		"only.two",          // not 3 segments
+		"a.b.c",             // middle not base64/JSON
+		fakeJWT(`not-json`), // payload not JSON
+	} {
+		if jwtLacksExpiry(s) {
+			t.Errorf("non-JWT / undecodable value must not be flagged: %q", s)
+		}
+	}
+}
 
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()


### PR DESCRIPTION
Fixes #76.

## The footgun

A task `identity` block with **no `ttl`** makes Nomad issue a **non-expiring** JWT and **never rewrite the file**. So workload-identity login works for the first `max_token_ttl` (~30 min) and then **silently breaks**: once the exchanged ACL token expires, nomad-gitops re-logins with the stale JWT, `/v1/acl/login` rejects it (`token is expired`), and every drift check fails with `ACL token expired`. The first ~30 min look perfectly healthy, which makes it easy to miss.

## Fix

**Code (the WARN you asked for):** nomad-gitops decodes the identity JWT at login and logs a WARN — once, at startup — when it carries **no `exp` claim**, which is exactly the no-`ttl` condition. This turns a 30-minutes-later silent failure into an immediate, actionable startup log:

> Workload-identity JWT has no expiry (exp) claim: the identity block is missing a ttl … Set ttl on the identity block, e.g. `ttl = "1h"` with `change_mode = "noop"` …

Implemented as `jwtLacksExpiry` (decodes the JWT payload, no signature check, no new dependency; returns false for anything not positively a JWT so a real SecretID never trips it) + a `sync.Once` guard in `login()`.

**Docs & example:** `docs/setup/nomad-access.md` and `examples/nomad-gitops.hcl` now set `ttl` **and** `change_mode = "noop"` on the identity block, with a prominent ⚠️ warning explaining why `ttl` is required. New FAQ entry ("worked, then broke after ~30 minutes") and a CHANGELOG note.

## Tests

- Unit: `TestJWTLacksExpiry` (JWT with exp → not flagged; JWT without exp → flagged; SecretID / empty / malformed / non-JSON payload → not flagged).
- Regression: the existing login-exchange test (real Nomad) still passes, and confirms the WARN does **not** false-fire for a normal exp-carrying JWT.
- `make lint` clean; example HCL validates with the new `ttl`/`change_mode`.

Candidate for **v1.0.1** (changelog entry is under `Unreleased`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)