### PR TITLE
Name the drifting job in the NomadJobDrift alert

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -141,7 +141,7 @@ configuration files:
 
 The alerts cover:
 
-- **NomadJobDrift** — any drift detected for more than 5 minutes
+- **NomadJobDrift** — any drift detected for more than 5 minutes, alerting per job so the alert names the drifting job and diff type
 - **NomadJobModifiedPersistent** — a job's config has diverged from git for over 1 hour
 - **NomadJobMissingFromNomad** — a git-defined job has been absent from Nomad for over 15 minutes
 - **NomadJobMissingFromHCL** — a running Nomad job has no HCL file in the repo for over 1 hour

--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -12,21 +12,26 @@ groups:
   - name: nomad_gitops_drift
     rules:
 
-      # Any drift detected. The 5m 'for' window absorbs the normal gap
-      # between a git push and the next diff check — a job transitioning
-      # through a deploy will look drifted briefly. Tune to your
-      # --diff-interval / --poll-interval values.
+      # Any drift detected, alerting per job so the offending job and diff
+      # type are named in the alert itself (via the `job` and `diff_type`
+      # labels) rather than only a count. nomad_gitops_job_diffs is 1 for each
+      # drifting (job, diff_type) and absent otherwise, so the 5m 'for' window
+      # means "this job has been drifting for 5m" — absorbing the normal gap
+      # between a git push and the next diff check, where a job transitioning
+      # through a deploy looks drifted briefly. Tune to your --diff-interval /
+      # --poll-interval values. Alertmanager will group the per-job alerts
+      # (e.g. group_by: [alertname]) into a single notification listing them.
       - alert: NomadJobDrift
-        expr: nomad_gitops:drifted_jobs:total > 0
+        expr: nomad_gitops_job_diffs > 0
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: "{{ $value }} Nomad job(s) have drifted from git"
+          summary: "Nomad job {{ $labels.job }} has drifted from git ({{ $labels.diff_type }})"
           description: >
-            nomad-gitops has detected drift between the git repo and the
-            live Nomad cluster for more than 5 minutes.
-            Check /healthz or /diffs for details.
+            nomad-gitops has detected drift ({{ $labels.diff_type }}) between
+            the git repo and the live Nomad cluster for job {{ $labels.job }}
+            for more than 5 minutes. Check /healthz or /diffs for details.
 
       # A specific job has been in a modified state for an extended period.
       # This usually means a deploy is stuck or someone edited the job in


### PR DESCRIPTION
The `NomadJobDrift` alert fired on the aggregate `nomad_gitops:drifted_jobs:total`, so the notification only said "N Nomad job(s) have drifted from git" — you had to open `/diffs` to find which. The other three drift alerts in the group already name the job via `{{ $labels.job }}`; this brings the catch-all in line.

## Change

`monitoring/alerts.yml` — `NomadJobDrift` now uses the per-job `nomad_gitops_job_diffs` metric (1 for each drifting `(job, diff_type)`, absent otherwise) instead of the aggregate count:

```yaml
expr: nomad_gitops_job_diffs > 0
for: 5m
annotations:
  summary: "Nomad job {{ $labels.job }} has drifted from git ({{ $labels.diff_type }})"
  description: >
    nomad-gitops has detected drift ({{ $labels.diff_type }}) between the git
    repo and the live Nomad cluster for job {{ $labels.job }} for more than
    5 minutes. Check /healthz or /diffs for details.
```

It now fires per drifting job and names the job and diff type. The `5m` `for` window keeps the same "has been drifting for 5m" semantics because the metric only exists while a job is drifting. Alertmanager groups the per-job alerts (e.g. `group_by: [alertname]`) into one notification listing them.

The `nomad_gitops:drifted_jobs:total` recording rule is left in place — it's still the right series for a single "is anything wrong?" dashboard gauge.

## Docs

- `docs/monitoring.md`: note that `NomadJobDrift` alerts per job and names the drifting job/diff type.

YAML validated (no `promtool` in the environment; templating and PromQL mirror the existing per-job alerts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)