### PR TITLE
Fix two memory leaks: server goroutine and git object store growth

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,7 @@ read at startup; flags override them when explicitly passed.
 | `--managed-meta-prefix` | `MANAGED_META_PREFIX` | `gitops` | Prefix for job meta keys used by nomad-gitops. With prefix `gitops`, the key `gitops_managed = "true"` opts a job in. Empty disables meta-based selection. |
 | `--max-git-staleness` | `MAX_GIT_STALENESS` | `0` (disabled) | If the git repo has not been successfully fetched within this window, force an immediate fetch. Set to `0` to disable. E.g. `--max-git-staleness=30m` |
 | `--max-nomad-staleness` | `MAX_NOMAD_STALENESS` | `0` (disabled) | If the Nomad diff check has not run within this window, force an immediate check. Set to `0` to disable. E.g. `--max-nomad-staleness=10m` |
+| `--reclone-interval` | `RECLONE_INTERVAL` | `24h` | How often to discard the in-memory git clone and fetch a fresh one, reclaiming the object store that grows as pulls accumulate history over a long-running process. Runs from the same loop as polling, so it never overlaps a pull. Set to `0` to disable. |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 
 Logs are written to stderr as JSON (structured via `log/slog`).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,6 +113,11 @@ type Config struct {
 	MaxGitStaleness   time.Duration
 	MaxNomadStaleness time.Duration
 
+	// RecloneInterval is how often to discard the in-memory git clone and
+	// fetch a fresh one, reclaiming the git object store that grows as pulls
+	// accumulate history over a long-running process. 0 disables reclones.
+	RecloneInterval time.Duration
+
 	// Logging
 	LogLevel string
 }
@@ -167,6 +172,7 @@ func LoadFromArgs(fs *flag.FlagSet, args []string) (*Config, error) {
 	fs.StringVar(&c.ManagedMetaPrefix, "managed-meta-prefix", envOrDefault("MANAGED_META_PREFIX", "gitops"), "Prefix for job meta keys used by nomad-gitops (e.g. 'gitops' means 'gitops_managed = true' in a job's HCL opts it in). Git is always the source of truth for these keys: when a job has an HCL file, the live job's keys are ignored for selection. Empty disables meta-based selection.")
 	fs.DurationVar(&c.MaxGitStaleness, "max-git-staleness", envDurationOrDefault("MAX_GIT_STALENESS", 0), "Maximum time since last successful git fetch before forcing a refresh (0 disables)")
 	fs.DurationVar(&c.MaxNomadStaleness, "max-nomad-staleness", envDurationOrDefault("MAX_NOMAD_STALENESS", 0), "Maximum time since last successful Nomad diff check before forcing a refresh (0 disables)")
+	fs.DurationVar(&c.RecloneInterval, "reclone-interval", envDurationOrDefault("RECLONE_INTERVAL", 24*time.Hour), "How often to discard and re-fetch the in-memory git clone to reclaim memory that grows as pulls accumulate history (0 disables)")
 
 	fs.StringVar(&c.LogLevel, "log-level", envOrDefault("LOG_LEVEL", "info"), "Log level: debug, info, warn, error")
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -455,6 +455,43 @@ func TestLoadFromArgs_MaxNomadStalenessEnv(t *testing.T) {
 	}
 }
 
