### PR TITLE
Cap plan-diff nesting depth to prevent unbounded recursion

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -152,3 +152,13 @@ secret-like names are redacted before the diff is stored, so they never reach
 
 An instance watches one `--nomad-namespace`. Run one per namespace (and, with
 workload identity, grant the ACL policy on each namespace you target).
+
+## A diff is truncated with "exceeds maximum nesting depth"
+
+nomad-gitops caps how deep it will walk into a Nomad plan diff's nested
+objects (classification, redaction, and `/diffs` rendering all share the same
+cap). No real job spec nests anywhere near this deep — it exists to stop a
+pathologically nested job spec (however it got there) from recursing without
+bound. A diff hitting the cap is conservatively classified as a non-image,
+non-meta change, so it still requires the `full` update policy to apply
+rather than being waved through as trivial.

--- a/internal/nomad/classify.go
+++ b/internal/nomad/classify.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"log/slog"
 	"strings"
 
 	nomadapi "github.com/hashicorp/nomad/api"
@@ -64,7 +65,7 @@ func classifyDiff(d *nomadapi.JobDiff, autoscaled map[string]bool, metaPrefix st
 
 	var c changeCounts
 	c.addFields(d.Fields, nil, false, false, metaPrefix)
-	c.addObjects(d.Objects, metaPrefix)
+	c.addObjects(d.Objects, metaPrefix, 1)
 
 	for _, tg := range d.TaskGroups {
 		if tg == nil {
@@ -89,7 +90,7 @@ func classifyDiff(d *nomadapi.JobDiff, autoscaled map[string]bool, metaPrefix st
 			if isAuto && o.Name == "Scaling" {
 				continue
 			}
-			c.addObject(o, metaPrefix)
+			c.addObject(o, metaPrefix, 1)
 		}
 
 		for _, task := range tg.Tasks {
@@ -104,7 +105,7 @@ func classifyDiff(d *nomadapi.JobDiff, autoscaled map[string]bool, metaPrefix st
 				if o == nil {
 					continue
 				}
-				c.addObject(o, metaPrefix)
+				c.addObject(o, metaPrefix, 1)
 			}
 		}
 	}
@@ -125,17 +126,28 @@ func classifyDiff(d *nomadapi.JobDiff, autoscaled map[string]bool, metaPrefix st
 // objects: "Config" (whose "image" field is a Docker image reference) and
 // "Meta" (whose fields are meta keys, so managed-prefix ones are tracked
 // separately). Image/meta semantics do not propagate into nested sub-objects.
-func (c *changeCounts) addObject(o *nomadapi.ObjectDiff, metaPrefix string) {
+// depth is the object's nesting level (1 at the top); beyond
+// MaxPlanDiffObjectDepth, recursion stops and the unexamined subtree counts as
+// a non-image, non-meta change — the conservative reading, since an
+// update-policy of image-only or none must not wave through a change nobody
+// actually looked at.
+func (c *changeCounts) addObject(o *nomadapi.ObjectDiff, metaPrefix string, depth int) {
+	if depth > MaxPlanDiffObjectDepth {
+		slog.Warn("Plan diff exceeds maximum nesting depth; treating unexamined nesting as a non-trivial change",
+			"depth", depth, "max_depth", MaxPlanDiffObjectDepth)
+		c.other++
+		return
+	}
 	c.addFields(o.Fields, nil, o.Name == "Meta", o.Name == "Config", metaPrefix)
-	c.addObjects(o.Objects, metaPrefix)
+	c.addObjects(o.Objects, metaPrefix, depth+1)
 }
 
-func (c *changeCounts) addObjects(objs []*nomadapi.ObjectDiff, metaPrefix string) {
+func (c *changeCounts) addObjects(objs []*nomadapi.ObjectDiff, metaPrefix string, depth int) {
 	for _, o := range objs {
 		if o == nil {
 			continue
 		}
-		c.addObject(o, metaPrefix)
+		c.addObject(o, metaPrefix, depth)
 	}
 }
 

--- a/internal/nomad/classify_test.go
+++ b/internal/nomad/classify_test.go
@@ -2,6 +2,7 @@ package nomad_test
 
 import (
 	"testing"
+	"time"
 
 	nomadapi "github.com/hashicorp/nomad/api"
 
@@ -268,6 +269,32 @@ func TestClassifyDiff(t *testing.T) {
 				t.Errorf("classifyDiff = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestClassifyDiff_DepthCapPreventsUnboundedRecursion verifies that a plan
+// diff nested far deeper than any real Nomad job spec produces does not
+// recurse without bound, and is conservatively classified as DiffClassOther
+// (never image-only or none) so an update policy short of "full" cannot wave
+// it through unexamined.
+func TestClassifyDiff_DepthCapPreventsUnboundedRecursion(t *testing.T) {
+	var deep *nomadapi.ObjectDiff
+	cur := &nomadapi.ObjectDiff{Type: "Edited", Name: "leaf"}
+	for i := 1; i < nomad.MaxPlanDiffObjectDepth+50; i++ {
+		cur = &nomadapi.ObjectDiff{Type: "Edited", Name: "nested", Objects: []*nomadapi.ObjectDiff{cur}}
+	}
+	deep = cur
+	diff := &nomadapi.JobDiff{Type: "Edited", ID: "myapp", Objects: []*nomadapi.ObjectDiff{deep}}
+
+	done := make(chan nomad.DiffClass, 1)
+	go func() { done <- nomad.ClassifyDiff(diff, nil, "gitops") }()
+	select {
+	case got := <-done:
+		if got != nomad.DiffClassOther {
+			t.Errorf("classifyDiff of an over-deep diff = %v, want %v", got, nomad.DiffClassOther)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("classifyDiff did not return; recursion depth cap did not stop it")
 	}
 }
 

--- a/internal/nomad/diffdepth.go
+++ b/internal/nomad/diffdepth.go
@@ -1,0 +1,12 @@
+package nomad
+
+// MaxPlanDiffObjectDepth caps how deep nomad-gitops recurses into a Nomad
+// plan-diff's Objects tree (classification, redaction; internal/server/render.go
+// mirrors this cap for text rendering). A legitimate job spec never nests
+// anywhere near this deep — real ObjectDiff trees bottom out within a handful
+// of levels (job/group/task/config). Depth beyond this cap can only come from
+// a deliberately crafted HCL job spec, and traversal stops there rather than
+// recursing without bound: unbounded recursion risks a stack-overflow crash,
+// which is not a recoverable panic and would take down the whole process, not
+// just the one job's check.
+const MaxPlanDiffObjectDepth = 200

--- a/internal/nomad/redact.go
+++ b/internal/nomad/redact.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"log/slog"
 	"strings"
 
 	nomadapi "github.com/hashicorp/nomad/api"
@@ -49,32 +50,42 @@ func RedactJobDiff(d *nomadapi.JobDiff) int {
 		return 0
 	}
 	n := redactFields(d.Fields)
-	n += redactObjects(d.Objects)
+	n += redactObjects(d.Objects, 1)
 	for _, tg := range d.TaskGroups {
 		if tg == nil {
 			continue
 		}
 		n += redactFields(tg.Fields)
-		n += redactObjects(tg.Objects)
+		n += redactObjects(tg.Objects, 1)
 		for _, t := range tg.Tasks {
 			if t == nil {
 				continue
 			}
 			n += redactFields(t.Fields)
-			n += redactObjects(t.Objects)
+			n += redactObjects(t.Objects, 1)
 		}
 	}
 	return n
 }
 
-func redactObjects(objs []*nomadapi.ObjectDiff) int {
+// redactObjects walks a diff's Objects tree redacting sensitive field values.
+// depth is the nesting level (1 at the top); beyond MaxPlanDiffObjectDepth,
+// recursion stops rather than continuing without bound — see
+// diffdepth.go. A diff pathological enough to hit this cap is not a shape any
+// legitimate job spec produces.
+func redactObjects(objs []*nomadapi.ObjectDiff, depth int) int {
+	if depth > MaxPlanDiffObjectDepth {
+		slog.Warn("Plan diff exceeds maximum nesting depth; stopped redacting beyond this point",
+			"depth", depth, "max_depth", MaxPlanDiffObjectDepth)
+		return 0
+	}
 	n := 0
 	for _, o := range objs {
 		if o == nil {
 			continue
 		}
 		n += redactFields(o.Fields)
-		n += redactObjects(o.Objects)
+		n += redactObjects(o.Objects, depth+1)
 	}
 	return n
 }

--- a/internal/nomad/redact_test.go
+++ b/internal/nomad/redact_test.go
@@ -1,13 +1,29 @@
 package nomad_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	nomadapi "github.com/hashicorp/nomad/api"
 
 	"github.com/gerrowadat/nomad-gitops/internal/nomad"
 )
+
+// deepObjectDiffChain builds a chain of nested ObjectDiffs depth levels deep,
+// returning the outermost node.
+func deepObjectDiffChain(depth int) *nomadapi.ObjectDiff {
+	cur := &nomadapi.ObjectDiff{Type: "Edited", Name: "leaf"}
+	for i := 1; i < depth; i++ {
+		cur = &nomadapi.ObjectDiff{
+			Type:    "Edited",
+			Name:    fmt.Sprintf("nested%d", i),
+			Objects: []*nomadapi.ObjectDiff{cur},
+		}
+	}
+	return cur
+}
 
 func TestRedactJobDiff_EnvValues(t *testing.T) {
 	d := &nomadapi.JobDiff{
@@ -171,5 +187,40 @@ func TestRedactJobDiff_NilEntriesSkipped(t *testing.T) {
 	}
 	if d.Fields[1].New != nomad.RedactedValue {
 		t.Errorf("non-nil env field should still be redacted: %q", d.Fields[1].New)
+	}
+}
+
+// TestRedactJobDiff_DepthCapPreventsUnboundedRecursion verifies that a plan
+// diff nested far deeper than any real Nomad job spec produces (e.g. a
+// deliberately crafted HCL file) does not recurse without bound. A shallow
+// sensitive field alongside the deep chain still gets redacted normally.
+func TestRedactJobDiff_DepthCapPreventsUnboundedRecursion(t *testing.T) {
+	deep := deepObjectDiffChain(nomad.MaxPlanDiffObjectDepth + 50)
+	d := &nomadapi.JobDiff{
+		Type: "Edited",
+		Objects: []*nomadapi.ObjectDiff{
+			deep,
+			{
+				Type:   "Edited",
+				Name:   "Config",
+				Fields: []*nomadapi.FieldDiff{{Type: "Edited", Name: "registry_password", Old: "a", New: "b"}},
+			},
+		},
+	}
+
+	done := make(chan int, 1)
+	go func() { done <- nomad.RedactJobDiff(d) }()
+	select {
+	case n := <-done:
+		if n != 1 {
+			t.Errorf("want 1 redaction (the shallow sensitive field), got %d", n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RedactJobDiff did not return; recursion depth cap did not stop it")
+	}
+
+	cfgField := d.Objects[1].Fields[0]
+	if cfgField.New != nomad.RedactedValue {
+		t.Errorf("shallow sensitive field alongside a deep chain should still be redacted: %q", cfgField.New)
 	}
 }

--- a/internal/server/render.go
+++ b/internal/server/render.go
@@ -121,10 +121,22 @@ func renderFields(b *strings.Builder, fields []*nomadapi.FieldDiff, indent strin
 }
 
 func renderObjects(b *strings.Builder, objects []*nomadapi.ObjectDiff, indent string) {
+	renderObjectsDepth(b, objects, indent, 1)
+}
+
+// renderObjectsDepth is renderObjects with an explicit nesting level. depth is
+// 1 at the top; beyond nomad.MaxPlanDiffObjectDepth, rendering stops rather
+// than recursing without bound, mirroring the cap classification and
+// redaction apply to the same plan-diff tree (internal/nomad/diffdepth.go).
+func renderObjectsDepth(b *strings.Builder, objects []*nomadapi.ObjectDiff, indent string, depth int) {
+	if depth > nomad.MaxPlanDiffObjectDepth {
+		fmt.Fprintf(b, "%s... (diff truncated: exceeds maximum nesting depth)\n", indent)
+		return
+	}
 	for _, o := range objects {
 		fmt.Fprintf(b, "%s%s %s {\n", indent, diffSymbol(o.Type), o.Name)
 		renderFields(b, o.Fields, indent+"  ")
-		renderObjects(b, o.Objects, indent+"  ")
+		renderObjectsDepth(b, o.Objects, indent+"  ", depth+1)
 		fmt.Fprintf(b, "%s}\n", indent)
 	}
 }

--- a/internal/server/render_test.go
+++ b/internal/server/render_test.go
@@ -318,3 +318,33 @@ func TestDiffs_NoApplyActionWhenEmpty(t *testing.T) {
 		t.Errorf("no reason arrow expected when ApplyAction is empty, got:\n%s", body)
 	}
 }
+
+// TestDiffs_DeepNesting_DoesNotHangOrPanic verifies that rendering a plan
+// diff nested far deeper than any real Nomad job spec produces (e.g. a
+// deliberately crafted HCL file) terminates instead of recursing without
+// bound, mirroring the depth cap classification and redaction apply to the
+// same tree (internal/nomad/diffdepth.go).
+func TestDiffs_DeepNesting_DoesNotHangOrPanic(t *testing.T) {
+	cur := &nomadapi.ObjectDiff{Type: "Edited", Name: "leaf"}
+	for i := 1; i < nomad.MaxPlanDiffObjectDepth+50; i++ {
+		cur = &nomadapi.ObjectDiff{Type: "Edited", Name: "nested", Objects: []*nomadapi.ObjectDiff{cur}}
+	}
+	diffs := []nomad.JobDiff{
+		{
+			JobID:    "myapp",
+			DiffType: nomad.DiffTypeModified,
+			PlanDiff: &nomadapi.JobDiff{Type: "Edited", ID: "myapp", Objects: []*nomadapi.ObjectDiff{cur}},
+		},
+	}
+
+	done := make(chan string, 1)
+	go func() { done <- diffsResponse(t, diffs, time.Now()) }()
+	select {
+	case body := <-done:
+		if !strings.Contains(body, "exceeds maximum nesting depth") {
+			t.Errorf("expected a truncation notice in the rendered output, got:\n%s", body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("/diffs did not return; recursion depth cap did not stop it")
+	}
+}


### PR DESCRIPTION
## Summary

Security audit pass over the codebase. `classifyDiff`, `RedactJobDiff`, and `renderDiffsText` all recurse into a Nomad plan diff's `Objects` tree with no depth limit. That tree's shape follows the job spec being diffed, which comes from HCL in the watched git branch — so a deliberately crafted job spec with deep object nesting could drive all three into effectively unbounded recursion: a stack-overflow crash (not a recoverable panic) that would take down the whole process, not just the one job's check.

This adds a shared `MaxPlanDiffObjectDepth` cap (`internal/nomad/diffdepth.go`, 200 levels — far beyond anything a real job spec produces):

- `classifyDiff` treats an over-deep diff conservatively as a non-image, non-meta change, so it can't be waved through by anything short of a `full` update policy.
- `RedactJobDiff` stops descending at the cap rather than recursing further (logs a warning).
- `renderDiffsText` (the `/diffs` text renderer) stops descending at the cap and prints a truncation notice instead of recursing further.

The rest of the audit (auth, CAS enforcement, secret redaction, webhook HMAC verification, SSH host-key handling, dependency versions) turned up nothing else exploitable — this codebase already has substantial existing hardening (see `internal/server/server_hardening_test.go`, `tests/regression/security_test.go`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (`make lint`)
- [x] `gofmt -l .` (clean)
- [x] `go test -race -timeout 90s ./...` — full suite passes
- [x] New tests added: `TestClassifyDiff_DepthCapPreventsUnboundedRecursion`, `TestRedactJobDiff_DepthCapPreventsUnboundedRecursion`, `TestDiffs_DeepNesting_DoesNotHangOrPanic` — each builds an `ObjectDiff` chain deeper than the cap and asserts the call returns (via a goroutine + 5s timeout) instead of hanging or crashing


---
_Generated by [Claude Code](https://claude.ai/code/session_012Z1dWeLTLn8i3E5XACUsqK)_