### PR TITLE
Bump go directive to 1.25.12 for the crypto/tls ECH fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gerrowadat/nomad-gitops
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/go-git/go-billy/v5 v5.9.0


### PR DESCRIPTION
## What

Bumps the `go` directive in `go.mod` from 1.25.11 to 1.25.12.

## Why

govulncheck flags **GO-2026-5856** (Encrypted Client Hello privacy leak in
`crypto/tls`) as *reachable* from this codebase — traced through the HTTP
server, the Nomad API client, and go-git's TLS transport. It is fixed in
stdlib **go1.25.12** (and **go1.26.5** on the 1.26 branch).

The Security scan's govulncheck job installs the toolchain via
`go-version-file: go.mod`, so it runs under 1.25.11 and reports the alert —
even though the released image already builds with `golang:1.26.5-alpine`,
which carries the 1.26-branch fix. So the shipped binary was not vulnerable;
the alert reflected the `go` directive, not the build toolchain.

Bumping the directive to 1.25.12 installs the patched stdlib in CI and records
the true minimum-safe language version.

## Test

- `go build ./...` and `go test ./...` pass under go1.25.12.
- `govulncheck ./...` now reports **0 reachable vulnerabilities** (down from 1);
  the remaining findings are non-reachable module-level advisories (e.g. the
  `x/crypto/openpgp` deprecation, already triaged; `x/net`, addressed in the
  separate v0.55.0 bump PR).