### PR TITLE
Explain policy-blocked diffs specifically in /diffs

### DIFF
--- a/docs/applying-changes.md
+++ b/docs/applying-changes.md
@@ -221,6 +221,14 @@ and what to change to apply it — for example:
 → not applied: update policy is "image-only" (set by gitops_update_policy in the job's HCL meta), but this change modifies more than the container image. Set the policy to "full" to apply it.
 ```
 
+When the `gitops_update_policy` meta value is not a recognised policy, it is
+coerced to `none`; the detail surfaces the raw value and the coercion rather
+than claiming the job asked for `none`:
+
+```
+→ not applied: gitops_update_policy is set to "yolo" in the job's HCL meta, which is not a valid update policy, so it is treated as "none" and never applies drift for this job. Set gitops_update_policy to "image-only" or "full" to enable applies.
+```
+
 The `/diffs` text view shows this `apply_detail` in place of the generic
 description when it is present; the JSON APIs expose it as the `apply_detail`
 field (omitted when the action alone is self-explanatory).

--- a/docs/applying-changes.md
+++ b/docs/applying-changes.md
@@ -210,3 +210,17 @@ in the OpenAPI spec. Values:
 | `deregister_pending_grace` | Removed from the repo; deregistration is waiting out `--deregister-grace`. |
 | `no_actionable_change` | The only diff is autoscaler-owned Count/Scaling churn. |
 | `blocked_known_failed` | The flap-loop guard is holding the apply: this spec matches a recent deployment that failed. Released when Git moves to a spec that has not failed. See [Rollback](rollback.md). |
+
+For a policy block, the coarse `blocked_by_policy` action is accompanied by an
+`apply_detail` string that names the effective policy, where it came from (the
+job's `gitops_update_policy` meta key or the `--default-update-policy` default),
+and what to change to apply it — for example:
+
+```
+→ not applied: update policy is "none" (the --default-update-policy default), which never applies drift for this job. Set the policy to "image-only" or "full" to enable applies.
+→ not applied: update policy is "image-only" (set by gitops_update_policy in the job's HCL meta), but this change modifies more than the container image. Set the policy to "full" to apply it.
+```
+
+The `/diffs` text view shows this `apply_detail` in place of the generic
+description when it is present; the JSON APIs expose it as the `apply_detail`
+field (omitted when the action alone is self-explanatory).

--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -64,7 +64,8 @@ Example `/api/v1/diffs` response when drift is detected:
       "hcl_file": "jobs/api-server.hcl",
       "diff_type": "modified",
       "detail": "Nomad plan shows diff type \"Edited\"",
-      "apply_action": "blocked_by_policy"
+      "apply_action": "blocked_by_policy",
+      "apply_detail": "not applied: update policy is \"none\" (the --default-update-policy default), which never applies drift for this job. Set the policy to \"image-only\" or \"full\" to enable applies."
     },
     {
       "job_id": "legacy-worker",
@@ -78,6 +79,12 @@ Example `/api/v1/diffs` response when drift is detected:
 }
 ```
 
-The `apply_action` field on each diff explains whether and why it will (not) be
-applied — see
+The `apply_action` field on each diff is a stable machine-readable disposition
+explaining whether and why it will (not) be applied — see
 [Why a diff is or is not applied](applying-changes.md#why-a-diff-is-or-is-not-applied).
+Some dispositions also carry an `apply_detail`: a human-readable string with the
+specific values involved (for a policy block, the effective policy, where it came
+from — a job's meta key or the `--default-update-policy` default — and what to
+change to apply it). It is omitted when `apply_action` alone says everything. The
+`/diffs` text view shows `apply_detail` in place of the generic description when
+it is present.

--- a/internal/nomad/apply_test.go
+++ b/internal/nomad/apply_test.go
@@ -290,6 +290,20 @@ func TestApply_ImageOnlyPolicy_MixedDiff_DetailExplainsScope(t *testing.T) {
 		`"image-only"`, "modifies more than the container image", "full")
 }
 
+func TestApply_InvalidMetaPolicy_DetailSurfacesRawValue(t *testing.T) {
+	var calls []registerCall
+	meta := map[string]string{"gitops_managed": "true", "gitops_update_policy": "yolo"}
+	mock := applyMock(meta, editedMixedDiff(), 42, &calls)
+	// Default is full; the invalid meta value is coerced to none. The detail
+	// must show the raw "yolo" and the coercion, not claim the operator set none.
+	d := nomad.NewWithClient(applyCfg("full", false), mock)
+
+	runCheck(t, d, "aaaa111fffff")
+
+	requireDetail(t, d, nomad.ApplyActionPolicyBlocked,
+		`gitops_update_policy is set to "yolo"`, "not a valid update policy", `treated as "none"`)
+}
+
 func TestApply_MetaPolicyFull_RegistersWithCAS(t *testing.T) {
 	var calls []registerCall
 	meta := map[string]string{"gitops_managed": "true", "gitops_update_policy": "full"}

--- a/internal/nomad/apply_test.go
+++ b/internal/nomad/apply_test.go
@@ -231,6 +231,65 @@ func TestApply_DefaultPolicyNone_NothingApplied(t *testing.T) {
 	}
 }
 
+// requireDetail fails unless every want substring is present in the diff's
+// ApplyDetail.
+func requireDetail(t *testing.T, d *nomad.Differ, wantAction nomad.ApplyAction, wants ...string) {
+	t.Helper()
+	diffs, _, _ := d.Diffs()
+	if len(diffs) != 1 {
+		t.Fatalf("want 1 diff, got %d: %+v", len(diffs), diffs)
+	}
+	if diffs[0].ApplyAction != wantAction {
+		t.Fatalf("ApplyAction: want %q, got %q", wantAction, diffs[0].ApplyAction)
+	}
+	detail := diffs[0].ApplyDetail
+	if detail == "" {
+		t.Fatalf("ApplyDetail should be populated for a %q diff", wantAction)
+	}
+	for _, w := range wants {
+		if !strings.Contains(detail, w) {
+			t.Errorf("ApplyDetail %q should mention %q", detail, w)
+		}
+	}
+}
+
+func TestApply_DefaultPolicyNone_DetailNamesDefaultSource(t *testing.T) {
+	var calls []registerCall
+	mock := applyMock(map[string]string{"gitops_managed": "true"}, editedMixedDiff(), 42, &calls)
+	d := nomad.NewWithClient(applyCfg("none", false), mock)
+
+	runCheck(t, d, "aaaa111fffff")
+
+	// The job sets no gitops_update_policy, so "none" is the default's doing.
+	requireDetail(t, d, nomad.ApplyActionPolicyBlocked,
+		`"none"`, "--default-update-policy default", "image-only", "full")
+}
+
+func TestApply_MetaPolicyNone_DetailNamesMetaKey(t *testing.T) {
+	var calls []registerCall
+	meta := map[string]string{"gitops_managed": "true", "gitops_update_policy": "none"}
+	mock := applyMock(meta, editedMixedDiff(), 42, &calls)
+	// Default is full; the per-job meta key is what forces "none".
+	d := nomad.NewWithClient(applyCfg("full", false), mock)
+
+	runCheck(t, d, "aaaa111fffff")
+
+	requireDetail(t, d, nomad.ApplyActionPolicyBlocked,
+		`"none"`, "set by gitops_update_policy in the job's HCL meta")
+}
+
+func TestApply_ImageOnlyPolicy_MixedDiff_DetailExplainsScope(t *testing.T) {
+	var calls []registerCall
+	meta := map[string]string{"gitops_managed": "true", "gitops_update_policy": "image-only"}
+	mock := applyMock(meta, editedMixedDiff(), 42, &calls)
+	d := nomad.NewWithClient(applyCfg("none", false), mock)
+
+	runCheck(t, d, "aaaa111fffff")
+
+	requireDetail(t, d, nomad.ApplyActionPolicyBlocked,
+		`"image-only"`, "modifies more than the container image", "full")
+}
+
 func TestApply_MetaPolicyFull_RegistersWithCAS(t *testing.T) {
 	var calls []registerCall
 	meta := map[string]string{"gitops_managed": "true", "gitops_update_policy": "full"}

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -1186,13 +1186,20 @@ func (d *Differ) effectivePolicy(meta map[string]string) UpdatePolicy {
 	return d.defaultPolicy
 }
 
+// policyMetaKey is the meta key that overrides the update policy per job.
+func (d *Differ) policyMetaKey() string {
+	return d.managedMetaPrefix + "_update_policy"
+}
+
 // policySource describes where a job's effective update policy comes from, for
-// operator-facing messages: the per-job HCL meta key or the configured default.
+// operator-facing messages: the per-job HCL meta key (only when its value is a
+// recognised policy) or the configured default. A present-but-invalid meta
+// value is handled separately by policyBlockedDetail, since effectivePolicy
+// coerces it to "none" and the raw value is what the operator needs to see.
 func (d *Differ) policySource(meta map[string]string) string {
 	if d.managedMetaPrefix != "" {
-		key := d.managedMetaPrefix + "_update_policy"
-		if _, ok := meta[key]; ok {
-			return "set by " + key + " in the job's HCL meta"
+		if v, ok := meta[d.policyMetaKey()]; ok && ValidUpdatePolicy(v) {
+			return "set by " + d.policyMetaKey() + " in the job's HCL meta"
 		}
 	}
 	return "the --default-update-policy default"
@@ -1202,6 +1209,14 @@ func (d *Differ) policySource(meta map[string]string) string {
 // candidate's effective update policy stops this change from being applied: the
 // policy value, where it came from, and what would need to change to apply it.
 func (d *Differ) policyBlockedDetail(c *updateCandidate, policy UpdatePolicy) string {
+	// A present-but-unrecognised meta value is coerced to "none" by
+	// effectivePolicy. Report the actual value and the coercion rather than
+	// claiming the operator asked for "none".
+	if d.managedMetaPrefix != "" {
+		if v, ok := c.job.Meta[d.policyMetaKey()]; ok && !ValidUpdatePolicy(v) {
+			return fmt.Sprintf("not applied: %s is set to %q in the job's HCL meta, which is not a valid update policy, so it is treated as %q and never applies drift for this job. Set %s to \"image-only\" or \"full\" to enable applies.", d.policyMetaKey(), v, UpdatePolicyNone, d.policyMetaKey())
+		}
+	}
 	src := d.policySource(c.job.Meta)
 	switch policy {
 	case UpdatePolicyNone:

--- a/internal/nomad/differ.go
+++ b/internal/nomad/differ.go
@@ -72,6 +72,13 @@ type JobDiff struct {
 	// non-application without log scraping.
 	ApplyAction ApplyAction `json:"apply_action,omitempty"`
 
+	// ApplyDetail is an optional, more specific human-readable explanation
+	// that refines ApplyAction with the actual values involved — for example,
+	// which update policy blocked the change, where that policy came from, and
+	// what would need to change. Empty when ApplyAction.Describe() already says
+	// everything there is to say.
+	ApplyDetail string `json:"apply_detail,omitempty"`
+
 	// PlanDiff holds the structured diff from the Nomad plan API.
 	// Only populated for DiffTypeModified entries.
 	PlanDiff *nomadapi.JobDiff `json:"-"`
@@ -791,16 +798,17 @@ func (d *Differ) parseHCLCandidates(hclFiles map[string]string, metaSeen map[str
 // JobUpdate: the parsed job, the CAS token, and the diff classification.
 // Policy gating happens later, in maybeEnqueueUpdate.
 type updateCandidate struct {
-	jobID       string
-	hclFile     string
-	job         *nomadapi.Job
-	modifyIndex uint64
-	class       DiffClass
-	isCreation  bool               // job absent (or dead) in Nomad: first-time registration
-	globSel     bool               // selected by job-selector-glob (no opt-in moment)
-	operation   JobUpdateOperation // REGISTER (default) or DEREGISTER
-	policy      UpdatePolicy       // effective policy, for DEREGISTER candidates (from live meta)
-	action      ApplyAction        // disposition, decided in decideApplyAction
+	jobID        string
+	hclFile      string
+	job          *nomadapi.Job
+	modifyIndex  uint64
+	class        DiffClass
+	isCreation   bool               // job absent (or dead) in Nomad: first-time registration
+	globSel      bool               // selected by job-selector-glob (no opt-in moment)
+	operation    JobUpdateOperation // REGISTER (default) or DEREGISTER
+	policy       UpdatePolicy       // effective policy, for DEREGISTER candidates (from live meta)
+	action       ApplyAction        // disposition, decided in decideApplyAction
+	actionDetail string             // optional specific explanation refining action
 }
 
 // jobModifyIndex safely extracts a job's ModifyIndex.
@@ -1050,6 +1058,7 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 			}
 			if cand != nil {
 				diff.ApplyAction = cand.action
+				diff.ApplyDetail = cand.actionDetail
 			}
 			// A diff confined to our own meta keys is an expected,
 			// non-disruptive difference. By default it is not counted as
@@ -1120,6 +1129,7 @@ func (d *Differ) Check(hclFiles map[string]string, commit string) error {
 				}
 				cand.action = d.decideDeregisterAction(cand)
 				diff.ApplyAction = cand.action
+				diff.ApplyDetail = cand.actionDetail
 				candidates = append(candidates, cand)
 			}
 			diffs = append(diffs, diff)
@@ -1174,6 +1184,35 @@ func (d *Differ) effectivePolicy(meta map[string]string) UpdatePolicy {
 		}
 	}
 	return d.defaultPolicy
+}
+
+// policySource describes where a job's effective update policy comes from, for
+// operator-facing messages: the per-job HCL meta key or the configured default.
+func (d *Differ) policySource(meta map[string]string) string {
+	if d.managedMetaPrefix != "" {
+		key := d.managedMetaPrefix + "_update_policy"
+		if _, ok := meta[key]; ok {
+			return "set by " + key + " in the job's HCL meta"
+		}
+	}
+	return "the --default-update-policy default"
+}
+
+// policyBlockedDetail explains, for the /diffs view and JSON API, exactly why a
+// candidate's effective update policy stops this change from being applied: the
+// policy value, where it came from, and what would need to change to apply it.
+func (d *Differ) policyBlockedDetail(c *updateCandidate, policy UpdatePolicy) string {
+	src := d.policySource(c.job.Meta)
+	switch policy {
+	case UpdatePolicyNone:
+		return fmt.Sprintf("not applied: update policy is %q (%s), which never applies drift for this job. Set the policy to \"image-only\" or \"full\" to enable applies.", policy, src)
+	case UpdatePolicyImageOnly:
+		if c.isCreation {
+			return fmt.Sprintf("not applied: update policy is %q (%s), and a first-time registration is not an image-only change. Set the policy to \"full\" to allow creating this job.", policy, src)
+		}
+		return fmt.Sprintf("not applied: update policy is %q (%s), but this change modifies more than the container image. Set the policy to \"full\" to apply it.", policy, src)
+	}
+	return ""
 }
 
 // SetHistorySource wires the git-history accessor used to detect pre-existing
@@ -1314,6 +1353,7 @@ func (d *Differ) decideDeregisterAction(c *updateCandidate) ApplyAction {
 	}
 	if c.policy != UpdatePolicyFull {
 		d.updatesBlockedByPolicy.WithLabelValues(c.jobID, string(c.policy)).Inc()
+		c.actionDetail = fmt.Sprintf("not applied: deregistration requires update policy \"full\", but this job's effective policy is %q. A job removed from the repo is only deregistered under a full policy.", c.policy)
 		return ApplyActionPolicyBlocked
 	}
 	if !d.orphanGraceElapsed(c.jobID) {
@@ -1369,12 +1409,14 @@ func (d *Differ) decideApplyAction(c *updateCandidate, commit string, q *nomadap
 	switch policy {
 	case UpdatePolicyNone:
 		d.updatesBlockedByPolicy.WithLabelValues(c.jobID, string(policy)).Inc()
+		c.actionDetail = d.policyBlockedDetail(c, policy)
 		return ApplyActionPolicyBlocked
 	case UpdatePolicyImageOnly:
 		// Initial registration is full-only by design: registering a job
 		// for the first time is not an image-only change.
 		if c.isCreation || c.class != DiffClassImageOnly {
 			d.updatesBlockedByPolicy.WithLabelValues(c.jobID, string(policy)).Inc()
+			c.actionDetail = d.policyBlockedDetail(c, policy)
 			return ApplyActionPolicyBlocked
 		}
 	}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -186,7 +186,8 @@ const openAPISpec = `{
           "hcl_file":  {"type": "string"},
           "diff_type": {"type": "string", "enum": ["modified", "missing_from_nomad", "missing_from_hcl"]},
           "detail":    {"type": "string"},
-          "apply_action": {"type": "string", "description": "Disposition of this diff: whether it will be applied and, if not, why.", "enum": ["queued", "blocked_by_policy", "blocked_preexisting_drift", "blocked_creation_disabled", "skipped_meta_only", "observation_only", "queued_deregister", "deregister_pending_grace", "no_actionable_change", "blocked_known_failed"]}
+          "apply_action": {"type": "string", "description": "Disposition of this diff: whether it will be applied and, if not, why.", "enum": ["queued", "blocked_by_policy", "blocked_preexisting_drift", "blocked_creation_disabled", "skipped_meta_only", "observation_only", "queued_deregister", "deregister_pending_grace", "no_actionable_change", "blocked_known_failed"]},
+          "apply_detail": {"type": "string", "description": "Optional human-readable explanation refining apply_action with the specific values involved (e.g. the effective update policy, its source, and what to change to apply the diff). Omitted when apply_action alone is self-explanatory."}
         }
       },
       "SelectedJob": {

--- a/internal/server/render.go
+++ b/internal/server/render.go
@@ -50,7 +50,9 @@ func renderDiffsText(diffs []nomad.JobDiff, lastCheck time.Time, commit string, 
 				fmt.Fprintf(&b, "  %s\n", d.Detail)
 			}
 		}
-		if d.ApplyAction != "" {
+		if d.ApplyDetail != "" {
+			fmt.Fprintf(&b, "  → %s\n", d.ApplyDetail)
+		} else if d.ApplyAction != "" {
 			fmt.Fprintf(&b, "  → %s\n", d.ApplyAction.Describe())
 		}
 	}

--- a/internal/server/render_internal_test.go
+++ b/internal/server/render_internal_test.go
@@ -140,3 +140,45 @@ func TestRenderFields_EditedType(t *testing.T) {
 		t.Errorf("edited field should render with '~' and old/new values, got:\n%s", out)
 	}
 }
+
+// TestRenderDiffsText_ApplyDetailPreferred verifies that when a diff carries a
+// specific ApplyDetail, the renderer shows it instead of the generic
+// ApplyAction.Describe() text.
+func TestRenderDiffsText_ApplyDetailPreferred(t *testing.T) {
+	detail := `not applied: update policy is "none" (the --default-update-policy default), which never applies drift for this job. Set the policy to "image-only" or "full" to enable applies.`
+	diffs := []nomad.JobDiff{
+		{
+			JobID:       "myapp",
+			HCLFile:     "myapp.hcl",
+			DiffType:    nomad.DiffTypeModified,
+			Detail:      "changed",
+			ApplyAction: nomad.ApplyActionPolicyBlocked,
+			ApplyDetail: detail,
+		},
+	}
+	out := renderDiffsText(diffs, time.Now(), "abc123", false)
+	if !strings.Contains(out, detail) {
+		t.Errorf("renderer should show the specific ApplyDetail, got:\n%s", out)
+	}
+	if strings.Contains(out, nomad.ApplyActionPolicyBlocked.Describe()) {
+		t.Errorf("renderer should not fall back to the generic Describe() when ApplyDetail is set, got:\n%s", out)
+	}
+}
+
+// TestRenderDiffsText_ApplyActionFallback verifies that without an ApplyDetail
+// the renderer still shows the generic ApplyAction description.
+func TestRenderDiffsText_ApplyActionFallback(t *testing.T) {
+	diffs := []nomad.JobDiff{
+		{
+			JobID:       "myapp",
+			HCLFile:     "myapp.hcl",
+			DiffType:    nomad.DiffTypeModified,
+			Detail:      "changed",
+			ApplyAction: nomad.ApplyActionCreationBlocked,
+		},
+	}
+	out := renderDiffsText(diffs, time.Now(), "abc123", false)
+	if !strings.Contains(out, nomad.ApplyActionCreationBlocked.Describe()) {
+		t.Errorf("renderer should fall back to Describe() when ApplyDetail is empty, got:\n%s", out)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -368,6 +368,7 @@ type DiffEntry struct {
 	DiffType    string `json:"diff_type"`
 	Detail      string `json:"detail"`
 	ApplyAction string `json:"apply_action,omitempty"`
+	ApplyDetail string `json:"apply_detail,omitempty"`
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
@@ -397,6 +398,7 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 			DiffType:    string(d.DiffType),
 			Detail:      d.Detail,
 			ApplyAction: string(d.ApplyAction),
+			ApplyDetail: d.ApplyDetail,
 		})
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -312,6 +312,38 @@ func TestHealthz_WithDiffs(t *testing.T) {
 	}
 }
 
+func TestHealthz_ApplyDetailInJSON(t *testing.T) {
+	detail := `not applied: update policy is "none" (the --default-update-policy default), which never applies drift for this job.`
+	diffs := []nomad.JobDiff{
+		{
+			JobID:       "api",
+			HCLFile:     "jobs/api.hcl",
+			DiffType:    nomad.DiffTypeModified,
+			Detail:      "Edited",
+			ApplyAction: nomad.ApplyActionPolicyBlocked,
+			ApplyDetail: detail,
+		},
+	}
+	srv, _ := newTestServer(t, diffs)
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	var resp server.HealthResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Diffs) != 1 {
+		t.Fatalf("want 1 diff entry, got %d", len(resp.Diffs))
+	}
+	if resp.Diffs[0].ApplyAction != string(nomad.ApplyActionPolicyBlocked) {
+		t.Errorf("apply_action: want %q, got %q", nomad.ApplyActionPolicyBlocked, resp.Diffs[0].ApplyAction)
+	}
+	if resp.Diffs[0].ApplyDetail != detail {
+		t.Errorf("apply_detail: want %q, got %q", detail, resp.Diffs[0].ApplyDetail)
+	}
+}
+
 func TestHealthz_ContentType(t *testing.T) {
 	srv, _ := newTestServer(t, nil)
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)


### PR DESCRIPTION
When a change is committed for a managed job but its update policy won't apply it, `/diffs` only said:

```
→ not applied: blocked by update policy
```

That doesn't tell you *which* policy is in effect, where it came from, or what to change. This adds a specific explanation.

## What changed

`JobDiff` gains an optional `ApplyDetail` string, populated when the update policy blocks a change. `ApplyAction` stays the stable machine-readable disposition (`blocked_by_policy` etc.); `ApplyDetail` refines it with the actual values:

- **policy `none`** — `not applied: update policy is "none" (<source>), which never applies drift for this job. Set the policy to "image-only" or "full" to enable applies.`
- **policy `image-only`, non-image change** — `... but this change modifies more than the container image. Set the policy to "full" to apply it.`
- **policy `image-only`, first-time registration** — `... and a first-time registration is not an image-only change. Set the policy to "full" to allow creating this job.`
- **deregister under a non-`full` policy** — `not applied: deregistration requires update policy "full", but this job's effective policy is "<policy>". ...`

`<source>` is either `set by gitops_update_policy in the job's HCL meta` or `the --default-update-policy default`, so you know which knob to turn.

## Where it shows up

- `/diffs` text view prints `ApplyDetail` in place of the generic `ApplyAction.Describe()` when present, and falls back to the description otherwise.
- `/api/v1/diffs` and `/healthz` JSON expose it as `apply_detail` (omitted when empty).
- Inline OpenAPI spec (`/api/openapi.json`) documents the field.

## Tests

- nomad: default-policy-none names the `--default-update-policy` default source; meta-policy-none names the `gitops_update_policy` key; image-only mixed diff explains the scope. (`internal/nomad/apply_test.go`)
- server: renderer prefers `ApplyDetail` over `Describe()`, and falls back when empty; `apply_detail` round-trips through the `/healthz` JSON. (`render_internal_test.go`, `server_test.go`)

## Docs

- `docs/applying-changes.md`: examples of the policy `apply_detail`.
- `docs/json-api.md`: `apply_detail` in the example response and field description.

`go test ./...` and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)