### PR TITLE
Add periodic security scanning and CVE remediation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+# Static analysis for source-level security issues (injection, unsafe
+# deserialization, weak crypto, etc.) — a different category from the
+# dependency/CVE scanning in security-scan.yml. Standard GitHub-native
+# setup: no external service, results land in the repository's Security tab.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "43 6 * * 4" # weekly, Thursday 06:43 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:go"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,107 @@
+name: Security scan
+
+# Periodic vulnerability scanning, independent of Dependabot's version-bump
+# PRs (.github/dependabot.yml): this looks for known CVEs in the *current*
+# tree on a schedule, rather than only when a dependency changes.
+#
+#   - govulncheck: the Go team's own scanner. Call-graph aware — it flags a
+#     vulnerable dependency only if nomad-gitops actually reaches the
+#     vulnerable code path, so it does not fail on CVEs in unreachable code
+#     the way a naive version-match scanner would.
+#   - Trivy: scans the Go module list and the built container image (base OS
+#     packages plus Go deps) against multiple CVE databases. Covers what
+#     govulncheck does not: OS-level vulnerabilities in the alpine base image.
+#
+# Both upload SARIF to GitHub code scanning so results show up as repository
+# Security alerts rather than requiring anyone to read workflow logs.
+on:
+  schedule:
+    - cron: "17 6 * * 1" # weekly, Monday 06:17 UTC
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck -format sarif ./... > govulncheck.sarif
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: govulncheck.sarif
+          category: govulncheck
+
+  trivy-fs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Trivy filesystem scan (go.mod / go.sum)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-fs.sarif
+          severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
+          exit-code: "0" # report, don't fail the run; see the docker-image job for the gate
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-filesystem
+
+  trivy-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build image for scanning
+        run: docker build -t nomad-gitops:scan .
+
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: nomad-gitops:scan
+          format: sarif
+          output: trivy-image.sarif
+          severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
+          exit-code: "1" # the published image is the actual release artifact: fail on known-fixable CVEs
+          ignore-unfixed: true
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,8 +40,8 @@ your deployment.
 
 ## Contributing
 
-- [Development](development.md) — build, test, the regression suite, and the
-  release process.
+- [Development](development.md) — build, test, the regression suite, security
+  scanning, and the release process.
 - [Nomad version compatibility](nomad-versions.md) — which Nomad versions each
   release is verified against.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,6 +33,42 @@ make clean        # remove build artefacts
 `make lint` fails if any file is not gofmt-clean, then runs `go vet`. CI runs the
 same `make lint` on every push and PR, so keep the tree formatted (`make fmt`).
 
+## Security scanning
+
+Three GitHub Actions workflows watch the repo and its dependencies on a
+schedule, independent of the regular test suite:
+
+- **[Dependabot](../.github/dependabot.yml)** — weekly version-bump PRs for Go
+  modules, GitHub Actions, and the Dockerfile's base images. If a bump fixes a
+  known vulnerability, Dependabot says so in the PR description.
+- **[Security scan](../.github/workflows/security-scan.yml)** (weekly, plus
+  every push to `main`) — `govulncheck` (the Go team's own scanner; flags a
+  vulnerable dependency only if nomad-gitops's code actually reaches the
+  vulnerable path) against the module, and
+  [Trivy](https://github.com/aquasecurity/trivy) against both `go.mod`/`go.sum`
+  and the built container image (catches OS-package CVEs in the `alpine` base
+  image that govulncheck, being Go-specific, cannot see). The image scan fails
+  the run on a known-fixable CRITICAL/HIGH CVE; the filesystem scan and
+  govulncheck report only, since a reachable-but-unfixed advisory shouldn't
+  block every push.
+- **[CodeQL](../.github/workflows/codeql.yml)** (weekly, plus every push and
+  PR to `main`) — GitHub's static analysis for source-level issues (injection,
+  unsafe deserialization, weak crypto) rather than known-CVE dependency
+  matching.
+
+All three upload SARIF results to the repository's **Security → Code scanning
+alerts** tab, so findings surface there rather than requiring anyone to read
+workflow logs. Dependabot's own vulnerability alerts (Settings → Code security)
+should also be enabled on the repo — that's what turns a known-CVE dependency
+into an automatic remediation PR rather than just a Security-tab alert.
+
+Run `govulncheck ./...` locally the same way CI does:
+
+```bash
+go install golang.org/x/vuln/cmd/govulncheck@latest
+govulncheck ./...
+```
+
 ## Simulating a webhook
 
 `scripts/send-webhook.sh` constructs a minimal GitHub push event payload and


### PR DESCRIPTION
## Summary

Three GitHub Actions workflows, independent of the regular test suite (`test.yml`):

- **`.github/dependabot.yml`** — add the `docker` ecosystem (the Dockerfile's `golang` builder and `alpine` runtime base images) alongside the existing `gomod` and `github-actions` entries, so a vulnerable base image gets the same automatic version-bump PR treatment a vulnerable Go module already gets.
- **`.github/workflows/security-scan.yml`** (new — weekly cron + every push to `main` + manual dispatch):
  - `govulncheck` (the Go team's own scanner) against the module. It's call-graph aware, so it only flags a dependency vulnerability if nomad-gitops's code actually reaches the vulnerable path, rather than failing on CVEs in code that's never called.
  - [Trivy](https://github.com/aquasecurity/trivy) against `go.mod`/`go.sum` and against the built container image. The image scan is what catches OS-package CVEs in the `alpine` base image — something govulncheck, being Go-specific, can't see.
  - The image scan fails the run on a known-fixable CRITICAL/HIGH CVE (that's the actual release artifact); the filesystem scan and govulncheck report only, since a reachable-but-not-yet-fixed advisory shouldn't fail every push.
- **`.github/workflows/codeql.yml`** (new — weekly cron + push/PR to `main` + manual dispatch): GitHub's static analysis for source-level issues (injection, unsafe deserialization, weak crypto) — a different category from known-CVE dependency matching.

All three upload SARIF results to the repository's **Security → Code scanning alerts** tab, so findings surface there rather than requiring anyone to read workflow logs.

Documented in a new "Security scanning" section in `docs/development.md`, linked from `docs/README.md`.

### Note for repo admin

Dependabot's *version-update* PRs (what this PR configures) are separate from Dependabot *vulnerability alerts*, which is a repo setting (Settings → Code security → Dependabot alerts). If that isn't already enabled, turning it on is what converts a known-CVE dependency into an automatic remediation PR rather than just a Security-tab alert — the docs note this but I can't toggle it myself from here.

## Test plan

- [x] Validated all three YAML files parse correctly (`yaml.safe_load`)
- [x] Verified current action versions/inputs against upstream docs (`aquasecurity/trivy-action@v0.36.0` input names, `govulncheck -format sarif` flag, `github/codeql-action@v4`)
- [x] `go build ./...` and `make lint` still pass (no Go code touched by this branch)
- [ ] Workflow itself can only be exercised by actually running in GitHub Actions after merge — not something I can dry-run locally


---
_Generated by [Claude Code](https://claude.ai/code/session_012Z1dWeLTLn8i3E5XACUsqK)_