+func TestLoadFromArgs_RecloneIntervalDefault(t *testing.T) {
+	os.Unsetenv("RECLONE_INTERVAL")
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RecloneInterval != 24*time.Hour {
+		t.Errorf("RecloneInterval default: want 24h, got %v", cfg.RecloneInterval)
+	}
+}
+
+func TestLoadFromArgs_RecloneIntervalFlag(t *testing.T) {
+	os.Unsetenv("RECLONE_INTERVAL")
+	cfg, err := LoadFromArgs(newFS(), []string{
+		"--repo-url", "https://example.com/r.git",
+		"--reclone-interval", "0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RecloneInterval != 0 {
+		t.Errorf("RecloneInterval: want 0 (disabled), got %v", cfg.RecloneInterval)
+	}
+}
+
+func TestLoadFromArgs_RecloneIntervalEnv(t *testing.T) {
+	os.Setenv("RECLONE_INTERVAL", "6h")
+	t.Cleanup(func() { os.Unsetenv("RECLONE_INTERVAL") })
+	cfg, err := LoadFromArgs(newFS(), []string{"--repo-url", "https://example.com/r.git"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RecloneInterval != 6*time.Hour {
+		t.Errorf("RecloneInterval: want 6h, got %v", cfg.RecloneInterval)
+	}
+}
+
 func TestLoadFromArgs_StalenessIndependent(t *testing.T) {
 	os.Unsetenv("MAX_GIT_STALENESS")
 	os.Unsetenv("MAX_NOMAD_STALENESS")

--- a/internal/gitwatch/watcher.go
+++ b/internal/gitwatch/watcher.go
@@ -74,14 +74,16 @@ func NewWithRegistry(cfg *config.Config, onChange func(commit string), reg prome
 	}
 }
 
-// Clone performs the initial clone into memory. Must be called before Run.
-func (w *Watcher) Clone(ctx context.Context) error {
+// cloneInto performs a fresh clone into a new in-memory store and returns the
+// repository and its HEAD commit. It touches no Watcher state beyond the fetch
+// metrics, so it is safe to call while the current w.repo is still in use by a
+// concurrent reader; the caller decides when to swap the result in.
+func (w *Watcher) cloneInto(ctx context.Context) (*git.Repository, string, error) {
 	auth, err := w.buildAuth()
 	if err != nil {
-		return fmt.Errorf("building git auth: %w", err)
+		return nil, "", fmt.Errorf("building git auth: %w", err)
 	}
 
-	slog.Info("Cloning repository", "url", w.cfg.RepoURL, "branch", w.cfg.Branch)
 	w.gitFetches.Inc()
 
 	storer := memory.NewStorage()
@@ -96,12 +98,23 @@ func (w *Watcher) Clone(ctx context.Context) error {
 	})
 	if err != nil {
 		w.gitFetchErrors.Inc()
-		return fmt.Errorf("cloning %s: %w", w.cfg.RepoURL, err)
+		return nil, "", fmt.Errorf("cloning %s: %w", w.cfg.RepoURL, err)
 	}
 
 	commit, err := headCommit(repo)
 	if err != nil {
 		w.gitFetchErrors.Inc()
+		return nil, "", err
+	}
+	return repo, commit, nil
+}
+
+// Clone performs the initial clone into memory. Must be called before Run.
+func (w *Watcher) Clone(ctx context.Context) error {
+	slog.Info("Cloning repository", "url", w.cfg.RepoURL, "branch", w.cfg.Branch)
+
+	repo, commit, err := w.cloneInto(ctx)
+	if err != nil {
 		return err
 	}
 
@@ -118,10 +131,22 @@ func (w *Watcher) Clone(ctx context.Context) error {
 }
 
 // Run polls for updates on the configured interval and also reacts to Trigger
-// calls. Blocks until ctx is cancelled.
+// calls. It optionally re-clones on a slow cadence to reclaim memory. All git
+// operations it drives (pull, reclone) run from this single goroutine, so they
+// are serialised with each other and never overlap. Blocks until ctx is
+// cancelled.
 func (w *Watcher) Run(ctx context.Context) {
 	ticker := time.NewTicker(w.cfg.PollInterval)
 	defer ticker.Stop()
+
+	// A nil channel blocks forever in select, disabling the reclone case when
+	// the interval is 0.
+	var recloneC <-chan time.Time
+	if w.cfg.RecloneInterval > 0 {
+		recloneTicker := time.NewTicker(w.cfg.RecloneInterval)
+		defer recloneTicker.Stop()
+		recloneC = recloneTicker.C
+	}
 
 	for {
 		select {
@@ -132,6 +157,44 @@ func (w *Watcher) Run(ctx context.Context) {
 		case <-w.triggerCh:
 			slog.Info("Webhook trigger received, pulling")
 			w.pull(ctx)
+		case <-recloneC:
+			w.reclone(ctx)
+		}
+	}
+}
+
+// reclone replaces the in-memory clone with a fresh one, discarding the git
+// object store that grows as pulls accumulate history. The fetch runs before
+// any lock is taken, so concurrent readers keep using the old repo; the swap is
+// atomic under w.mu, and readers that captured the old *git.Repository continue
+// against it until they finish (the old store is freed once unreferenced). A
+// failed reclone leaves the existing clone untouched. Called only from Run, so
+// it never overlaps a pull.
+func (w *Watcher) reclone(ctx context.Context) {
+	slog.Info("Re-cloning repository to reclaim memory", "url", w.cfg.RepoURL, "branch", w.cfg.Branch)
+
+	repo, commit, err := w.cloneInto(ctx)
+	if err != nil {
+		slog.Warn("Reclone failed, keeping existing clone", "err", err)
+		return
+	}
+
+	now := time.Now()
+	w.mu.Lock()
+	prev := w.lastCommit
+	w.repo = repo
+	w.lastCommit = commit
+	w.lastUpdate = now
+	w.mu.Unlock()
+
+	w.gitLastUpdate.Set(float64(now.Unix()))
+
+	if commit != prev {
+		// A reclone normally lands on the same HEAD, but a commit may have
+		// arrived since the last pull; treat it like any other new commit.
+		slog.Info("New commit observed during reclone", "branch", w.cfg.Branch, "commit", commit, "prev", prev)
+		if w.onChange != nil {
+			w.onChange(commit)
 		}
 	}
 }

--- a/internal/gitwatch/watcher_clone_test.go
+++ b/internal/gitwatch/watcher_clone_test.go
@@ -222,6 +222,146 @@ func TestPull_RemoteGone_RecloneFails(t *testing.T) {
 	}
 }
 
+func TestReclone_NoNewCommit_SwapsCloneQuietly(t *testing.T) {
+	dir, _ := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+
+	changed := make(chan string, 1)
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, func(commit string) {
+		changed <- commit
+	})
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	first := w.LastCommit()
+	oldRepo := w.repo
+
+	w.reclone(context.Background())
+
+	if w.LastCommit() != first {
+		t.Errorf("reclone changed commit without a new commit: %q -> %q", first, w.LastCommit())
+	}
+	if w.repo == oldRepo {
+		t.Error("reclone should have swapped in a fresh repository")
+	}
+	select {
+	case c := <-changed:
+		t.Errorf("reclone fired onChange with no new commit: %q", c)
+	default:
+	}
+
+	// The swapped-in clone still serves file contents.
+	files, err := w.ReadHCLFiles()
+	if err != nil {
+		t.Fatalf("ReadHCLFiles after reclone: %v", err)
+	}
+	if files["app.hcl"] != `job "app" {}` {
+		t.Errorf("reclone lost file contents: %v", files)
+	}
+}
+
+func TestReclone_NewCommit_FiresOnChange(t *testing.T) {
+	dir, repo := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+
+	changed := make(chan string, 1)
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, func(commit string) {
+		changed <- commit
+	})
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	first := w.LastCommit()
+
+	// A commit arrives before the reclone (e.g. no pull ran in between).
+	commitFiles(t, dir, repo, map[string]string{"app.hcl": `job "app" { type = "service" }`}, "update app")
+
+	w.reclone(context.Background())
+
+	select {
+	case commit := <-changed:
+		if commit == first {
+			t.Error("reclone fired onChange with the old commit")
+		}
+		if commit != w.LastCommit() {
+			t.Errorf("onChange commit %q != LastCommit %q", commit, w.LastCommit())
+		}
+	default:
+		t.Fatal("reclone did not fire onChange for a new commit")
+	}
+}
+
+func TestReclone_Fails_KeepsExistingClone(t *testing.T) {
+	dir, _ := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+
+	w := newTestWatcher(&config.Config{RepoURL: dir, Branch: "main"}, nil)
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	first := w.LastCommit()
+
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("removing source repo: %v", err)
+	}
+	w.reclone(context.Background())
+
+	if w.LastCommit() != first {
+		t.Error("commit should be unchanged after a failed reclone")
+	}
+	if !w.Ready() {
+		t.Error("watcher should keep serving the last good clone after a failed reclone")
+	}
+	if _, err := w.ReadHCLFiles(); err != nil {
+		t.Errorf("existing clone should still be readable after failed reclone: %v", err)
+	}
+}
+
+func TestRun_RecloneIntervalCausesReclone(t *testing.T) {
+	dir, _ := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
+
+	w := newTestWatcher(&config.Config{
+		RepoURL:         dir,
+		Branch:          "main",
+		PollInterval:    time.Hour,
+		RecloneInterval: 50 * time.Millisecond,
+	}, nil)
+	if err := w.Clone(context.Background()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	w.mu.RLock()
+	oldRepo := w.repo
+	w.mu.RUnlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+
+	// Wait for the reclone ticker to swap in a fresh repository.
+	swapped := false
+	for i := 0; i < 100; i++ {
+		w.mu.RLock()
+		cur := w.repo
+		w.mu.RUnlock()
+		if cur != oldRepo {
+			swapped = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !swapped {
+		t.Error("reclone interval did not trigger a reclone")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}
+
 func TestRun_TriggerCausesPull(t *testing.T) {
 	dir, repo := makeDiskRepo(t, map[string]string{"app.hcl": `job "app" {}`})
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -169,18 +169,36 @@ func (s *Server) newHTTPServer() *http.Server {
 func (s *Server) Run(ctx context.Context) error {
 	srv := s.newHTTPServer()
 
+	// ListenAndServe runs in the background so the main path can wait on both
+	// it and ctx. Keeping it here (rather than a separate ctx.Done waiter
+	// goroutine) means the goroutine always ends before Run returns: on
+	// shutdown ListenAndServe returns ErrServerClosed, and on an early bind
+	// error it returns that error directly — neither outlives Run.
+	serveErr := make(chan error, 1)
 	go func() {
-		<-ctx.Done()
-		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = srv.Shutdown(shutCtx)
+		err := srv.ListenAndServe()
+		if err == http.ErrServerClosed {
+			err = nil
+		}
+		serveErr <- err
 	}()
 
 	slog.Info("HTTP server listening", "addr", s.cfg.ListenAddr)
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		return fmt.Errorf("http server: %w", err)
+
+	select {
+	case <-ctx.Done():
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+		// Drain the serve goroutine so it does not outlive Run.
+		<-serveErr
+		return nil
+	case err := <-serveErr:
+		if err != nil {
+			return fmt.Errorf("http server: %w", err)
+		}
+		return nil
 	}
-	return nil
 }
 
 // Handler returns the underlying http.Handler, useful for testing without a

--- a/internal/server/server_run_test.go
+++ b/internal/server/server_run_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -54,6 +55,44 @@ func TestServer_Run_BadListenAddr(t *testing.T) {
 	if err := srv.Run(ctx); err == nil {
 		t.Error("Run with an unbindable address should return an error")
 	}
+}
+
+// TestServer_Run_BadListenAddr_NoGoroutineLeak verifies that an early
+// ListenAndServe failure does not leave a goroutine blocked waiting on the
+// context. Run is called with an unbindable address (so it returns before the
+// context is ever cancelled) and the goroutine count is expected to settle
+// back to its pre-Run baseline.
+func TestServer_Run_BadListenAddr_NoGoroutineLeak(t *testing.T) {
+	cfg := &config.Config{ListenAddr: "256.256.256.256:0", WebhookPath: "/webhook", Branch: "main"}
+	diffSrc := &mockDiffSource{lastCheck: time.Now()}
+	gitSrc := &mockGitSource{lastUpdate: time.Now()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Let any goroutines from earlier tests settle before sampling.
+	time.Sleep(50 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	for i := 0; i < 20; i++ {
+		srv := server.NewWithRegistry(cfg, diffSrc, gitSrc, server.BuildInfo{Version: "test"}, prometheus.NewRegistry())
+		if err := srv.Run(ctx); err == nil {
+			t.Fatal("Run with an unbindable address should return an error")
+		}
+	}
+
+	// The old implementation leaked one goroutine per failed Run (blocked on
+	// ctx.Done()); 20 iterations would show a clear jump. Poll to let the
+	// runtime reclaim finished goroutines before asserting.
+	var got int
+	for i := 0; i < 20; i++ {
+		got = runtime.NumGoroutine()
+		if got <= baseline+2 {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Errorf("goroutine count grew after 20 failed Run calls: baseline %d, got %d", baseline, got)
 }
 
 // TestNew_DefaultRegistry exercises the production constructor, which


### PR DESCRIPTION
Two memory leaks found while auditing the codebase.

## Server shutdown goroutine leak

`server.Run` spawned a goroutine blocked on `<-ctx.Done()` to trigger shutdown, and ran `ListenAndServe` on the main path. When `ListenAndServe` failed early (unbindable address, port already in use), `Run` returned the error immediately but the shutdown-waiter goroutine stayed blocked on `ctx.Done()` until the parent context was eventually cancelled — one leaked goroutine per failed `Run`.

Fixed by running `ListenAndServe` in the background over a buffered channel and having the main path `select` on both it and `ctx.Done()`. On shutdown the goroutine is drained after `Shutdown`; on an early error it returns directly. Either way the goroutine ends before `Run` returns. Added `TestServer_Run_BadListenAddr_NoGoroutineLeak` (20 failed `Run` calls, asserts goroutine count settles to baseline).

## git in-memory object store growth

`gitwatch.Watcher` keeps a persistent in-memory clone (`memory.NewStorage()`) and pulls into it. go-git's in-memory object store never garbage-collects, so it grows with the repo's commit churn over the process lifetime — a slow leak for a long-running daemon.

Re-cloning every cycle is explicitly an anti-pattern for this project (CLAUDE.md), so this is a slow, opt-outable reclaim instead: `--reclone-interval` / `RECLONE_INTERVAL`, default `24h`, `0` disables. A ticker discards the clone and fetches a fresh one, freeing the accumulated object store.

Concurrency: the reclone runs from the same `Run` loop as `pull` and webhook triggers, so it never overlaps another git operation. The fetch (`cloneInto`) happens before any lock is taken, so concurrent `ReadHCLFiles`/`FileAtParentOf` readers keep using the old repo; the swap of `w.repo`/`w.lastCommit`/`w.lastUpdate` is atomic under `w.mu`, and readers that captured the old `*git.Repository` finish against it before it is freed. A failed reclone logs a warning and leaves the existing clone untouched. If a new commit landed since the last pull, the reclone fires `onChange` like any other advance.

## Tests

- gitwatch: reclone with no new commit (quiet swap, clone still serves files), reclone with a new commit (fires `onChange`), failed reclone (keeps existing clone), and the `Run` reclone ticker triggering a swap. Race detector clean.
- config: default (`24h`), flag (`0`), and env (`6h`) for `--reclone-interval`.
- server: goroutine-leak regression test.

`go test ./...`, `go test -race ./internal/gitwatch/`, and `make lint` all pass.

## Docs

- `docs/configuration.md`: `--reclone-interval` / `RECLONE_INTERVAL` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)