### PR TITLE
Release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@
 > `nomad_botherer_*` metric names, because that is what those releases actually
 > shipped.
 
+## v1.0.3 — 2026-07-31
+
+A small feature and dependency patch. All changes are backward compatible;
+defaults are unchanged. Verified against Nomad 1.9.7, 1.10.5, 1.11.3, and 2.0.4
+(full regression suite).
+
+### Changed
+
+- **`/diffs` and the JSON API now explain a policy-blocked diff specifically.**
+  A diff held back by the update policy previously showed only "blocked by
+  update policy". Diffs now carry an optional `apply_detail` string that names
+  the effective policy, where it came from (the job's `gitops_update_policy`
+  meta key or the `--default-update-policy` default), and what to change to
+  apply it. An unrecognised `gitops_update_policy` value — which is coerced to
+  `none` — is reported as such, showing the raw value rather than claiming the
+  operator asked for `none`. `apply_detail` appears in the `/diffs` text view
+  (in place of the generic line), in the `/api/v1/diffs` and `/healthz` JSON,
+  and in the OpenAPI spec. `apply_action` is unchanged. See
+  [Applying changes](docs/applying-changes.md#why-a-diff-is-or-is-not-applied).
+- **The example `NomadJobDrift` alert now names the drifting job.** It alerts on
+  the per-job `nomad_gitops_job_diffs` metric instead of the aggregate count, so
+  the alert labels and annotations carry the job and diff type. See
+  [`monitoring/alerts.yml`](monitoring/alerts.yml).
+
+### Added
+
+- **`--reclone-interval` / `RECLONE_INTERVAL` (default `24h`, `0` disables).**
+  The in-memory git clone is periodically discarded and re-fetched to reclaim
+  the go-git object store, which grows with commit churn over a long-running
+  process. The reclone runs from the same loop as polling, so it never overlaps
+  a pull. See [Configuration](docs/configuration.md).
+
+### Fixed
+
+- **Server shutdown goroutine leak.** `Server.Run` spawned a goroutine that
+  blocked on the context to trigger shutdown; when `ListenAndServe` failed early
+  (e.g. an unbindable address) that goroutine was left blocked. `ListenAndServe`
+  now runs in the background and `Run` selects on both it and the context, so the
+  goroutine always ends before `Run` returns.
+
+### Dependencies
+
+- Bump `golang.org/x/crypto` to v0.54.0.
+- Bump `github.com/prometheus/client_golang` to v1.24.1.
+- Bump `github.com/go-git/go-billy/v5` to v5.9.1.
+- Bump `actions/setup-go` to v7 (CI).
+- Transitive bumps: `prometheus/common` v0.70.1, `prometheus/procfs` v0.21.1,
+  `golang.org/x/net` v0.57.0, `golang.org/x/sys` v0.47.0.
+
 ## v1.0.2 — 2026-07-15
 
 A security and dependency patch. No new features and no config, meta-key, or

--- a/docs/nomad-versions.md
+++ b/docs/nomad-versions.md
@@ -22,6 +22,7 @@ After a successful run, add a row to the table below and update `tests/regressio
 
 | nomad-gitops | Nomad 1.9.x | Nomad 1.10.x | Nomad 1.11.x | Nomad 2.0.x | Notes |
 |----------------|:-----------:|:------------:|:------------:|:-----------:|-------|
+| v1.0.3         | ✅ 1.9.7    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.4    | `apply_detail` on diffs; per-job drift alert; `--reclone-interval`; dependency bumps (no Nomad-facing behaviour change) |
 | v1.0.2         | ✅ 1.9.7    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.4    | Security/dependency patch; plan-diff depth cap (no behaviour change for well-formed jobs) |
 | v1.0.0         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Renamed from nomad-botherer; metrics `nomad_botherer_*` → `nomad_gitops_*` (no behaviour change) |
 | v0.9.1         | ✅ 1.9.6    | ✅ 1.10.5    | ✅ 1.11.3    | ✅ 2.0.2    | Workload identity fixed via `/v1/acl/login` token exchange (#74) |

--- a/tests/regression/compat.go
+++ b/tests/regression/compat.go
@@ -52,6 +52,30 @@ type VersionRecord struct {
 var TestedVersions = []VersionRecord{
 	{
 		NomadVersion:  "2.0.4",
+		GitopsRelease: "v1.0.3",
+		TestedAt:      time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+		Passed:        true,
+	},
+	{
+		NomadVersion:  "1.11.3",
+		GitopsRelease: "v1.0.3",
+		TestedAt:      time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+		Passed:        true,
+	},
+	{
+		NomadVersion:  "1.10.5",
+		GitopsRelease: "v1.0.3",
+		TestedAt:      time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+		Passed:        true,
+	},
+	{
+		NomadVersion:  "1.9.7",
+		GitopsRelease: "v1.0.3",
+		TestedAt:      time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+		Passed:        true,
+	},
+	{
+		NomadVersion:  "2.0.4",
 		GitopsRelease: "v1.0.2",
 		TestedAt:      time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC),
 		Passed:        true,


### PR DESCRIPTION
Changelog roll and compat records for v1.0.3. Everything here is already merged to main; this PR just rolls the changelog and matrix so the tag can be cut after merge.

## What's in the release

All changes are backward compatible; defaults are unchanged.

### Changed
- `/diffs` and the JSON API now explain a policy-blocked diff specifically, via a new `apply_detail` string (effective policy, its source, and how to apply it; an invalid `gitops_update_policy` value is surfaced rather than shown as `none`). `apply_action` is unchanged. (#92)
- The example `NomadJobDrift` alert alerts on the per-job `nomad_gitops_job_diffs` metric, so it names the drifting job and diff type. (#93)

### Added
- `--reclone-interval` / `RECLONE_INTERVAL` (default `24h`, `0` disables): periodically discards and re-fetches the in-memory git clone to reclaim the go-git object store. (#88)

### Fixed
- Server shutdown goroutine leak when `ListenAndServe` fails early. (#88)

### Dependencies
- `golang.org/x/crypto` v0.54.0, `prometheus/client_golang` v1.24.1, `go-git/go-billy/v5` v5.9.1, `actions/setup-go` v7, plus transitive bumps (`prometheus/common` v0.70.1, `prometheus/procfs` v0.21.1, `golang.org/x/net` v0.57.0, `golang.org/x/sys` v0.47.0).

## Verification
- Unit tests and `make lint` pass.
- Full regression suite passed against Nomad 1.9.7, 1.10.5, 1.11.3, and 2.0.4 (~125s each). Recorded in `docs/nomad-versions.md` and `tests/regression/compat.go`.

## After merge
Cut the tag and release (not done here):

```
make release-patch   # v1.0.2 → v1.0.3
gh release create v1.0.3 --notes-from-tag   # or from the changelog section
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)