### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 A security and dependency patch. No new features and no config, meta-key, or
 metric changes. Verified against Nomad 1.9.7, 1.10.5, 1.11.3, and 2.0.4 (full
-regression suite).
+regression suite). The default Nomad version for a Docker-started regression
+run is now 1.9.7 (was 1.9.6).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@
 > `nomad_botherer_*` metric names, because that is what those releases actually
 > shipped.
 
+## v1.0.2 — 2026-07-15
+
+A security and dependency patch. No new features and no config, meta-key, or
+metric changes. Verified against Nomad 1.9.7, 1.10.5, 1.11.3, and 2.0.4 (full
+regression suite).
+
+### Security
+
+- **Cap plan-diff nesting depth to prevent unbounded recursion.**
+  `classifyDiff`, `RedactJobDiff`, and the `/diffs` text renderer all walked a
+  Nomad plan diff's `Objects` tree with no depth limit. That tree's shape
+  follows the HCL job spec in the watched branch, so a deliberately crafted job
+  with deep object nesting could drive them into effectively unbounded
+  recursion — a stack-overflow crash that takes down the whole process, not a
+  recoverable panic. A shared `MaxPlanDiffObjectDepth` (200) now caps traversal:
+  classification treats an over-deep diff conservatively (non-image, non-meta,
+  so nothing short of a `full` policy could apply it), and redaction and
+  rendering stop descending and log a warning. See the new
+  [FAQ](docs/faq.md) entry, "A diff is truncated with 'exceeds maximum nesting
+  depth'".
+- **JSON API bearer-token check no longer hashes the key before comparing.**
+  The API auth middleware compared SHA-256 digests of the expected and
+  presented tokens; it now compares the raw `Bearer <key>` bytes in constant
+  time behind a length gate (`subtle.ConstantTimeCompare`), computed once per
+  middleware instance. Same timing guarantee, without hashing sensitive data
+  (code scanning alert #17).
+- **Periodic security scanning.** A weekly `security-scan` workflow runs
+  govulncheck, gosec, and Trivy and uploads SARIF to the repository's Security
+  tab (see [docs/development.md](docs/development.md)); added `SECURITY.md`.
+
+### Dependencies
+
+- Bump the `go` directive to 1.25.12 (picks up the `crypto/tls` ECH fix).
+- Bump `golang.org/x/net` to v0.55.0.
+- Bump the builder base image to `golang:1.26.5-alpine` and the runtime base
+  image to `alpine:3.24`.
+
 ## v1.0.1 — 2026-07-02
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test:
 	go test -race -timeout 60s ./...
 
 ## test-regression: run the regression suite against a real Nomad cluster (via Docker).
-## Requires Docker. Set NOMAD_VERSION to target a specific version (default: 1.9.6).
+## Requires Docker. Set NOMAD_VERSION to target a specific version (default: 1.9.7).
 ## Set NOMAD_ADDR to use an existing cluster instead of starting one via Docker.
 ## Example: make test-regression NOMAD_VERSION=1.11.3
 test-regression:

--- a/docs/nomad-versions.md
+++ b/docs/nomad-versions.md
@@ -22,6 +22,7 @@ After a successful run, add a row to the table below and update `tests/regressio
 
 | nomad-gitops | Nomad 1.9.x | Nomad 1.10.x | Nomad 1.11.x | Nomad 2.0.x | Notes |
 |----------------|:-----------:|:------------:|:------------:|:-----------:|-------|
+| v1.0.2         | ✅ 1.9.7    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.4    | Security/dependency patch; plan-diff depth cap (no behaviour change for well-formed jobs) |
 | v1.0.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Renamed from nomad-botherer; metrics `nomad_botherer_*` → `nomad_gitops_*` (no behaviour change) |
 | v0.9.1         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Workload identity fixed via `/v1/acl/login` token exchange (#74) |
 | v0.9.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Nomad workload-identity auth; policy-widening defers pre-existing drift (#69) |

--- a/tests/regression/compat.go
+++ b/tests/regression/compat.go
@@ -18,7 +18,7 @@
 //
 // Environment variables:
 //
-//	NOMAD_VERSION   Nomad version to pull from Docker Hub (default: 1.9.3)
+//	NOMAD_VERSION   Nomad version to pull from Docker Hub (default: 1.9.7)
 //	NOMAD_ADDR      Use an existing cluster; skips Docker startup entirely
 //	NOMAD_TOKEN     ACL token for the cluster (if needed)
 package regression
@@ -26,7 +26,7 @@ package regression
 import "time"
 
 // defaultNomadVersion is used when NOMAD_VERSION is unset and Docker is available.
-const defaultNomadVersion = "1.9.6"
+const defaultNomadVersion = "1.9.7"
 
 // VersionRecord documents the result of running the regression suite against
 // a specific Nomad version. Records are added manually after each release.

--- a/tests/regression/compat.go
+++ b/tests/regression/compat.go
@@ -51,6 +51,30 @@ type VersionRecord struct {
 //  3. Update docs/nomad-versions.md.
 var TestedVersions = []VersionRecord{
 	{
+		NomadVersion:  "2.0.4",
+		GitopsRelease: "v1.0.2",
+		TestedAt:      time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC),
+		Passed:        true,
+	},
+	{
+		NomadVersion:  "1.11.3",
+		GitopsRelease: "v1.0.2",
+		TestedAt:      time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC),
+		Passed:        true,
+	},
+	{
+		NomadVersion:  "1.10.5",
+		GitopsRelease: "v1.0.2",
+		TestedAt:      time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC),
+		Passed:        true,
+	},
+	{
+		NomadVersion:  "1.9.7",
+		GitopsRelease: "v1.0.2",
+		TestedAt:      time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC),
+		Passed:        true,
+	},
+	{
 		NomadVersion:  "2.0.2",
 		GitopsRelease: "v1.0.0",
 		TestedAt:      time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),


### PR DESCRIPTION
Rolls the changelog to v1.0.2 and records the compatibility matrix for the security and dependency fixes that landed on `main` since v1.0.1. No code changes in this PR — those are already merged; this is the release-prep bookkeeping.

## What's in v1.0.2

Security:
- Plan-diff depth cap (`MaxPlanDiffObjectDepth`) guarding `classifyDiff`, `RedactJobDiff`, and the `/diffs` renderer against unbounded recursion / stack-overflow from a crafted deeply-nested HCL job spec.
- JSON API bearer-token check compares the raw `Bearer <key>` bytes in constant time behind a length gate instead of hashing first (code scanning alert #17).
- Weekly `security-scan` workflow (govulncheck, gosec, Trivy) and `SECURITY.md`.

Dependencies:
- `go` directive → 1.25.12 (crypto/tls ECH fix), `golang.org/x/net` → v0.55.0, builder base → `golang:1.26.5-alpine`, runtime base → `alpine:3.24`.

## Testing

Full regression suite run against the latest patch in each supported Nomad line — **1.9.7, 1.10.5, 1.11.3, 2.0.4** — all green (~2 min each). Unit suite (`go test -race ./...`) and `make lint` pass. Recorded results in `docs/nomad-versions.md` and `tests/regression/compat.go`.

Tag `v1.0.2` after merge.